### PR TITLE
fix: clean up auths --help and rewrite CLI README

### DIFF
--- a/crates/auths-cli/README.md
+++ b/crates/auths-cli/README.md
@@ -1,620 +1,90 @@
-# Auths CLI
+# auths
 
-Cryptographic identity for developers. Sign commits, link devices, verify signatures — all stored in Git, no central server.
+Cryptographic identity for developers. One command to set up, Git-native storage, no central server.
 
-## Installation
-
-```bash
-cargo install --path crates/auths-cli --force
-```
-
-This installs three binaries to `~/.cargo/bin`:
-
-- `auths` — main CLI
-- `auths-sign` — standalone signing (for git hooks)
-- `auths-verify` — standalone verification
-
-Ensure `~/.cargo/bin` is in your PATH:
+## Getting Started (10 seconds)
 
 ```bash
-echo $PATH | grep -q ".cargo/bin" || echo 'export PATH="$HOME/.cargo/bin:$PATH"' >> ~/.zshrc
-```
-
-### Run without installing
-
-```bash
-cargo run -p auths-cli -- <arguments...>
-```
-
-### Global flags
-
-These flags apply to all commands:
-
-```
---repo <PATH>       Override storage directory (default: ~/.auths)
---format <FORMAT>   Output format: text or json
---json              Shorthand for --format json
--q, --quiet         Suppress non-essential output
-```
-
----
-
-## Quick Start
-
-Three commands to go from zero to signed commits:
-
-```bash
-# 1. Create your identity
 auths init
-
-# 2. Verify everything is wired up
 auths doctor
-
-# 3. Sign and verify a commit
 git commit -m "first signed commit"
 auths verify HEAD
 ```
 
-`auths init` handles everything: generates keys, creates your identity, links your device, and configures Git for automatic commit signing.
+That's it. `auths init` generates keys, creates your identity, and configures Git signing.
 
----
+## The Basics
 
-## Getting Started
-
-### `auths init`
-
-Interactive setup that creates your identity and configures Git signing.
+### `auths sign` — Sign a commit or artifact
 
 ```bash
-auths init                              # Interactive developer setup
-auths init --profile developer          # Same as above, explicit
-auths init --profile ci                 # Ephemeral identity for CI/CD
-auths init --profile agent              # Scoped identity for AI agents
-auths init --non-interactive            # Skip prompts, use defaults
+auths sign HEAD                    # Sign latest commit
+auths sign main..HEAD              # Sign a range
+auths sign ./release.tar.gz       # Sign a file
 ```
 
-| Flag | Description |
-|---|---|
-| `--profile <PROFILE>` | `developer`, `ci`, or `agent` |
-| `--key-alias <ALIAS>` | Key alias (default: `main`) |
-| `--non-interactive` | Skip interactive prompts |
-| `--force` | Overwrite existing identity |
-| `--dry-run` | Preview without creating files |
-| `--registry <URL>` | Registry URL for identity publication |
-| `--skip-registration` | Skip automatic registry registration |
+### `auths verify` — Verify signatures
 
-### `auths status`
+```bash
+auths verify                       # Verify HEAD
+auths verify HEAD~3..HEAD          # Verify a range
+auths verify abc1234               # Verify specific commit
+auths verify path/to/attestation   # Verify attestation file
+```
 
-Show current identity, agent, and device status at a glance.
+### `auths status` — See your identity at a glance
 
 ```bash
 auths status
 ```
 
-### `auths doctor`
+### `auths whoami` — Show the current identity
 
-Run health checks on your setup: Git config, keychain access, identity state, allowed signers file.
+```bash
+auths whoami
+```
+
+### `auths doctor` — Health checks
 
 ```bash
 auths doctor
 # Exit code 0 = all checks pass, 1 = something needs attention
 ```
 
-### `auths tutorial`
-
-Interactive walkthrough covering identities, signing, verification, devices, and revocation.
+### `auths tutorial` — Interactive walkthrough
 
 ```bash
-auths tutorial                # Start from beginning
-auths tutorial --list         # List all sections
-auths tutorial --skip 3       # Jump to section 3
-auths tutorial --reset        # Reset progress
+auths tutorial
 ```
 
----
+## Advanced Commands
 
-## Verification & Signing
+Run `auths --help-all` to see the full command list:
 
