### PR TITLE
refactor: replace static mut JSON_MODE with AtomicBool

### DIFF
--- a/crates/auths-cli/src/ux/format.rs
+++ b/crates/auths-cli/src/ux/format.rs
@@ -10,10 +10,9 @@
 use console::{Style, Term};
 use serde::Serialize;
 use std::io::IsTerminal;
+use std::sync::atomic::{AtomicBool, Ordering};
 
-/// Global flag for whether we're in JSON output mode.
-/// Set this to true before any output to disable colors.
-pub static mut JSON_MODE: bool = false;
+static JSON_MODE: AtomicBool = AtomicBool::new(false);
 
 /// Standard JSON response structure for all commands.
 ///
@@ -62,8 +61,7 @@ impl<T: Serialize> JsonResponse<T> {
 
 /// Check if JSON mode is enabled.
 pub fn is_json_mode() -> bool {
-    // Safety: This is only read after main() sets it, so it's effectively single-threaded
-    unsafe { JSON_MODE }
+    JSON_MODE.load(Ordering::Relaxed)
 }
 
 /// Terminal output helper with color support.
@@ -122,9 +120,7 @@ impl Output {
 
     /// Determine if colors should be used.
     fn should_use_colors(term: &Term) -> bool {
-        // Check JSON mode first
-        // Safety: This is only read after main() sets it, so it's effectively single-threaded
-        if unsafe { JSON_MODE } {
+        if JSON_MODE.load(Ordering::Relaxed) {
             return false;
         }
 
@@ -293,10 +289,7 @@ impl Output {
 ///
 /// Call this at the start of command handling if `--json` flag is set.
 pub fn set_json_mode(enabled: bool) {
-    // Safety: This is called once at startup before any concurrent access
-    unsafe {
-        JSON_MODE = enabled;
-    }
+    JSON_MODE.store(enabled, Ordering::Relaxed);
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

- Replaces `static mut JSON_MODE: bool` with `static JSON_MODE: AtomicBool` in `crates/auths-cli/src/ux/format.rs`
- Removes all `unsafe` blocks for reading/writing the global JSON output mode flag
- Uses `Ordering::Relaxed` since this is a single-writer (main thread at startup), multi-reader flag with no synchronization requirements
- Public API (`is_json_mode()`, `set_json_mode()`) unchanged

Addresses v1 launch plan Task 1.3.

## Test plan

- [x] All 142 auths-cli tests pass
- [x] `cargo clippy -p auths-cli --all-targets -- -D warnings` passes