### PR TITLE
fix: clock injection, typed errors, and missing Python imports

### DIFF
--- a/crates/auths-core/src/witness/server.rs
+++ b/crates/auths-core/src/witness/server.rs
@@ -26,6 +26,7 @@ use axum::{
     http::StatusCode,
     routing::{get, post},
 };
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::sync::Mutex;
 
@@ -48,6 +49,8 @@ struct WitnessServerInner {
     public_key: [u8; 32],
     /// SQLite storage (Mutex for thread safety since Connection is !Sync)
     storage: Mutex<WitnessStorage>,
+    /// Clock function for getting current time
+    clock: Box<dyn Fn() -> DateTime<Utc> + Send + Sync>,
 }
 
 /// Configuration for the witness server.
@@ -136,6 +139,7 @@ pub struct ErrorResponse {
 
 impl WitnessServerState {
     /// Create a new server state.
+    #[allow(clippy::disallowed_methods)] // Server constructor is a clock boundary
     pub fn new(config: WitnessServerConfig) -> Result<Self, WitnessError> {
         let storage = WitnessStorage::open(&config.db_path)?;
 
@@ -145,11 +149,13 @@ impl WitnessServerState {
                 seed: config.keypair_seed,
                 public_key: config.keypair_pubkey,
                 storage: Mutex::new(storage),
+                clock: Box::new(Utc::now),
             }),
         })
     }
 
     /// Create a new server state with in-memory storage (for testing).
+    #[allow(clippy::disallowed_methods)] // Server constructor is a clock boundary
     pub fn in_memory(
         witness_did: String,
         seed: SecureSeed,
@@ -163,11 +169,13 @@ impl WitnessServerState {
                 seed,
                 public_key,
                 storage: Mutex::new(storage),
+                clock: Box::new(Utc::now),
             }),
         })
     }
 
     /// Create a new server state with generated keypair (for testing).
+    #[allow(clippy::disallowed_methods)] // Server constructor is a clock boundary
     pub fn in_memory_generated() -> Result<Self, WitnessError> {
         use crate::crypto::provider_bridge;
 
@@ -184,6 +192,7 @@ impl WitnessServerState {
                 seed,
                 public_key,
                 storage: Mutex::new(storage),
+                clock: Box::new(Utc::now),
             }),
         })
     }
@@ -428,7 +437,6 @@ fn verify_inception_self_signature(event: &serde_json::Value) -> Result<(), Stri
 
 /// POST /witness/:prefix/event - Submit an event for witnessing.
 #[allow(clippy::too_many_lines)]