-### `auths verify`
-
-Verify commit signatures or attestation files. Accepts git refs, commit ranges, file paths, or stdin.
-
-```bash
-auths verify                            # Verify HEAD
-auths verify HEAD~3..HEAD               # Verify a range
-auths verify abc1234                    # Verify specific commit
-auths verify path/to/attestation.json   # Verify attestation file
-cat attestation.json | auths verify -   # Verify from stdin
-```
-
-| Flag | Description |
+| Group | What it does |
 |---|---|
-| `--allowed-signers <PATH>` | Signers file (default: `.auths/allowed_signers`) |
-| `--identity-bundle <PATH>` | Identity bundle JSON for stateless CI verification |
-| `--issuer-did <DID>` | Issuer identity for trust-based key resolution |
-| `--witness-receipts <PATH>` | Witness receipts JSON file |
-| `--witness-threshold <N>` | Witness quorum threshold (default: 1) |
-| `--witness-keys <KEYS>...` | Witness public keys as DID:hex pairs |
-
-### `auths sign`
-
-Sign a commit or artifact file.
-
-```bash
-auths sign HEAD                         # Sign latest commit
-auths sign main..HEAD                   # Sign a range
-auths sign ./release.tar.gz             # Sign a file
-```
-
-| Flag | Description |
-|---|---|
-| `--device-key-alias <ALIAS>` | Device key for signing |
-| `--identity-key-alias <ALIAS>` | Identity key (for dual-signing) |
-| `--sig-output <PATH>` | Output path for signature file |
-| `--expires-in-days <N>` | Signature expiration |
-| `--note <NOTE>` | Embed a note in the attestation |
-
----
-
-## Devices
-
-Link multiple machines to your identity. Each device has its own key; the identity key authorizes them.
-
-### `auths device list`
-
-```bash
-auths device list
-auths device list --include-revoked
-```
-
-### `auths device link`
-
-Authorize a new device by creating a signed attestation.
-
-```bash
-auths device link \
-  --identity-key-alias main \
-  --device-key-alias laptop \
-  --device-did "did:key:z6Mk..." \
-  --note "Work laptop" \
-  --expires-in-days 90
-```
-
-| Flag | Description |
-|---|---|
-| `--identity-key-alias <ALIAS>` | Identity key for signing (required) |
-| `--device-key-alias <ALIAS>` | Device key to authorize (required) |
-| `--device-did <DID>` | Device DID (required) |
-| `--capabilities <CAPS>` | Comma-separated permissions |
-| `--expires-in-days <N>` | Authorization expiration |
-| `--note <NOTE>` | Description |
-| `--payload <PATH>` | JSON payload file |
-| `--schema <PATH>` | JSON schema for payload validation |
-
-### `auths device revoke`
-
-```bash
-auths device revoke \
-  --identity-key-alias main \
-  --device-did "did:key:z6Mk..." \
-  --note "Laptop retired"
-```
-
-### `auths device extend`
-
-Extend a device authorization's expiration.
-
-```bash
-auths device extend \
-  --device-did "did:key:z6Mk..." \
-  --days 90 \
-  --identity-key-alias main \
-  --device-key-alias laptop
-```
-
-### `auths device resolve`
-
-Look up a device by DID.
-
-```bash
-auths device resolve --device-did "did:key:z6Mk..."
-```
-
-### `auths device pair`
-
-Link a device via QR code or short code (for cross-device pairing).
-
-### `auths device verify-attestation`
-
-Verify a device authorization's signatures directly.
-
----
-
-## Identity Management
-
-### `auths id create`
-
-Create a new identity manually (most users should use `auths init` instead).
-
-```bash
-auths id create \
-  --local-key-alias main \
-  --metadata-file ~/metadata.json \
-  --preset default
-```
-
-| Flag | Description |
-|---|---|
-| `--local-key-alias <ALIAS>` | Alias for generated key |
-| `--metadata-file <PATH>` | JSON metadata to embed |
-| `--preset <PRESET>` | Storage layout: `default`, `radicle`, or `gitoxide` |
-
-### `auths id show`
-
-Display identity DID and metadata.
-
-```bash
-auths id show
-```
-
-### `auths id rotate`
-
-Rotate identity keys using KERI pre-rotation. Your `did:keri:E...` stays the same; only the active signing key changes.
-
-```bash
-auths id rotate --alias main
-auths id rotate --current-key-alias main --next-key-alias main_v2
-```
-
-| Flag | Description |
-|---|---|
-| `--alias <ALIAS>` | Key to rotate |
-| `--current-key-alias <ALIAS>` | Alternative to `--alias` |
-| `--next-key-alias <ALIAS>` | Alias for the new key |
-| `--add-witness <PREFIX>` | Add a witness server (repeatable) |
-| `--remove-witness <PREFIX>` | Remove a witness server (repeatable) |
-| `--witness-threshold <N>` | New witness quorum threshold |
-
-### `auths id export-bundle`
-
-Export an identity bundle for stateless verification (useful for CI).
-
-```bash
-auths id export-bundle --alias main -o bundle.json
-```
-
-### `auths id register`
-
-Publish your identity to a registry.
-
-```bash
-auths id register --registry https://auths-registry.fly.dev
-```
-
-### `auths id claim`
-
-Add a platform claim to your identity (e.g., GitHub, email).
-
-### `auths id migrate`
-
-Import existing GPG or SSH keys into an Auths identity.
-
----
-
-## Key Management
-
-### `auths key list`
-
-List all key aliases in secure storage.
-
-### `auths key import`
-
-Import a 32-byte Ed25519 seed file.
-
-```bash
-auths key import \
-  --alias my_device \
-  --seed-file ~/device.seed \
-  --controller-did "did:keri:E..."
-```
-
-### `auths key export`
-
-Export a key in different formats.
-
-```bash
-auths key export --alias main --passphrase "..." --format pub   # Public key
-auths key export --alias main --passphrase "..." --format pem   # Private key (PEM)
-auths key export --alias main --passphrase "..." --format enc   # Encrypted
-```
-
-### `auths key delete`
-
-Remove a key from secure storage.
-
-```bash
-auths key delete --alias old_key
-```
-
-### `auths key copy-backend`
-
-Copy a key to a different storage backend (e.g., file keychain for CI).
-
-```bash
-auths key copy-backend --alias main --dst-backend file --dst-file ./keys.json
-```
-
----
-
-## Organizations
-
-Manage organizations with member roles and authorization policies.
-
-### `auths org init`
-
-Create an organization identity.
-
-```bash
-auths org init --name "My Org"
-auths org init --name "My Org" --local-key-alias org_key --metadata-file org.json
-```
-
-### `auths org add-member`
-
-```bash
-auths org add-member \
-  --org "did:keri:E..." \
-  --member "did:keri:E..." \
-  --role admin \
-  --signer-alias org_key
-```
-
-Roles: `admin`, `member`, `readonly`.
-
-### `auths org revoke-member`
-
-```bash
-auths org revoke-member \
-  --org "did:keri:E..." \
-  --member "did:keri:E..." \
-  --signer-alias org_key \
-  --note "Access removed"
-```
-
-### `auths org list-members`
-
-```bash
-auths org list-members --org "did:keri:E..."
-auths org list-members --org "did:keri:E..." --include-revoked
-```
-
-### `auths org attest`
-
-Issue an organizational attestation for a subject.
-
-```bash
-auths org attest \
-  --subject "did:keri:E..." \
-  --payload-file claim.json \
-  --signer-alias org_key \
-  --expires-at "2025-12-31T00:00:00Z"
-```
-
-### `auths org revoke`
-
-Revoke an organizational attestation.
-
-```bash
-auths org revoke --subject "did:keri:E..." --signer-alias org_key
-```
-
-### `auths org show`
-
-Show attestations for a subject.
-
-```bash
-auths org show --subject "did:keri:E..."
-auths org show --subject "did:keri:E..." --include-revoked
-```
-
-### `auths org list`
-
-List all organizational attestations.
-
-### `auths policy`
-
-Validate, test, and compare authorization policies.
-
-| Subcommand | Description |
-|---|---|
-| `auths policy lint <file>` | Validate policy JSON syntax and structure |
-| `auths policy compile <file>` | Compile a policy to its canonical form |
-| `auths policy explain <file> -c context.json` | Explain how a policy evaluates against a context |
-| `auths policy test <file> -t tests.json` | Run a policy test suite |
-| `auths policy diff <old> <new>` | Show differences between two policy versions |
-
----
-
-## Artifacts
-
-Sign, verify, and publish arbitrary files (binaries, packages, configs).
-
-### `auths artifact sign`
-
-```bash
-auths artifact sign release.tar.gz \
-  --device-key-alias laptop \
-  --identity-key-alias main \
-  --expires-in-days 365
-```
-
-### `auths artifact verify`
-
-```bash
-auths artifact verify release.tar.gz
-auths artifact verify release.tar.gz --signature release.tar.gz.auths.json
-```
-
-### `auths artifact publish`
-
-Publish a signature to a registry.
-
-```bash
-auths artifact publish \
-  --signature release.tar.gz.auths.json \
-  --package "npm:my-package@1.0.0" \
-  --registry https://auths-registry.fly.dev
-```
-
----
-
-## Trust & Witnesses
-
-### `auths trust`
-
-Pin identity-to-key bindings locally (trust-on-first-use).
-
-| Subcommand | Description |
-|---|---|
-| `auths trust list` | Show all pinned identities |
-| `auths trust show <DID>` | Show details for a pinned identity |
-| `auths trust pin --did <DID> --key <HEX>` | Pin an identity's public key |
-| `auths trust remove <DID>` | Remove a pinned identity |
-
-### `auths witness`
-
-Run or manage KERI witness servers for independent event verification.
-
-| Subcommand | Description |
-|---|---|
-| `auths witness serve` | Run a witness server (`--bind`, `--db-path`) |
-| `auths witness add --url <URL>` | Register a witness |
-| `auths witness remove --url <URL>` | Unregister a witness |
-| `auths witness list` | Show configured witnesses |
-
----
-
-## Git Integration
-
-### `auths git allowed-signers`
-
-Generate an `allowed_signers` file from your identity's device keys.
-
-```bash
-auths git allowed-signers -o .auths/allowed_signers
-```
-
-### `auths git install-hooks`
-
-Install Git hooks for automatic signature verification.
-
-```bash
-auths git install-hooks --repo .
-auths git install-hooks --repo . --force   # Overwrite existing hooks
-```
-
----
-
-## Security & Compliance
-
-### `auths audit`
-
-Generate signing audit reports for compliance.
-
-```bash
-auths audit --since 2025-Q1 --format table
-auths audit --since 2025-01-01 --until 2025-03-31 --format csv -o report.csv
-auths audit --require-all-signed --exit-code   # Fail if unsigned commits found
-```
-
-| Flag | Description |
-|---|---|
-| `--since <DATE>` | Start date (YYYY-MM-DD or YYYY-QN) |
-| `--until <DATE>` | End date |
-| `--format <FMT>` | `table`, `csv`, `json`, or `html` |
-| `--author <EMAIL>` | Filter by author |
-| `--signer <DID>` | Filter by signing identity |
-| `-n, --count <N>` | Max commits (default: 100) |
-| `--require-all-signed` | Require all commits to be signed |
-| `--exit-code` | Exit 1 if unsigned commits found |
-| `-o, --output-file <PATH>` | Output file |
-
-### `auths emergency`
-
-Emergency response commands for key compromise or security incidents. Running without a subcommand starts an interactive flow.
-
-| Subcommand | Description |
-|---|---|
-| `auths emergency revoke-device` | Emergency device revocation (`--device`, `--dry-run`, `-y`) |
-| `auths emergency rotate-now` | Immediate key rotation (`--current-alias`, `--next-alias`, `--reason`) |
-| `auths emergency freeze` | Temporarily freeze identity operations (`--duration`, default 24h) |
-| `auths emergency unfreeze` | Resume operations after a freeze |
-| `auths emergency report` | Generate incident report (`--events <N>`, `-o <PATH>`) |
-
----
-
-## SSH Agent
-
-The Auths agent daemon manages keys in memory and provides SSH agent protocol support.
-
-| Subcommand | Description |
-|---|---|
-| `auths agent start` | Start the daemon (`--socket`, `--foreground`, `--timeout`) |
-| `auths agent stop` | Stop the daemon |
-| `auths agent status` | Show daemon status |
-| `auths agent env` | Print shell environment variables (`--shell bash\|zsh\|fish`) |
-| `auths agent lock` | Clear keys from memory |
-| `auths agent unlock` | Load a key into the agent (`--key <ALIAS>`) |
-| `auths agent install-service` | Install as system service (launchd/systemd) |
-| `auths agent uninstall-service` | Remove system service |
-
----
-
-## Utilities
-
-### `auths completions`
-
-Generate shell completions.
-
-```bash
-auths completions bash > ~/.bash_completion.d/auths
-auths completions zsh > ~/.zfunc/_auths
-auths completions fish > ~/.config/fish/completions/auths.fish
-```
-
-### `auths util derive-did`
-
-Derive a `did:key` from an Ed25519 seed.
-
-```bash
-auths util derive-did --seed-hex $(xxd -p -c 256 my_seed.raw)
-```
-
-### `auths util pubkey-to-did`
-
-Convert an OpenSSH Ed25519 public key to a DID.
-
-```bash
-auths util pubkey-to-did "ssh-ed25519 AAAA..."
-```
-
-### `auths util verify-attestation`
-
-Verify an attestation file directly with a known issuer public key.
-
-```bash
-auths util verify-attestation \
-  --attestation-file auth.json \
-  --issuer-pubkey <64-char-hex>
-```
-
----
+| `id` | Create, rotate, export, and register identities |
+| `device` | Link, revoke, and manage device authorizations |
+| `key` | List, import, export, and delete keys |
+| `approval` | Manage approval workflows |
+| `artifact` | Sign, verify, and publish arbitrary files |
+| `policy` | Lint, compile, test, and diff authorization policies |
+| `git` | Generate allowed-signers files, install hooks |
+| `trust` | Pin identity-to-key bindings (TOFU) |
+| `org` | Manage organizations, members, and attestations |
+| `audit` | Generate signing audit reports |
+| `agent` | Start/stop the SSH agent daemon |
+| `witness` | Run or manage KERI witness servers |
+| `scim` | SCIM provisioning integration |
+| `config` | View and modify configuration |
+| `emergency` | Key compromise response (revoke, rotate, freeze) |
+| `completions` | Generate shell completions |
+
+Run `auths <group> --help` for details on any group.
 
 ## CI Setup (GitHub Actions)
 
