### PR TITLE
feat: fix passphrase fatigue by wiring OS keychain caching into all CLI commands

### DIFF
--- a/crates/auths-cli/src/factories/mod.rs
+++ b/crates/auths-cli/src/factories/mod.rs
@@ -2,18 +2,19 @@ pub mod storage;
 
 use std::io::IsTerminal;
 use std::sync::Arc;
-use std::time::Duration;
 
 use anyhow::Result;
 
-use auths_core::config::EnvironmentConfig;
+use auths_core::config::{EnvironmentConfig, load_config};
 use auths_core::paths::auths_home;
-use auths_core::signing::{CachedPassphraseProvider, PassphraseProvider};
+use auths_core::signing::{KeychainPassphraseProvider, PassphraseProvider};
+use auths_core::storage::passphrase_cache::{get_passphrase_cache, parse_duration_str};
 use auths_sdk::ports::agent::AgentSigningPort;
 use auths_telemetry::TelemetryShutdown;
 use auths_telemetry::config::{build_sinks_from_config, load_audit_config};
 use auths_telemetry::sinks::composite::CompositeSink;
 
+use crate::adapters::config_store::FileConfigStore;
 use crate::cli::AuthsCli;
 use crate::config::{CliConfig, OutputFormat};
 use crate::core::provider::{CliPassphraseProvider, PrefilledPassphraseProvider};
@@ -50,10 +51,20 @@ pub fn build_config(cli: &AuthsCli) -> Result<CliConfig> {
                 passphrase,
             )))
         } else {
+            let config = load_config(&FileConfigStore);
+            let cache = get_passphrase_cache(config.passphrase.biometric);
+            let ttl_secs = config
+                .passphrase
+                .duration
+                .as_deref()
+                .and_then(parse_duration_str);
             let inner = Arc::new(CliPassphraseProvider::new());
-            Arc::new(CachedPassphraseProvider::new(
+            Arc::new(KeychainPassphraseProvider::new(
                 inner,
-                Duration::from_secs(3600),
+                cache,
+                "default".to_string(),
+                config.passphrase.cache,
+                ttl_secs,
             ))
         };
 

--- a/crates/auths-cli/src/factories/storage.rs
+++ b/crates/auths-cli/src/factories/storage.rs
@@ -131,6 +131,7 @@ pub fn build_auths_context(
         .identity_storage(identity_storage)
         .attestation_sink(attestation_sink)
         .attestation_source(attestation_source);
+    builder = builder.agent_signing(crate::factories::build_agent_provider());
     if let Some(pp) = passphrase_provider {
         builder = builder.passphrase_provider(pp);
     }

--- a/crates/auths-core/src/error.rs
+++ b/crates/auths-core/src/error.rs
@@ -155,7 +155,9 @@ impl AuthsErrorInfo for AgentError {
     fn suggestion(&self) -> Option<&'static str> {
         match self {
             Self::KeyNotFound => Some("Run `auths key list` to see available keys"),
-            Self::IncorrectPassphrase => Some("Check your passphrase and try again"),
+            Self::IncorrectPassphrase => Some(
+                "Check your passphrase and try again. Set AUTHS_PASSPHRASE for automation, or run `auths agent start` for session caching",
+            ),
             Self::MissingPassphrase => {
                 Some("Provide a passphrase with --passphrase or set AUTHS_PASSPHRASE")
             }

--- a/crates/auths-sdk/src/signing.rs
+++ b/crates/auths-sdk/src/signing.rs
@@ -86,9 +86,9 @@ impl auths_core::error::AuthsErrorInfo for SigningError {
             }
             Self::AgentUnavailable(_) => Some("Start the agent with `auths agent start`"),
             Self::AgentSigningFailed(_) => Some("Check agent logs with `auths agent status`"),
-            Self::PassphraseExhausted { .. } => {
-                Some("Run `auths key reset <alias>` to reset your passphrase")
-            }
+            Self::PassphraseExhausted { .. } => Some(
+                "Run `auths key reset <alias>` to reset, or `auths agent start` to cache keys in memory",
+            ),
             Self::KeychainUnavailable(_) => Some("Run `auths doctor` to diagnose keychain issues"),
             Self::KeyDecryptionFailed(_) => Some("Check your passphrase and try again"),
         }


### PR DESCRIPTION
The main `auths` binary used an in-process CachedPassphraseProvider that
  was empty on every invocation, prompting for a passphrase every time.
  Meanwhile `auths-sign` already used KeychainPassphraseProvider (OS
  keychain-backed, persists across invocations).

  - Replace CachedPassphraseProvider with KeychainPassphraseProvider in build_config() so all CLI commands benefit from OS keychain caching
  - Wire agent_signing into build_auths_context() so CommitSigningContext gets a real agent provider instead of NoopAgentProvider
  - Improve error messages for IncorrectPassphrase and PassphraseExhausted to surface AUTHS_PASSPHRASE and `auths agent start` options