### PR TITLE
fix: use standard auths layout as CLI default, not radicle

### DIFF
--- a/crates/auths-cli/src/commands/id/identity.rs
+++ b/crates/auths-cli/src/commands/id/identity.rs
@@ -34,7 +34,7 @@ use auths_id::{
     storage::{
         attestation::AttestationSource,
         identity::IdentityStorage,
-        layout::{self, BlobName, GitRef, StorageLayoutConfig},
+        layout::{self, StorageLayoutConfig},
     },
 };
 use auths_storage::git::{
@@ -44,10 +44,10 @@ use auths_storage::git::{
 /// Storage layout presets for different ecosystems.
 #[derive(Debug, Clone, Copy, ValueEnum, Default)]
 pub enum LayoutPreset {
-    /// RIP-X layout (refs/rad/id, refs/keys)
+    /// Standard Auths layout (refs/auths/identity, refs/auths/keys)
     #[default]
     Default,
-    /// Alias for default — explicitly Radicle-compatible
+    /// Radicle-compatible layout (refs/rad/id, refs/keys)
     Radicle,
     /// Gitoxide-compatible layout (refs/auths/id, refs/auths/devices)
     Gitoxide,
@@ -57,18 +57,9 @@ impl LayoutPreset {
     /// Convert the preset to a StorageLayoutConfig.
     pub fn to_config(self) -> StorageLayoutConfig {
         match self {
-            LayoutPreset::Default | LayoutPreset::Radicle => StorageLayoutConfig {
-                identity_ref: GitRef::new("refs/rad/id"),
-                device_attestation_prefix: GitRef::new("refs/keys"),
-                attestation_blob_name: BlobName::new(layout::ATTESTATION_JSON),
-                identity_blob_name: BlobName::new(layout::IDENTITY_JSON),
-            },
-            LayoutPreset::Gitoxide => StorageLayoutConfig {
-                identity_ref: GitRef::new("refs/auths/id"),
-                device_attestation_prefix: GitRef::new("refs/auths/devices"),
-                attestation_blob_name: BlobName::new(layout::ATTESTATION_JSON),
-                identity_blob_name: BlobName::new(layout::IDENTITY_JSON),
-            },
+            LayoutPreset::Default => StorageLayoutConfig::default(),
+            LayoutPreset::Radicle => StorageLayoutConfig::radicle(),
+            LayoutPreset::Gitoxide => StorageLayoutConfig::gitoxide(),
         }
     }
 }

--- a/crates/auths-cli/src/commands/registry_overrides.rs
+++ b/crates/auths-cli/src/commands/registry_overrides.rs
@@ -5,28 +5,28 @@ pub struct RegistryOverrides {
     #[arg(
         long = "identity-ref",
         value_name = "GIT_REF",
-        help = "Override Git ref for the identity commit [default: refs/rad/id]"
+        help = "Override Git ref for the identity commit [default: refs/auths/identity]"
     )]
     pub identity_ref: Option<String>,
 
     #[arg(
         long = "identity-blob",
         value_name = "FILENAME",
-        help = "Override blob filename for identity data [default: radicle-identity.json]"
+        help = "Override blob filename for identity data [default: identity.json]"
     )]
     pub identity_blob: Option<String>,
 
     #[arg(
         long = "attestation-prefix",
         value_name = "GIT_REF_PREFIX",
-        help = "Override base Git ref prefix for device authorizations [default: refs/keys]"
+        help = "Override base Git ref prefix for device authorizations [default: refs/auths/keys]"
     )]
     pub attestation_prefix: Option<String>,
 
     #[arg(
         long = "attestation-blob",
         value_name = "FILENAME",
-        help = "Override blob filename for device authorization data [default: link-attestation.json]"
+        help = "Override blob filename for device authorization data [default: attestation.json]"
     )]
     pub attestation_blob: Option<String>,
 }


### PR DESCRIPTION
LayoutPreset::Default now delegates to StorageLayoutConfig::default() (refs/auths/identity, refs/auths/keys) instead of hardcoding the Radicle layout. Radicle layout is only used with --preset radicle.