-`auths init --profile ci` creates an ephemeral in-memory identity scoped to the
-current run — no platform keychain required, no secrets to rotate, no state left
-behind after the job ends.
+`auths init --profile ci` creates an ephemeral in-memory identity scoped to the current run — no platform keychain required, no secrets to rotate.
 
 ### Signing commits in CI
 
@@ -658,28 +128,10 @@ jobs:
         run: auths verify HEAD
 ```
 
-### Troubleshooting CI
-
-Run `auths doctor` as the first step in any failing job.
-Exit code 0 = all checks pass. Exit code 1 = at least one check failed.
-
----
-
-## Advanced: Layout Overrides
-
-Several commands accept layout override flags under the "Advanced Setup" heading. These are per-command flags (not global) for working with non-default Git ref layouts:
-
-```
---identity-ref <GIT_REF>               Git ref for identity (e.g., refs/rad/id)
---identity-blob <FILENAME>             Blob name for identity data
---attestation-prefix <GIT_REF_PREFIX>  Base ref prefix for device attestations
---attestation-blob <FILENAME>          Blob name for attestation data
-```
-
-For most users, the `--preset` flag on `auths id create` is simpler:
+## Installation
 
 ```bash
-auths id create --preset default    # refs/rad/id, refs/keys (RIP-X layout)
-auths id create --preset radicle    # Same as default
-auths id create --preset gitoxide   # refs/auths/id, refs/auths/devices
+cargo install --path crates/auths-cli --force
 ```
+
+This installs three binaries: `auths`, `auths-sign`, and `auths-verify`. Ensure `~/.cargo/bin` is in your PATH.

--- a/crates/auths-cli/src/cli.rs
+++ b/crates/auths-cli/src/cli.rs
@@ -32,8 +32,8 @@ use crate::config::OutputFormat;
 
 fn cli_styles() -> Styles {
     Styles::styled()
-        .header(AnsiColor::Green.on_default() | Effects::BOLD)
-        .usage(AnsiColor::Green.on_default() | Effects::BOLD)
+        .header(AnsiColor::Blue.on_default() | Effects::BOLD)
+        .usage(AnsiColor::Blue.on_default() | Effects::BOLD)
         .literal(AnsiColor::Cyan.on_default() | Effects::BOLD)
         .placeholder(AnsiColor::Cyan.on_default())
         .error(AnsiColor::Red.on_default() | Effects::BOLD)
@@ -44,48 +44,38 @@ fn cli_styles() -> Styles {
 #[derive(Parser, Debug)]
 #[command(
     name = "auths",
-    about = "auths \u{2014} cryptographic identity for developers",
-    long_about = "auths \u{2014} cryptographic identity for developers\n\nCore commands:\n  init     Set up your cryptographic identity and Git signing\n  sign     Sign a Git commit or artifact\n  verify   Verify a signed commit or attestation\n  status   Show identity and signing status\n\nMore commands:\n  id, device, key, approval, artifact, policy, git, trust, org,\n  audit, agent, witness, scim, config, emergency\n\nRun `auths <command> --help` for details on any command.",
+    about = "\x1b[1;32mauths \u{2014} cryptographic identity for developers and agents\x1b[0m",
     version,
-    styles = cli_styles()
+    styles = cli_styles(),
+    after_help = "Run 'auths <command> --help' for details on any command.\nRun 'auths --help-all' for advanced commands (id, device, key, policy, ...)."
 )]
 pub struct AuthsCli {
     #[command(subcommand)]
-    pub command: RootCommand,
+    pub command: Option<RootCommand>,
+
+    #[clap(long, help = "Show all commands including advanced ones")]
+    pub help_all: bool,
 
     #[clap(
         long,
         value_enum,
         default_value = "text",
         global = true,
-        help_heading = "Display",
+        hide = true,
         help = "Output format (text or json)"
     )]
     pub format: OutputFormat,
 
-    #[clap(
-        long,
-        global = true,
-        help_heading = "Display",
-        help = "Emit machine-readable JSON"
-    )]
+    #[clap(long, global = true, help = "Emit machine-readable JSON")]
     pub json: bool,
 
-    #[clap(
-        short,
-        long,
-        global = true,
-        help_heading = "Display",
-        help = "Suppress non-essential output"
-    )]
+    #[clap(short, long, global = true, help = "Suppress non-essential output")]
     pub quiet: bool,
 
     #[clap(
         long,
         value_parser,
         global = true,
-        help_heading = "Advanced Setup",
-        hide_short_help = true,
         help = "Override the local storage directory (default: ~/.auths)"
     )]
     pub repo: Option<PathBuf>,
@@ -101,6 +91,7 @@ pub enum RootCommand {
     Whoami(WhoamiCommand),
     Tutorial(LearnCommand),
     Doctor(DoctorCommand),
+    #[command(hide = true)]
     Completions(CompletionsCommand),
     #[command(hide = true)]
     Emergency(EmergencyCommand),

--- a/crates/auths-cli/src/main.rs
+++ b/crates/auths-cli/src/main.rs
@@ -28,6 +28,22 @@ fn run() -> Result<()> {
 
     let cli = AuthsCli::parse();
 
+    if cli.help_all {
+        use clap::CommandFactory;
+        let mut cmd = AuthsCli::command();
+        let sub_names: Vec<String> = cmd
+            .get_subcommands()
+            .map(|s| s.get_name().to_string())
+            .collect();
+        for name in &sub_names {
+            if let Some(sub) = cmd.find_subcommand_mut(name) {
+                *sub = sub.clone().hide(false);
+            }
+        }
+        cmd.print_help()?;
+        return Ok(());
+    }
+
     let is_json = cli.json || matches!(cli.format, OutputFormat::Json);
     if is_json {
         set_json_mode(true);
@@ -35,7 +51,16 @@ fn run() -> Result<()> {
 
     let ctx = build_config(&cli)?;
 
-    match cli.command {
+    let command = match cli.command {
+        Some(cmd) => cmd,
+        None => {
+            use clap::CommandFactory;
+            AuthsCli::command().print_help()?;
+            return Ok(());
+        }
+    };
+
+    match command {
         RootCommand::Init(cmd) => cmd.execute(&ctx),
         RootCommand::Sign(cmd) => cmd.execute(&ctx),
         RootCommand::Verify(cmd) => cmd.execute(&ctx),

--- a/docs/cli/commands/advanced.md
+++ b/docs/cli/commands/advanced.md
@@ -19,6 +19,9 @@ auths device link
 | `--expires-in-days <DAYS>` | — |  |
 | `--note <NOTE>` | — |  |
 | `--capabilities <CAPABILITIES>` | — |  |
+| `--json` | — |  |
+| `-q, --quiet` | — |  |
+| `--repo <REPO>` | — |  |
 <!-- END GENERATED: auths device link -->
 
 ---
@@ -35,6 +38,10 @@ auths device revoke
 | `--device-did <DEVICE_DID>` | — |  |
 | `--identity-key-alias <IDENTITY_KEY_ALIAS>` | — |  |
 | `--note <NOTE>` | — |  |
+| `--dry-run` | — |  |
+| `--json` | — |  |
+| `-q, --quiet` | — |  |
+| `--repo <REPO>` | — |  |
 <!-- END GENERATED: auths device revoke -->
 
 ---
@@ -52,6 +59,9 @@ auths device extend
 | `--expires-in-days <DAYS>` | — |  |
 | `--identity-key-alias <IDENTITY_KEY_ALIAS>` | — |  |
 | `--device-key-alias <DEVICE_KEY_ALIAS>` | — |  |
+| `--json` | — |  |
+| `-q, --quiet` | — |  |
+| `--repo <REPO>` | — |  |
 <!-- END GENERATED: auths device extend -->
 
 ---
@@ -85,6 +95,10 @@ auths id rotate
 | `--add-witness <ADD_WITNESS>` | — |  |
 | `--remove-witness <REMOVE_WITNESS>` | — |  |
 | `--witness-threshold <WITNESS_THRESHOLD>` | — |  |
+| `--dry-run` | — |  |
+| `--json` | — |  |
+| `-q, --quiet` | — |  |
+| `--repo <REPO>` | — |  |
 <!-- END GENERATED: auths id rotate -->
 
 ---
@@ -103,6 +117,9 @@ auths key import
 | `--key-alias <KEY_ALIAS>` | — |  |
 | `--seed-file <SEED_FILE>` | — |  |
 | `--controller-did <CONTROLLER_DID>` | — |  |
+| `--json` | — |  |
+| `-q, --quiet` | — |  |
+| `--repo <REPO>` | — |  |
 <!-- END GENERATED: auths key import -->
 
 ---
@@ -116,9 +133,12 @@ auths key export
 <!-- BEGIN GENERATED: auths key export -->
 | Flag | Default | Description |
 |------|---------|-------------|
-| `--key-alias <KEY_ALIAS>` | — |  |
-| `--passphrase <PASSPHRASE>` | — |  |
-| `--format <FORMAT>` | — |  |
+| `--key-alias <KEY_ALIAS>` | — | Local alias of the key to export. [aliases: --alias] |
+| `--passphrase <PASSPHRASE>` | — | Passphrase to decrypt the key (needed for 'pem'/'pub' formats). |
+| `--format <FORMAT>` | — | Export format: pem (OpenSSH private), pub (OpenSSH public), enc (raw encrypted bytes). |
+| `--json` | — | Emit machine-readable JSON |
+| `-q, --quiet` | — | Suppress non-essential output |
+| `--repo <REPO>` | — | Override the local storage directory (default: ~/.auths) |
 <!-- END GENERATED: auths key export -->
 
 ---
@@ -132,7 +152,10 @@ auths key delete
 <!-- BEGIN GENERATED: auths key delete -->
 | Flag | Default | Description |
 |------|---------|-------------|
-| `--key-alias <KEY_ALIAS>` | — |  |
+| `--key-alias <KEY_ALIAS>` | — | Local alias of the key to remove. [aliases: --alias] |
+| `--json` | — | Emit machine-readable JSON |
+| `-q, --quiet` | — | Suppress non-essential output |
+| `--repo <REPO>` | — | Override the local storage directory (default: ~/.auths) |
 <!-- END GENERATED: auths key delete -->
 
 ---
@@ -148,8 +171,11 @@ auths policy explain
 <!-- BEGIN GENERATED: auths policy explain -->
 | Flag | Default | Description |
 |------|---------|-------------|
-| `<FILE>` | — |  |
-| `-c, --context <CONTEXT>` | — |  |
+| `<FILE>` | — | Path to the policy file (JSON) |
+| `-c, --context <CONTEXT>` | — | Path to the context file (JSON) |
+| `--json` | — | Emit machine-readable JSON |
+| `-q, --quiet` | — | Suppress non-essential output |
+| `--repo <REPO>` | — | Override the local storage directory (default: ~/.auths) |
 <!-- END GENERATED: auths policy explain -->
 
 ---
@@ -163,8 +189,11 @@ auths policy test
 <!-- BEGIN GENERATED: auths policy test -->
 | Flag | Default | Description |
 |------|---------|-------------|
-| `<FILE>` | — |  |
-| `-t, --tests <TESTS>` | — |  |
+| `<FILE>` | — | Path to the policy file (JSON) |
+| `-t, --tests <TESTS>` | — | Path to the test suite file (JSON) |
+| `--json` | — | Emit machine-readable JSON |
+| `-q, --quiet` | — | Suppress non-essential output |
+| `--repo <REPO>` | — | Override the local storage directory (default: ~/.auths) |
 <!-- END GENERATED: auths policy test -->
 
 ---
@@ -178,8 +207,11 @@ auths policy diff
 <!-- BEGIN GENERATED: auths policy diff -->
 | Flag | Default | Description |
 |------|---------|-------------|
-| `<OLD>` | — |  |
-| `<NEW>` | — |  |
+| `<OLD>` | — | Path to the old policy file (JSON) |
+| `<NEW>` | — | Path to the new policy file (JSON) |
+| `--json` | — | Emit machine-readable JSON |
+| `-q, --quiet` | — | Suppress non-essential output |
+| `--repo <REPO>` | — | Override the local storage directory (default: ~/.auths) |
 <!-- END GENERATED: auths policy diff -->
 
 ---
@@ -201,6 +233,8 @@ auths emergency revoke-device
 | `-y, --yes` | — |  |
 | `--dry-run` | — |  |
 | `--repo <REPO>` | — |  |
+| `--json` | — |  |
+| `-q, --quiet` | — |  |
 <!-- END GENERATED: auths emergency revoke-device -->
 
 ---
@@ -220,6 +254,8 @@ auths emergency rotate-now
 | `--dry-run` | — | Preview actions without making changes |
 | `--reason <REASON>` | — | Reason for rotation |
 | `--repo <REPO>` | — | Path to the Auths repository |
+| `--json` | — | Emit machine-readable JSON |
+| `-q, --quiet` | — | Suppress non-essential output |
 <!-- END GENERATED: auths emergency rotate-now -->
 
 ---
@@ -237,6 +273,8 @@ auths emergency freeze
 | `-y, --yes` | — | Skip confirmation prompt (requires typing identity name) |
 | `--dry-run` | — | Preview actions without making changes |
 | `--repo <REPO>` | — | Path to the Auths repository |
+| `--json` | — | Emit machine-readable JSON |
+| `-q, --quiet` | — | Suppress non-essential output |
 <!-- END GENERATED: auths emergency freeze -->
 
 ---
@@ -248,5 +286,11 @@ auths emergency report
 ```
 
 <!-- BEGIN GENERATED: auths emergency report -->
