### PR TITLE
docs: replace custom rustdocs with official links

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -49,11 +49,6 @@ jobs:
       - name: Regenerate CLI docs
         run: cargo run -p xtask -- gen-docs
 
-      - name: Build rustdoc
-        run: cargo doc --no-deps -p auths-sdk -p auths-core -p auths-crypto -p auths-verifier -p auths-id
-        env:
-          RUSTDOCFLAGS: "-D warnings"
-
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
@@ -68,18 +63,3 @@ jobs:
       - name: Build mkdocs
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         run: mkdocs build --strict
-
-      - name: Merge rustdoc into site
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        run: |
-          mkdir -p site/rustdoc
-          cp -r target/doc/* site/rustdoc/
-          echo '<meta http-equiv="refresh" content="0; url=auths_sdk">' > site/rustdoc/index.html
-          touch site/.nojekyll
-
-      - name: Deploy to GitHub Pages
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        uses: peaceiris/actions-gh-pages@v4
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./site

--- a/docs/sdk/rust/api-reference.md
+++ b/docs/sdk/rust/api-reference.md
@@ -1,15 +1,15 @@
 # Rust API Reference
 
-The full Rust API reference is generated from source via rustdoc.
+The full Rust API reference is hosted on docs.rs.
 
-**[Browse the API reference →](/rustdoc/auths_sdk/)**
+**[Browse the API reference →](https://docs.rs/auths-sdk/latest/auths_sdk/)**
 
 ## Key Crates
 
 | Crate | Description |
 |---|---|
-| [auths-sdk](/rustdoc/auths_sdk/) | Application services layer — start here |
-| [auths-core](/rustdoc/auths_core/) | Keychain, device pairing, trust model |
-| [auths-crypto](/rustdoc/auths_crypto/) | Ed25519 signing, DID encoding |
-| [auths-verifier](/rustdoc/auths_verifier/) | Attestation chain verification |
-| [auths-id](/rustdoc/auths_id/) | KERI Key Event Log management |
+| [auths-sdk](https://docs.rs/auths-sdk/latest/auths_sdk/) | Application services layer — start here |
+| [auths-core](https://docs.rs/auths-core/latest/auths_core/) | Keychain, device pairing, trust model |
+| [auths-crypto](https://docs.rs/auths-crypto/latest/auths_crypto/) | Ed25519 signing, DID encoding |
+| [auths-verifier](https://docs.rs/auths-verifier/latest/auths_verifier/) | Attestation chain verification |
+| [auths-id](https://docs.rs/auths-id/latest/auths_id/) | KERI Key Event Log management |


### PR DESCRIPTION
hotfix on the rustdocs portions of #58