### PR TITLE
refactor: audit and convert .expect() calls to Result

### DIFF
--- a/crates/auths-cli/src/commands/artifact/sign.rs
+++ b/crates/auths-cli/src/commands/artifact/sign.rs
@@ -54,7 +54,7 @@ pub fn handle_sign(
         .attestation_sink(attestation_sink)
         .attestation_source(attestation_source)
         .passphrase_provider(passphrase_provider)
-        .build();
+        .build()?;
 
     let params = ArtifactSigningParams {
         artifact: Arc::new(FileArtifact::new(file)),

--- a/crates/auths-cli/src/commands/device/authorization.rs
+++ b/crates/auths-cli/src/commands/device/authorization.rs
@@ -52,7 +52,7 @@ fn build_device_context(
     if let Some(pp) = passphrase_provider {
         builder = builder.passphrase_provider(pp);
     }
-    Ok(builder.build())
+    Ok(builder.build()?)
 }
 
 #[derive(Args, Debug, Clone)]

--- a/crates/auths-cli/src/commands/id/identity.rs
+++ b/crates/auths-cli/src/commands/id/identity.rs
@@ -486,7 +486,7 @@ pub fn handle_id(
                     .attestation_sink(attestation_sink)
                     .attestation_source(attestation_source)
                     .passphrase_provider(Arc::clone(&passphrase_provider))
-                    .build()
+                    .build()?
             };
             let result = auths_sdk::workflows::rotation::rotate_identity(
                 rotation_config,

--- a/crates/auths-cli/src/commands/init.rs
+++ b/crates/auths-cli/src/commands/init.rs
@@ -714,7 +714,7 @@ fn build_sdk_context(registry_path: &Path) -> Result<AuthsContext> {
         .identity_storage(identity_storage)
         .attestation_sink(attestation_sink)
         .attestation_source(attestation_source)
-        .build())
+        .build()?)
 }
 
 fn check_keychain_access(out: &Output) -> Result<Box<dyn KeyStorage + Send + Sync>> {

--- a/crates/auths-core/src/witness/receipt.rs
+++ b/crates/auths-core/src/witness/receipt.rs
@@ -102,9 +102,9 @@ impl Receipt {
     }
 
     /// Formats this receipt as a Git trailer value (base64url-encoded JSON).
-    pub fn to_trailer_value(&self) -> String {
-        let json = serde_json::to_string(self).expect("receipt is serializable");
-        URL_SAFE_NO_PAD.encode(json.as_bytes())
+    pub fn to_trailer_value(&self) -> Result<String, serde_json::Error> {
+        let json = serde_json::to_string(self)?;
+        Ok(URL_SAFE_NO_PAD.encode(json.as_bytes()))
     }
 
     /// Parses a receipt from a Git trailer value (base64url-encoded JSON).
@@ -380,7 +380,7 @@ mod tests {
     #[test]
     fn trailer_value_roundtrip() {
         let receipt = sample_receipt();
-        let encoded = receipt.to_trailer_value();
+        let encoded = receipt.to_trailer_value().unwrap();
         let decoded = Receipt::from_trailer_value(&encoded).unwrap();
         assert_eq!(receipt, decoded);
     }
@@ -388,7 +388,7 @@ mod tests {
     #[test]
     fn trailer_value_is_base64url() {
         let receipt = sample_receipt();
-        let encoded = receipt.to_trailer_value();
+        let encoded = receipt.to_trailer_value().unwrap();
         // base64url uses no padding and no '+' or '/'
         assert!(!encoded.contains('='));
         assert!(!encoded.contains('+'));

--- a/crates/auths-id/src/identity/resolve.rs
+++ b/crates/auths-id/src/identity/resolve.rs
@@ -151,6 +151,11 @@ pub fn did_key_to_ed25519(did: &str) -> Result<Ed25519PublicKey, DidResolverErro
 }
 
 /// Convert a 32-byte Ed25519 public key to `did:key` format.
+///
+/// # Panics
+///
+/// Panics if `public_key` is not exactly 32 bytes. Callers are expected
+/// to pass validated Ed25519 key material.
 pub fn ed25519_to_did_key(public_key: &[u8]) -> String {
     let array: [u8; 32] = public_key
         .try_into()

--- a/crates/auths-id/src/policy/mod.rs
+++ b/crates/auths-id/src/policy/mod.rs
@@ -37,7 +37,7 @@
 //! ```
 
 use auths_core::witness::{EventHash, WitnessProvider};
-use auths_policy::{CanonicalCapability, evaluate_strict};
+use auths_policy::{CanonicalCapability, DidParseError, evaluate_strict};
 use auths_verifier::core::Attestation;
 use auths_verifier::types::DeviceDID;
 use chrono::{DateTime, Utc};
@@ -67,13 +67,11 @@ pub use auths_policy::{
 ///
 /// An `EvalContext` populated with the attestation's fields.
 ///
-/// # Panics
-///
-/// Panics if the attestation's issuer or subject DID is malformed.
-/// This should not happen in practice as attestations are validated on creation.
-pub fn context_from_attestation(att: &Attestation, now: DateTime<Utc>) -> EvalContext {
-    let mut ctx = EvalContext::try_from_strings(now, &att.issuer, &att.subject.to_string())
-        .expect("attestation DIDs should be valid");
+pub fn context_from_attestation(
+    att: &Attestation,
+    now: DateTime<Utc>,
+) -> Result<EvalContext, DidParseError> {
+    let mut ctx = EvalContext::try_from_strings(now, &att.issuer, &att.subject.to_string())?;
 
     ctx = ctx.revoked(att.is_revoked());
 
@@ -110,7 +108,7 @@ pub fn context_from_attestation(att: &Attestation, now: DateTime<Utc>) -> EvalCo
         ctx = ctx.signer_type(policy_st);
     }
 
-    ctx
+    Ok(ctx)
 }
 
 /// Evaluate a compiled policy against an attestation.
@@ -156,9 +154,9 @@ pub fn evaluate_compiled(
     att: &Attestation,
     policy: &CompiledPolicy,
     now: DateTime<Utc>,
-) -> Decision {
-    let ctx = context_from_attestation(att, now);
-    evaluate_strict(policy, &ctx)
+) -> Result<Decision, DidParseError> {
+    let ctx = context_from_attestation(att, now)?;
+    Ok(evaluate_strict(policy, &ctx))
 }
 
 /// Evaluate policy with optional witness consistency checks.
@@ -195,22 +193,17 @@ pub fn evaluate_with_witness(
     now: DateTime<Utc>,
     local_head: EventHash,
     witnesses: &[&dyn WitnessProvider],
-) -> Decision {
-    // If no witnesses provided, delegate to normal policy evaluation
+) -> Result<Decision, DidParseError> {
     if witnesses.is_empty() {
         return evaluate_compiled(att, policy, now);
     }
 
-    // Get the required quorum from the first witness
-    // (assumes all witnesses use the same quorum, which is typical)
     let required_quorum = witnesses.first().map(|w| w.quorum()).unwrap_or(1);
 
-    // If quorum is 0 (e.g., NoOpWitness), skip witness checks
     if required_quorum == 0 {
         return evaluate_compiled(att, policy, now);
     }
 
-    // Count witnesses that agree with local head
     let mut matching = 0;
     let mut total_opinions = 0;
 
@@ -223,23 +216,20 @@ pub fn evaluate_with_witness(
         }
     }
 
-    // If no witnesses have opinions, proceed with normal policy
     if total_opinions == 0 {
         return evaluate_compiled(att, policy, now);
     }
 
-    // Check if quorum is met
     if matching < required_quorum {
-        return Decision::deny(
+        return Ok(Decision::deny(
             ReasonCode::WitnessQuorumNotMet,
             format!(
                 "Witness quorum not met: {}/{} matching, {} required",
                 matching, total_opinions, required_quorum
             ),
-        );
+        ));
     }
 
-    // Quorum met, proceed with normal policy evaluation
     evaluate_compiled(att, policy, now)
 }
 
@@ -369,34 +359,32 @@ pub fn evaluate_with_receipts(
     receipts: &EventReceipts,
     threshold: usize,
     key_resolver: Option<&dyn WitnessKeyResolver>,
-) -> Decision {
-    // 1. First, verify receipts
+) -> Result<Decision, DidParseError> {
     match verify_receipts(receipts, threshold, key_resolver) {
         ReceiptVerificationResult::Valid => {}
         ReceiptVerificationResult::InsufficientReceipts { required, got } => {
-            return Decision::deny(
+            return Ok(Decision::deny(
                 ReasonCode::WitnessQuorumNotMet,
                 format!(
                     "Insufficient receipts: {} required, {} present",
                     required, got
                 ),
-            );
+            ));
         }
         ReceiptVerificationResult::Duplicity { event_a, event_b } => {
-            return Decision::deny(
+            return Ok(Decision::deny(
                 ReasonCode::WitnessQuorumNotMet,
                 format!("Duplicity detected: {} vs {}", event_a, event_b),
-            );
+            ));
         }
         ReceiptVerificationResult::InvalidSignature { witness_did } => {
-            return Decision::deny(
+            return Ok(Decision::deny(
                 ReasonCode::WitnessQuorumNotMet,
                 format!("Invalid receipt signature from witness: {}", witness_did),
-            );
+            ));
         }
     }
 
-    // 2. Then, do witness head consistency check
     evaluate_with_witness(identity, att, policy, now, local_head, witnesses)
 }
 
@@ -472,7 +460,7 @@ mod tests {
     fn context_from_attestation_basic() {
         let att = make_attestation("did:keri:ETest", None, None);
         let now = Utc::now();
-        let ctx = context_from_attestation(&att, now);
+        let ctx = context_from_attestation(&att, now).unwrap();
 
         assert_eq!(ctx.issuer.as_str(), "did:keri:ETest");
         assert_eq!(ctx.subject.as_str(), "did:key:subject");
@@ -484,7 +472,7 @@ mod tests {
         let mut att = make_attestation("did:keri:ETest", None, None);
         att.capabilities = vec![Capability::sign_commit()];
         let now = Utc::now();
-        let ctx = context_from_attestation(&att, now);
+        let ctx = context_from_attestation(&att, now).unwrap();
 
         assert_eq!(ctx.capabilities.len(), 1);
         assert_eq!(ctx.capabilities[0].as_str(), "sign_commit");
@@ -495,7 +483,7 @@ mod tests {
         let mut att = make_attestation("did:keri:ETest", None, None);
         att.role = Some(auths_verifier::core::Role::Member);
         let now = Utc::now();
-        let ctx = context_from_attestation(&att, now);
+        let ctx = context_from_attestation(&att, now).unwrap();
 
         assert_eq!(ctx.role.as_deref(), Some("member"));
     }
@@ -506,7 +494,7 @@ mod tests {
         let policy = default_policy();
         let now = Utc::now();
 
-        let decision = evaluate_compiled(&att, &policy, now);
+        let decision = evaluate_compiled(&att, &policy, now).unwrap();
         assert_eq!(decision.outcome, Outcome::Allow);
     }
 
@@ -516,7 +504,7 @@ mod tests {
         let policy = default_policy();
         let now = Utc::now();
 
-        let decision = evaluate_compiled(&att, &policy, now);
+        let decision = evaluate_compiled(&att, &policy, now).unwrap();
         assert_eq!(decision.outcome, Outcome::Deny);
         assert_eq!(decision.reason, ReasonCode::Revoked);
     }
@@ -528,7 +516,7 @@ mod tests {
         let policy = default_policy();
         let now = Utc::now();
 
-        let decision = evaluate_compiled(&att, &policy, now);
+        let decision = evaluate_compiled(&att, &policy, now).unwrap();
         assert_eq!(decision.outcome, Outcome::Deny);
         assert_eq!(decision.reason, ReasonCode::Expired);
     }
@@ -540,7 +528,7 @@ mod tests {
         let policy = default_policy();
         let now = Utc::now();
 
-        let decision = evaluate_compiled(&att, &policy, now);
+        let decision = evaluate_compiled(&att, &policy, now).unwrap();
         assert_eq!(decision.outcome, Outcome::Allow);
     }
 
@@ -553,7 +541,7 @@ mod tests {
             .build();
         let now = Utc::now();
 
-        let decision = evaluate_compiled(&att, &policy, now);
+        let decision = evaluate_compiled(&att, &policy, now).unwrap();
         assert_eq!(decision.outcome, Outcome::Deny);
         assert_eq!(decision.reason, ReasonCode::IssuerMismatch);
     }
@@ -567,7 +555,7 @@ mod tests {
             .build();
         let now = Utc::now();
 
-        let decision = evaluate_compiled(&att, &policy, now);
+        let decision = evaluate_compiled(&att, &policy, now).unwrap();
         assert_eq!(decision.outcome, Outcome::Deny);
         assert_eq!(decision.reason, ReasonCode::CapabilityMissing);
     }
@@ -582,7 +570,7 @@ mod tests {
             .build();
         let now = Utc::now();
 
-        let decision = evaluate_compiled(&att, &policy, now);
+        let decision = evaluate_compiled(&att, &policy, now).unwrap();
         assert_eq!(decision.outcome, Outcome::Allow);
     }
 
@@ -592,8 +580,8 @@ mod tests {
         let policy = default_policy();
         let now = Utc::now();
 
-        let decision1 = evaluate_compiled(&att, &policy, now);
-        let decision2 = evaluate_compiled(&att, &policy, now);
+        let decision1 = evaluate_compiled(&att, &policy, now).unwrap();
+        let decision2 = evaluate_compiled(&att, &policy, now).unwrap();
 
         assert_eq!(decision1, decision2);
     }
@@ -610,7 +598,8 @@ mod tests {
         let now = Utc::now();
         let local_head = EventHash::from_hex("0000000000000000000000000000000000000001").unwrap();
 
-        let decision = evaluate_with_witness(&identity, &att, &policy, now, local_head, &[]);
+        let decision =
+            evaluate_with_witness(&identity, &att, &policy, now, local_head, &[]).unwrap();
 
         assert_eq!(decision.outcome, Outcome::Allow);
     }
@@ -626,7 +615,8 @@ mod tests {
         let noop = NoOpWitness;
         let witnesses: &[&dyn WitnessProvider] = &[&noop];
 
-        let decision = evaluate_with_witness(&identity, &att, &policy, now, local_head, witnesses);
+        let decision =
+            evaluate_with_witness(&identity, &att, &policy, now, local_head, witnesses).unwrap();
 
         assert_eq!(decision.outcome, Outcome::Allow);
     }
@@ -647,7 +637,8 @@ mod tests {
         };
         let witnesses: &[&dyn WitnessProvider] = &[&witness];
 
-        let decision = evaluate_with_witness(&identity, &att, &policy, now, local_head, witnesses);
+        let decision =
+            evaluate_with_witness(&identity, &att, &policy, now, local_head, witnesses).unwrap();
 
         assert_eq!(decision.outcome, Outcome::Deny);
         assert_eq!(decision.reason, ReasonCode::WitnessQuorumNotMet);
@@ -667,7 +658,8 @@ mod tests {
         };
         let witnesses: &[&dyn WitnessProvider] = &[&witness];
 
-        let decision = evaluate_with_witness(&identity, &att, &policy, now, local_head, witnesses);
+        let decision =
+            evaluate_with_witness(&identity, &att, &policy, now, local_head, witnesses).unwrap();
 
         assert_eq!(decision.outcome, Outcome::Allow);
     }
@@ -686,7 +678,8 @@ mod tests {
         };
         let witnesses: &[&dyn WitnessProvider] = &[&witness];
 
-        let decision = evaluate_with_witness(&identity, &att, &policy, now, local_head, witnesses);
+        let decision =
+            evaluate_with_witness(&identity, &att, &policy, now, local_head, witnesses).unwrap();
 
         assert_eq!(decision.outcome, Outcome::Deny);
         assert_eq!(decision.reason, ReasonCode::Revoked);
@@ -716,7 +709,8 @@ mod tests {
         };
         let witnesses: &[&dyn WitnessProvider] = &[&w1, &w2, &w3];
 
-        let decision = evaluate_with_witness(&identity, &att, &policy, now, local_head, witnesses);
+        let decision =
+            evaluate_with_witness(&identity, &att, &policy, now, local_head, witnesses).unwrap();
 
         assert_eq!(decision.outcome, Outcome::Allow);
     }
@@ -735,7 +729,8 @@ mod tests {
         };
         let witnesses: &[&dyn WitnessProvider] = &[&witness];
 
-        let decision = evaluate_with_witness(&identity, &att, &policy, now, local_head, witnesses);
+        let decision =
+            evaluate_with_witness(&identity, &att, &policy, now, local_head, witnesses).unwrap();
 
         assert_eq!(decision.outcome, Outcome::Allow);
     }
@@ -836,7 +831,8 @@ mod tests {
             &receipts,
             2,
             None,
-        );
+        )
+        .unwrap();
 
         assert_eq!(decision.outcome, Outcome::Allow);
     }
@@ -861,7 +857,8 @@ mod tests {
             &receipts,
             2, // Threshold 2, but only 1 receipt
             None,
-        );
+        )
+        .unwrap();
 
         assert_eq!(decision.outcome, Outcome::Deny);
         assert_eq!(decision.reason, ReasonCode::WitnessQuorumNotMet);

--- a/crates/auths-id/src/trailer.rs
+++ b/crates/auths-id/src/trailer.rs
@@ -275,7 +275,7 @@ mod tests {
     #[test]
     fn extract_witness_receipts_roundtrip() {
         let receipt = sample_receipt();
-        let trailer_value = receipt.to_trailer_value();
+        let trailer_value = receipt.to_trailer_value().unwrap();
         let msg = append_trailer(
             "feat: add agent signing",
             WITNESS_RECEIPT_KEY,
@@ -295,8 +295,8 @@ mod tests {
         r2.d = Said::new_unchecked("EReceipt456".into());
 
         let mut msg = "feat: signed commit".to_string();
-        msg = append_trailer(&msg, WITNESS_RECEIPT_KEY, &r1.to_trailer_value());
-        msg = append_trailer(&msg, WITNESS_RECEIPT_KEY, &r2.to_trailer_value());
+        msg = append_trailer(&msg, WITNESS_RECEIPT_KEY, &r1.to_trailer_value().unwrap());
+        msg = append_trailer(&msg, WITNESS_RECEIPT_KEY, &r2.to_trailer_value().unwrap());
 
         let receipts = extract_witness_receipts(&msg);
         assert_eq!(receipts.len(), 2);
@@ -307,7 +307,11 @@ mod tests {
         let receipt = sample_receipt();
         let mut msg = "feat: stuff".to_string();
         msg = append_trailer(&msg, "Signed-off-by", "Alice");
-        msg = append_trailer(&msg, WITNESS_RECEIPT_KEY, &receipt.to_trailer_value());
+        msg = append_trailer(
+            &msg,
+            WITNESS_RECEIPT_KEY,
+            &receipt.to_trailer_value().unwrap(),
+        );
         msg = append_trailer(&msg, "Co-authored-by", "Bob");
 
         let receipts = extract_witness_receipts(&msg);

--- a/crates/auths-radicle/src/verify.rs
+++ b/crates/auths-radicle/src/verify.rs
@@ -266,7 +266,11 @@ impl<S: AuthsStorage> RadicleAuthsBridge for DefaultBridge<S> {
         };
 
         // Step 6: Evaluate policy (revocation, expiry)
-        let decision = evaluate_compiled(&attestation, &self.policy, request.now);
+        let decision = evaluate_compiled(&attestation, &self.policy, request.now)
+            .map_err(|e| BridgeError::PolicyEvaluation {
+                did: identity_did.clone(),
+                reason: e.to_string(),
+            })?;
 
         // Step 7: Capability check
         if let Some(required_cap) = request.required_capability

--- a/crates/auths-sdk/src/context.rs
+++ b/crates/auths-sdk/src/context.rs
@@ -4,6 +4,7 @@
 //! (e.g. [`crate::types::DeveloperSetupConfig`]) remain Plain Old Data with no
 //! trait objects.
 
+use std::fmt;
 use std::sync::Arc;
 
 use auths_core::ports::clock::ClockProvider;
@@ -14,6 +15,18 @@ use auths_id::attestation::export::AttestationSink;
 use auths_id::ports::registry::RegistryBackend;
 use auths_id::storage::attestation::AttestationSource;
 use auths_id::storage::identity::IdentityStorage;
+
+/// A required builder field was not set before calling `build()`.
+#[derive(Debug, Clone)]
+pub struct BuilderError(pub &'static str);
+
+impl fmt::Display for BuilderError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "missing required builder field: {}", self.0)
+    }
+}
+
+impl std::error::Error for BuilderError {}
 
 /// Fire-and-forget sink for structured telemetry payloads emitted by SDK operations.
 ///
@@ -421,27 +434,27 @@ impl
     ///     .clock(Arc::new(SystemClock))
     ///     .build();
     /// ```
-    pub fn build(self) -> AuthsContext {
-        AuthsContext {
+    pub fn build(self) -> Result<AuthsContext, BuilderError> {
+        Ok(AuthsContext {
             registry: self.registry.0,
             key_storage: self.key_storage.0,
             clock: self.clock.0,
             event_sink: self.event_sink.unwrap_or_else(|| Arc::new(NoopSink)),
             identity_storage: self
                 .identity_storage
-                .expect("identity_storage is required — call .identity_storage(...)"),
+                .ok_or(BuilderError("identity_storage"))?,
             attestation_sink: self
                 .attestation_sink
-                .expect("attestation_sink is required — call .attestation_sink(...)"),
+                .ok_or(BuilderError("attestation_sink"))?,
             attestation_source: self
                 .attestation_source
-                .expect("attestation_source is required — call .attestation_source(...)"),
+                .ok_or(BuilderError("attestation_source"))?,
             passphrase_provider: self
                 .passphrase_provider
                 .unwrap_or_else(|| Arc::new(NoopPassphraseProvider)),
             uuid_provider: self
                 .uuid_provider
                 .unwrap_or_else(|| Arc::new(SystemUuidProvider)),
-        }
+        })
     }
 }

--- a/crates/auths-sdk/src/signing.rs
+++ b/crates/auths-sdk/src/signing.rs
@@ -296,7 +296,11 @@ fn resolve_required_key(
         passphrase_provider,
         passphrase_prompt,
     )
-    .map(|opt| opt.expect("resolve_optional_key with Some always returns Some"))
+    .map(|opt| {
+        opt.ok_or(ArtifactSigningError::KeyDecryptionFailed(
+            "expected key material but got None".into(),
+        ))
+    })?
 }
 
 /// Full artifact attestation signing pipeline.

--- a/crates/auths-sdk/src/workflows/rotation.rs
+++ b/crates/auths-sdk/src/workflows/rotation.rs
@@ -494,6 +494,7 @@ mod tests {
                     as Arc<dyn PassphraseProvider + Send + Sync>,
             )
             .build()
+            .unwrap()
     }
 
     fn provision_identity(ctx: &AuthsContext) -> KeyAlias {
@@ -788,7 +789,8 @@ mod tests {
                     call_count: AtomicU32::new(0),
                 })
                     as Arc<dyn PassphraseProvider + Send + Sync>)
-                .build();
+                .build()
+                .unwrap();
 
         let test_alias = KeyAlias::new_unchecked("test-alias");
         let old_alias = KeyAlias::new_unchecked("old-alias");

--- a/crates/auths-sdk/tests/cases/helpers.rs
+++ b/crates/auths-sdk/tests/cases/helpers.rs
@@ -65,7 +65,7 @@ pub fn build_test_context_with_provider(
         builder = builder.passphrase_provider(pp);
     }
 
-    builder.build()
+    builder.build().unwrap()
 }
 
 /// Build an [`AuthsContext`] over a fresh empty git repository with no identity stored.


### PR DESCRIPTION
## Summary

- Audited all `.expect()` calls in production code across auths-core (4), auths-id (5), and auths-sdk (4)
- Converted 6 calls to proper `Result` returns where callers benefit from error handling
- Kept 7 calls where `.expect()` is correct (structurally guaranteed invariants)

### Converted to `Result`:
- `Receipt::to_trailer_value()` → `Result<String, serde_json::Error>`
- `context_from_attestation()` → `Result<EvalContext, DidParseError>`
- `evaluate_compiled/with_witness/with_receipts` → `Result<Decision, DidParseError>`
- `AuthsContext::builder().build()` → `Result<AuthsContext, BuilderError>`
- `resolve_required_key` → uses `.ok_or()` instead of `.expect()`

### Kept as `.expect()` (true invariants):
- Tokio runtime creation at process init (`provider_bridge.rs`)
- `git2::Oid` / `EventHash` fixed-size byte conversions (`witness.rs`)
- Parent count guard in incremental KEL walk (`incremental.rs`)
- Length-checked array conversion in SSH agent (`runtime.rs`)
- FFI contract in unsafe block (`ffi.rs`)
- `ed25519_to_did_key` — added `# Panics` doc section

Addresses v1 launch plan Task 1.4.

## Test plan

- [x] All 1358 tests pass (`cargo nextest run --workspace`)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo fmt --check --all` passes