-_No options._
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--events <EVENTS>` | `100` | Include last N events in report |
+| `-o, --output <OUTPUT_FILE>` | — | Output file path (defaults to stdout) [aliases: --file] |
+| `--repo <REPO>` | — | Path to the Auths repository |
+| `--json` | — | Emit machine-readable JSON |
+| `-q, --quiet` | — | Suppress non-essential output |
 <!-- END GENERATED: auths emergency report -->

--- a/docs/cli/commands/primary.md
+++ b/docs/cli/commands/primary.md
@@ -19,6 +19,9 @@ auths init
 | `--dry-run` | — |  |
 | `--registry <REGISTRY>` | — |  |
 | `--skip-registration` | — |  |
+| `--json` | — |  |
+| `-q, --quiet` | — |  |
+| `--repo <REPO>` | — |  |
 <!-- END GENERATED: auths init -->
 
 ---
@@ -39,6 +42,9 @@ auths verify
 | `--witness-receipts <WITNESS_RECEIPTS>` | — |  |
 | `--witness-threshold <WITNESS_THRESHOLD>` | — |  |
 | `--witness-keys <WITNESS_KEYS>...` | — |  |
+| `--json` | — |  |
+| `-q, --quiet` | — |  |
+| `--repo <REPO>` | — |  |
 <!-- END GENERATED: auths verify -->
 
 ---
@@ -50,5 +56,9 @@ auths status
 ```
 
 <!-- BEGIN GENERATED: auths status -->
-_No options._
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--json` | — | Emit machine-readable JSON |
+| `-q, --quiet` | — | Suppress non-essential output |
+| `--repo <REPO>` | — | Override the local storage directory (default: ~/.auths) |
 <!-- END GENERATED: auths status -->


### PR DESCRIPTION
- Remove long_about prose that duplicated/conflicted with Commands list
- Add --help-all flag to discover hidden advanced commands
- Hide completions and --format from default help
- Change header/usage colors to blue, about line green
- Add after_help footer with discoverability hints
- Rewrite README with progressive disclosure structure
- Regenerate CLI docs via cargo xtask gen-docs