-#[allow(clippy::disallowed_methods)] // Server handler is a clock boundary
 async fn submit_event(
     State(state): State<WitnessServerState>,
     AxumPath(prefix_str): AxumPath<String>,
@@ -489,7 +497,7 @@ async fn submit_event(
     );
     let event_s = event.get("s").and_then(|v| v.as_u64()).unwrap_or(0);
 
-    let now = chrono::Utc::now();
+    let now = (state.inner.clock)();
     let storage = state.inner.storage.lock().map_err(|_| {
         (
             StatusCode::INTERNAL_SERVER_ERROR,

--- a/crates/auths-storage/src/git/identity_adapter.rs
+++ b/crates/auths-storage/src/git/identity_adapter.rs
@@ -27,8 +27,7 @@
 
 use std::path::PathBuf;
 
-use anyhow::Context;
-use auths_id::error::StorageError;
+use auths_id::error::{InitError, StorageError};
 use git2::Repository;
 use serde::{Deserialize, Serialize};
 
@@ -106,7 +105,7 @@ impl RegistryIdentityStorage {
         &self,
         metadata: Option<serde_json::Value>,
         witness_config: Option<&auths_id::witness_config::WitnessConfig>,
-    ) -> Result<(String, auths_id::keri::InceptionResult), anyhow::Error> {
+    ) -> Result<(String, auths_id::keri::InceptionResult), InitError> {
         use auths_core::crypto::said::compute_next_commitment;
         use auths_id::keri::{
             Event, IcpEvent, InceptionResult, KERI_VERSION, KeriSequence, Prefix, Said,
@@ -119,19 +118,19 @@ impl RegistryIdentityStorage {
         // Initialize registry if needed
         self.backend
             .init_if_needed()
-            .context("Failed to initialize registry")?;
+            .map_err(|e| InitError::Registry(format!("Failed to initialize registry: {e}")))?;
 
         // Generate keypairs
         let rng = SystemRandom::new();
         let current_pkcs8 = Ed25519KeyPair::generate_pkcs8(&rng)
-            .map_err(|e| anyhow::anyhow!("Key generation failed: {}", e))?;
+            .map_err(|e| InitError::Crypto(format!("Key generation failed: {e}")))?;
         let current_keypair = Ed25519KeyPair::from_pkcs8(current_pkcs8.as_ref())
-            .map_err(|e| anyhow::anyhow!("Key generation failed: {}", e))?;
+            .map_err(|e| InitError::Crypto(format!("Key parsing failed: {e}")))?;
 
         let next_pkcs8 = Ed25519KeyPair::generate_pkcs8(&rng)
-            .map_err(|e| anyhow::anyhow!("Key generation failed: {}", e))?;
+            .map_err(|e| InitError::Crypto(format!("Key generation failed: {e}")))?;
         let next_keypair = Ed25519KeyPair::from_pkcs8(next_pkcs8.as_ref())
-            .map_err(|e| anyhow::anyhow!("Key generation failed: {}", e))?;
+            .map_err(|e| InitError::Crypto(format!("Key parsing failed: {e}")))?;
 
         // Encode current public key with derivation code prefix
         let current_pub_encoded = format!(
@@ -169,19 +168,19 @@ impl RegistryIdentityStorage {
 
         // Finalize event (computes SAID)
         let mut finalized = finalize_icp_event(icp)
-            .map_err(|e| anyhow::anyhow!("Failed to finalize ICP: {}", e))?;
+            .map_err(|e| InitError::Keri(format!("Failed to finalize ICP: {e}")))?;
         let prefix = finalized.i.clone();
 
         // Sign the event
         let canonical = serialize_for_signing(&Event::Icp(finalized.clone()))
-            .map_err(|e| anyhow::anyhow!("Failed to serialize for signing: {}", e))?;
+            .map_err(|e| InitError::Keri(format!("Failed to serialize for signing: {e}")))?;
         let sig = current_keypair.sign(&canonical);
         finalized.x = URL_SAFE_NO_PAD.encode(sig.as_ref());
 
         // Store event in packed registry
         self.backend
             .append_event(&prefix, &Event::Icp(finalized))
-            .map_err(|e| anyhow::anyhow!("Failed to store event in registry: {}", e))?;
+            .map_err(|e| InitError::Registry(format!("Failed to store event in registry: {e}")))?;
 
         let controller_did = format!("did:keri:{}", prefix);
 

--- a/packages/auths-python/python/auths/__init__.py
+++ b/packages/auths-python/python/auths/__init__.py
@@ -36,7 +36,8 @@ from auths.policy import PolicyBuilder
 from auths.devices import Device, DeviceExtension, DeviceService
 from auths.identity import AgentIdentity, DelegatedAgent, Identity, IdentityService
 from auths.rotation import IdentityRotationResult
-from auths.verify import WitnessConfig, WitnessKey
+from auths.verify import WitnessConfig, WitnessKey, verify_chain_with_witnesses
+from auths.policy import compile_policy
 from auths.git import (
     CommitResult,
     ErrorCode,


### PR DESCRIPTION
## Summary
- **fn-38.1**: Inject clock into `WitnessServerState` instead of calling `Utc::now()` in `submit_event` handler. Removes `#[allow(clippy::disallowed_methods)]` from the handler.
- **fn-38.2**: Replace 7 `anyhow::anyhow!()` calls with `InitError` variants (`Crypto`, `Keri`, `Registry`) in `identity_adapter.rs`. No more `anyhow` in Layer 4.
- **fn-38.3**: Add missing `verify_chain_with_witnesses` and `compile_policy` imports to `__init__.py`. All 48 `__all__` items now importable.

## Test plan
- [x] `cargo nextest run --workspace` — 1593 tests pass
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `python -c "from auths import verify_chain_with_witnesses, compile_policy"` — OK
- [x] Pre-push hooks pass (fmt, clippy, tests, wasm, cross-compile)