### PR TITLE
security: close RT-002 and harden the verify path (#263)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,13 @@ jobs:
             target
           key: ${{ runner.os }}-clippy-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: ${{ runner.os }}-clippy-
-      - run: cargo clippy --all-targets --all-features -- -D warnings
+      # `fips`/`cnsa` are mutually exclusive (RT-012 compile_error! in
+      # auths-crypto/src/provider.rs), so --all-features can't compile. Lint the
+      # bulk workspace minus the five dual-provider crypto crates, then lint those
+      # five under each provider separately.
+      - run: cargo clippy --all-targets --all-features --workspace --exclude auths-crypto --exclude auths-core --exclude auths-keri --exclude auths-pairing-protocol --exclude auths-pairing-daemon -- -D warnings
+      - run: cargo clippy --all-targets -p auths-crypto -p auths-core -p auths-keri -p auths-pairing-protocol -p auths-pairing-daemon --features fips -- -D warnings
+      - run: cargo clippy --all-targets -p auths-crypto -p auths-core -p auths-keri -p auths-pairing-protocol -p auths-pairing-daemon --features cnsa -- -D warnings
       - run: cargo run -p xtask -- check-clippy-sync
 
   xtask-checks:
@@ -75,6 +81,7 @@ jobs:
           cargo run -p xtask -- check-rfc6979
           cargo run -p xtask -- check-admission-policy
           cargo run -p xtask -- check-command-drift
+          cargo run -p xtask -- check-verify-path-completeness
           cargo run -p xtask -- gen-error-docs --check
       - name: Architecture boundary checks
         run: |
@@ -184,9 +191,17 @@ jobs:
         with:
           go-version: 'stable'
 
-      - name: Run tests (Ubuntu — all features incl. FIPS)
+      # `fips`/`cnsa` are mutually exclusive (RT-012), so --all-features can't
+      # compile. Run the bulk workspace with --all-features minus the five
+      # dual-provider crypto crates, then run those five under FIPS (the provider
+      # this job has always exercised — aws-lc-rs needs the Go/CMake toolchain
+      # installed above).
+      - name: Run tests (Ubuntu — all features, crypto crates excluded)
         if: matrix.os == 'ubuntu-latest'
-        run: cargo nextest run --workspace --all-features --no-fail-fast
+        run: cargo nextest run --workspace --all-features --no-fail-fast --exclude auths-crypto --exclude auths-core --exclude auths-keri --exclude auths-pairing-protocol --exclude auths-pairing-daemon
+      - name: Run tests (Ubuntu — crypto crates under FIPS)
+        if: matrix.os == 'ubuntu-latest'
+        run: cargo nextest run -p auths-crypto -p auths-core -p auths-keri -p auths-pairing-protocol -p auths-pairing-daemon --features fips --no-fail-fast
 
       - name: Run tests (macOS — exclude FIPS, requires Go + Linux)
         if: matrix.os == 'macos-latest'

--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -38,12 +38,12 @@ jobs:
           fetch-depth: 0
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@master
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
           toolchain: "1.93"
 
       - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           cache-on-failure: true
 

--- a/.github/workflows/publish-node.yml
+++ b/.github/workflows/publish-node.yml
@@ -47,7 +47,7 @@ jobs:
         shell: bash
         run: rm -f rust-toolchain.toml
 
-      - uses: dtolnay/rust-toolchain@master
+      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
           toolchain: "1.93"
           targets: ${{ matrix.target }}
@@ -62,7 +62,7 @@ jobs:
 
       - name: Install dependencies
         working-directory: packages/auths-node
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: Build native module
         working-directory: packages/auths-node
@@ -103,7 +103,7 @@ jobs:
 
       - name: Install dependencies
         working-directory: packages/auths-node
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
 
       - uses: actions/download-artifact@v4
         with:
@@ -139,7 +139,7 @@ jobs:
 
       - name: Install dependencies
         working-directory: packages/auths-node
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
 
       - uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -60,11 +60,11 @@ jobs:
           python-version: "3.12"
 
       - name: Build wheels
-        uses: PyO3/maturin-action@v1
+        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1
         with:
           target: ${{ matrix.target }}
           manylinux: ${{ matrix.manylinux }}
-          args: --release --out dist ${{ matrix.args }}
+          args: --release --locked --out dist ${{ matrix.args }}
           working-directory: packages/auths-python
           sccache: "true"
 
@@ -80,7 +80,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Build sdist
-        uses: PyO3/maturin-action@v1
+        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1
         with:
           command: sdist
           args: --out dist
@@ -140,7 +140,7 @@ jobs:
           merge-multiple: true
 
       - name: Publish
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
         with:
           verbose: true
           packages-dir: dist/

--- a/.github/workflows/publish-typescript.yml
+++ b/.github/workflows/publish-typescript.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: dtolnay/rust-toolchain@master
+      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
           toolchain: "1.93"
           targets: wasm32-unknown-unknown
@@ -41,7 +41,7 @@ jobs:
 
       - name: Install dependencies
         working-directory: packages/auths-verifier-ts
-        run: npm install
+        run: npm ci
 
       - name: Build (wasm + ts)
         working-directory: packages/auths-verifier-ts
@@ -101,7 +101,7 @@ jobs:
             echo "Dry run - skipping publish"
             npm pack
           else
-            npm publish --provenance --access public
+            npm publish --ignore-scripts --provenance --access public
           fi
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release-go.yml
+++ b/.github/workflows/release-go.yml
@@ -46,7 +46,7 @@ jobs:
         shell: bash
         run: rm -f rust-toolchain.toml
 
-      - uses: dtolnay/rust-toolchain@master
+      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
           toolchain: "1.93"
 
@@ -58,7 +58,7 @@ jobs:
       # resolver = "3" rejects --features from the workspace root; run inside the crate.
       - name: Build cdylib (--features ffi)
         working-directory: crates/auths-verifier
-        run: cargo build --release --features ffi
+        run: cargo build --release --locked --features ffi
 
       - name: go test against the prebuilt lib (CGO_ENABLED=1)
         working-directory: packages/auths-verifier-go

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
           fetch-depth: 0
 
       - name: Verify commit signatures
-        uses: auths-dev/verify@v1
+        uses: auths-dev/verify@c7bee200ff881005bd13bd67f514b57edbfd0500 # v1
         with:
           auths-version: '0.1.2'
           identity-bundle: .auths/ci-bundle.json
@@ -60,19 +60,19 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@master
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
           toolchain: "1.93"
           targets: ${{ matrix.target }}
 
       - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: ${{ matrix.target }}
           cache-on-failure: true
 
       - name: Build release binaries
-        run: cargo build --release --package auths-cli --target ${{ matrix.target }}
+        run: cargo build --release --locked --package auths-cli --target ${{ matrix.target }}
 
       - name: Package (Unix)
         if: matrix.ext == '.tar.gz'
@@ -166,7 +166,7 @@ jobs:
           path: artifacts/
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         with:
           files: artifacts/**/*
           generate_release_notes: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -55,7 +55,12 @@ repos:
 
       - id: cargo-clippy
         name: cargo clippy
-        entry: cargo clippy --all-targets --all-features --keep-going -- -D warnings
+        # `fips` and `cnsa` are mutually exclusive (compile_error! in
+        # auths-crypto/src/provider.rs, RT-012), so `--all-features` no longer
+        # compiles. Lint the bulk workspace with --all-features excluding the five
+        # crates that carry both providers, then lint those five under each
+        # provider separately.
+        entry: bash -c 'cargo clippy --all-targets --all-features --keep-going --workspace --exclude auths-crypto --exclude auths-core --exclude auths-keri --exclude auths-pairing-protocol --exclude auths-pairing-daemon -- -D warnings && cargo clippy --all-targets --keep-going -p auths-crypto -p auths-core -p auths-keri -p auths-pairing-protocol -p auths-pairing-daemon --features fips -- -D warnings && cargo clippy --all-targets --keep-going -p auths-crypto -p auths-core -p auths-keri -p auths-pairing-protocol -p auths-pairing-daemon --features cnsa -- -D warnings'
         language: system
         types: [rust]
         pass_filenames: false

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -507,6 +507,7 @@ dependencies = [
  "bs58",
  "cesride",
  "chacha20poly1305",
+ "getrandom 0.2.17",
  "hex",
  "hkdf",
  "hmac",
@@ -1036,6 +1037,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "subtle",
  "thiserror 2.0.18",
  "tokio",
  "wasm-bindgen",
@@ -8450,11 +8452,3 @@ dependencies = [
  "syn",
  "winnow 0.7.15",
 ]
-
-[[patch.unused]]
-name = "radicle-core"
-version = "0.1.0"
-
-[[patch.unused]]
-name = "radicle-crypto"
-version = "0.14.0"

--- a/crates/auths-api/src/app.rs
+++ b/crates/auths-api/src/app.rs
@@ -8,6 +8,7 @@
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
+use axum::extract::DefaultBodyLimit;
 use axum::middleware::from_fn_with_state;
 use axum::routing::{get, post};
 use axum::Router;
@@ -192,6 +193,10 @@ pub fn build_router(state: AppState) -> Router {
                 .with_state(mint),
         )
         .merge(protected)
+        // Explicit request-body cap (RT-013): bound every endpoint well below
+        // Axum's 2 MB default so an oversized batch-revoke array cannot drive
+        // quadratic KEL replay. Batch size is additionally capped per-handler.
+        .layer(DefaultBodyLimit::max(1024 * 1024))
 }
 
 /// Liveness probe.

--- a/crates/auths-api/src/control_plane.rs
+++ b/crates/auths-api/src/control_plane.rs
@@ -366,6 +366,12 @@ pub async fn revoke_agent(
     }))
 }
 
+/// Upper bound on a single batch-revoke request. Caps the per-request KEL-replay
+/// cost (RT-013): each agent triggers a membership check, so an unbounded array
+/// drives quadratic work on the single-host control plane. Split larger
+/// off-boardings across requests.
+const MAX_BATCH_REVOKE: usize = 256;
+
 /// `POST /v1/org/{org}/agents/revoke-batch` — the kill switch: revoke an enumerated
 /// set of agents in one atomic KEL event. Idempotent; rejects an empty set (`400`).
 pub async fn batch_revoke_agents(
@@ -376,6 +382,12 @@ pub async fn batch_revoke_agents(
     state.ensure_org(&org)?;
     if req.agents.is_empty() {
         return Err(ApiError::BadRequest("agents must not be empty".to_string()));
+    }
+    if req.agents.len() > MAX_BATCH_REVOKE {
+        return Err(ApiError::BadRequest(format!(
+            "batch revoke is capped at {MAX_BATCH_REVOKE} agents (got {}); split into smaller batches",
+            req.agents.len()
+        )));
     }
     let receipt = revoke_batch(&state.ctx, &state.org_alias, &req.agents)?;
     Ok(Json(BatchRevocationResponse {

--- a/crates/auths-cli/src/commands/id/identity.rs
+++ b/crates/auths-cli/src/commands/id/identity.rs
@@ -797,23 +797,36 @@ pub fn handle_id(
             );
             let prefix = auths_sdk::keri::parse_did_keri(identity.controller_did.as_str())
                 .context("identity DID is not did:keri")?;
-            let mut kel: Vec<serde_json::Value> = Vec::new();
-            let mut kel_err: Option<String> = None;
+            // Collect the KEL events, then their stored CESR signature
+            // attachments (seq-indexed), so the exported bundle can be
+            // AUTHENTICATED by a stateless verifier — not just replayed
+            // structurally (RT-002).
+            let mut events = Vec::new();
             let _ = registry.visit_events(&prefix, 0, &mut |e| {
-                match serde_json::to_value(e) {
-                    Ok(v) => kel.push(v),
-                    Err(err) => kel_err = Some(err.to_string()),
-                }
+                events.push(e.clone());
                 std::ops::ControlFlow::Continue(())
             });
-            if let Some(err) = kel_err {
-                return Err(anyhow::anyhow!("failed to serialize KEL event: {err}"));
-            }
-            if kel.is_empty() {
+            if events.is_empty() {
                 return Err(anyhow::anyhow!(
                     "no KEL events found for {} — cannot export a verifiable bundle",
                     identity.controller_did
                 ));
+            }
+            let mut kel: Vec<auths_keri::Event> = Vec::with_capacity(events.len());
+            let mut kel_attachments: Vec<String> = Vec::with_capacity(events.len());
+            for e in &events {
+                let seq = e.sequence().value();
+                let att = registry
+                    .get_attachment(&prefix, seq)
+                    .map_err(|err| anyhow::anyhow!("failed to read KEL signature: {err}"))?
+                    .ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "KEL event at seq {seq} has no stored signature attachment; \
+                             cannot export a verifiable bundle (re-initialize this identity)"
+                        )
+                    })?;
+                kel.push(e.clone());
+                kel_attachments.push(hex::encode(att));
             }
 
             // Create the bundle. Curve flows in-band from the typed keychain
@@ -825,6 +838,7 @@ pub fn handle_id(
                 curve,
                 attestation_chain: attestations,
                 kel,
+                kel_attachments,
                 bundle_timestamp: now,
                 max_valid_for_secs: max_age_secs,
             };

--- a/crates/auths-cli/src/commands/scim.rs
+++ b/crates/auths-cli/src/commands/scim.rs
@@ -13,6 +13,7 @@ use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
 
 use auths_scim_server::{ServeConfig, TenantBootstrap, run};
+use auths_verifier::Capability;
 
 use crate::commands::executable::ExecutableCommand;
 use crate::config::CliConfig;
@@ -64,6 +65,13 @@ pub struct ScimServeCommand {
     /// Base URL used for SCIM `meta.location`.
     #[arg(long)]
     pub base_url: Option<String>,
+    /// Capability this tenant may grant (repeatable). Empty = deny all (RT-006);
+    /// pass --allow-all-capabilities to opt into permit-all.
+    #[arg(long = "allowed-capability")]
+    pub allowed_capability: Vec<Capability>,
+    /// Let this tenant grant ANY capability, bypassing the allowlist (opt-in).
+    #[arg(long)]
+    pub allow_all_capabilities: bool,
     /// Passphrase for the org signing key (single-host custody).
     #[arg(long)]
     pub passphrase: Option<String>,
@@ -167,6 +175,8 @@ fn handle_serve(cmd: ScimServeCommand, ctx: &CliConfig) -> Result<()> {
             bearer_token,
             org_key_alias: cmd.org_key,
             base_url: cmd.base_url,
+            allowed_capabilities: cmd.allowed_capability,
+            allow_all: cmd.allow_all_capabilities,
         }),
         (None, None, None) => {
             println!("No tenant configured — running discovery-only; /Users rejects all callers.");
@@ -222,6 +232,10 @@ fn handle_quickstart(cmd: ScimQuickstartCommand, ctx: &CliConfig) -> Result<()> 
             bearer_token: token,
             org_key_alias: None,
             base_url: Some(format!("http://{}/scim/v2", cmd.bind)),
+            // Quickstart stays deny-by-default; its demo provisions a bot with no
+            // capabilities, which passes. Grant caps via `scim serve`.
+            allowed_capabilities: Vec::new(),
+            allow_all: false,
         }),
         home: resolve_home(cmd.registry_path, ctx),
         passphrase: cmd.passphrase.unwrap_or_default(),

--- a/crates/auths-cli/src/commands/verify_commit.rs
+++ b/crates/auths-cli/src/commands/verify_commit.rs
@@ -159,26 +159,45 @@ pub async fn handle_verify_commit(
     // tree) — the source we replay to decide trust.
     let registry =
         GitRegistryBackend::from_config_unchecked(RegistryConfig::single_tenant(&auths_home));
-    // Trust roots = the committed `.auths/roots` pin, plus the verifier's own
-    // identity (self-trust — you can always verify what you signed), plus the
-    // root of any `--identity-bundle` the caller supplied (stateless CI). An
-    // unusable bundle fails closed — it must never silently leave trust
-    // unconstrained.
+    // Trust roots = the committed `.auths/roots` pin plus the verifier's own
+    // identity (self-trust — you can always verify what you signed). A
+    // `--identity-bundle` does NOT contribute a root: it supplies KEL *evidence*
+    // for a root that must already be pinned here (RT-005). An unusable or
+    // un-pinned bundle fails closed — trust is never left unconstrained.
     let mut pinned_roots = super::verify_helpers::load_project_pinned_roots();
     if let Some(own_root) = auths_sdk::workflows::commit_trust::local_self_root(&sdk_ctx)
         && !pinned_roots.contains(&own_root)
     {
         pinned_roots.push(own_root);
     }
-    let mut bundle_kel: Option<(String, Vec<Event>)> = None;
+    let mut bundle_kel: Option<BundleKel> = None;
     if let Some(bundle_path) = &cmd.identity_bundle {
         match load_bundle_trust(bundle_path, chrono::Utc::now()) {
             Ok((root, kel)) => {
-                if !kel.is_empty() {
-                    bundle_kel = Some((root.clone(), kel));
-                }
+                // Evidence-only (RT-005): the bundle is *evidence for* a root that
+                // must be pinned independently (`.auths/roots` or self-trust). It
+                // never becomes its own trust anchor — otherwise the anchor and the
+                // evidence both come from the same attacker-supplied file. (The
+                // self-certified root is additionally re-derived by replay and
+                // checked against the pins, so a coherent-but-unpinned bundle is
+                // still rejected.)
                 if !pinned_roots.contains(&root) {
-                    pinned_roots.push(root);
+                    return handle_error(
+                        &cmd,
+                        2,
+                        &format!(
+                            "identity bundle root {root} is not independently trusted: \
+                             add it to .auths/roots (or verify from the identity that \
+                             controls it). A bundle is evidence for a pinned root, never \
+                             the source of the pin."
+                        ),
+                    );
+                }
+                if !kel.is_empty() {
+                    bundle_kel = Some(BundleKel {
+                        did: root,
+                        events: kel,
+                    });
                 }
             }
             Err(e) => return handle_error(&cmd, 2, &e),
@@ -216,6 +235,18 @@ pub async fn handle_verify_commit(
 /// (freshness-checked via the SDK trust resolver) plus the KEL events it carries for
 /// stateless resolution. Fails closed: any read, parse, or staleness error is returned
 /// so the caller can abort rather than verify unconstrained.
+/// A bundle's authenticated KEL: the identity DID it self-certifies to plus the
+/// KEL events it carries. Built once by the `--identity-bundle` path and threaded
+/// into [`resolve_signer_kel`] so a stateless run (no identity store) can satisfy a
+/// signer lookup from the bundle. Replaces an anonymous `(String, Vec<Event>)`.
+struct BundleKel {
+    /// The bundle's identity DID (`did:keri:…`).
+    did: String,
+    /// The bundle's KEL events, oldest first — already signature-authenticated by
+    /// [`load_bundle_trust`] (RT-002).
+    events: Vec<Event>,
+}
+
 fn load_bundle_trust(
     path: &std::path::Path,
     now: chrono::DateTime<chrono::Utc>,
@@ -226,12 +257,45 @@ fn load_bundle_trust(
         .map_err(|e| format!("identity bundle {path:?} is not valid JSON: {e}"))?;
     let root = auths_sdk::workflows::commit_trust::trusted_root_from_bundle(&bundle, now)
         .map_err(|e| e.to_string())?;
-    let kel: Vec<Event> = bundle
-        .kel
-        .iter()
-        .map(|v| serde_json::from_value(v.clone()))
-        .collect::<std::result::Result<_, _>>()
-        .map_err(|e| format!("identity bundle {path:?} carries an unparseable KEL: {e}"))?;
+    // `bundle.kel` is already `Vec<Event>` — parsed at the deserialize boundary,
+    // so a structurally-broken event fails the bundle parse above rather than
+    // slipping through as loose JSON.
+    let kel = bundle.kel;
+
+    // Authenticate the bundle's KEL (RT-002): a bundle is attacker-controlled
+    // input, so we do NOT merely replay it structurally — we verify every event
+    // is signed by the controlling key-state via `validate_signed_kel`. The
+    // producer ships each event's CESR signature attachment (hex); a bundle
+    // missing them (length mismatch), or whose signatures don't verify, fails
+    // closed HERE, before its KEL is ever used to resolve a signer.
+    if !kel.is_empty() {
+        if bundle.kel_attachments.len() != kel.len() {
+            return Err(format!(
+                "identity bundle {path:?} carries {} KEL events but {} signature \
+                 attachments — cannot authenticate it; re-export with a current \
+                 `auths id export-bundle`",
+                kel.len(),
+                bundle.kel_attachments.len()
+            ));
+        }
+        let signed: Vec<auths_keri::SignedEvent> = kel
+            .iter()
+            .zip(bundle.kel_attachments.iter())
+            .map(|(event, att_hex)| {
+                let att = hex::decode(att_hex).map_err(|e| {
+                    format!("identity bundle {path:?} has a non-hex KEL signature: {e}")
+                })?;
+                let sigs = auths_keri::parse_attachment(&att).map_err(|e| {
+                    format!("identity bundle {path:?} has an unparseable KEL signature: {e}")
+                })?;
+                Ok(auths_keri::SignedEvent::new(event.clone(), sigs))
+            })
+            .collect::<std::result::Result<_, String>>()?;
+        auths_keri::validate_signed_kel(&signed, None).map_err(|e| {
+            format!("identity bundle {path:?} KEL failed signature authentication (RT-002): {e}")
+        })?;
+    }
+
     Ok((root, kel))
 }
 
@@ -340,18 +404,19 @@ fn extract_oidc_binding_display(attestation: &Attestation) -> Option<OidcBinding
 async fn resolve_signer_kel(
     registry: &dyn RegistryBackend,
     cmd: &VerifyCommitCommand,
-    bundle_kel: Option<&(String, Vec<Event>)>,
+    bundle_kel: Option<&BundleKel>,
     did: &str,
 ) -> Result<Vec<Event>, String> {
     // Stateless first: a bundle that carries the signer's KEL satisfies
     // resolution without any identity store (CI runners). Prefix binding is
     // still enforced, so a tampered bundle cannot smuggle a foreign KEL.
-    if let Some((bundle_did, events)) = bundle_kel
-        && bundle_did == did
+    if let Some(bundle) = bundle_kel
+        && bundle.did == did
     {
         let prefix = auths_sdk::keri::parse_did_keri(did).map_err(|e| e.to_string())?;
-        auths_sdk::keri::verify_prefix_binding(&prefix, events).map_err(|e| e.to_string())?;
-        return Ok(events.clone());
+        auths_sdk::keri::verify_prefix_binding(&prefix, &bundle.events)
+            .map_err(|e| e.to_string())?;
+        return Ok(bundle.events.clone());
     }
     if let Some(oobi_base) = &cmd.oobi {
         let prefix = auths_sdk::keri::parse_did_keri(did).map_err(|e| e.to_string())?;
@@ -385,7 +450,7 @@ async fn verify_one_commit(
     receipt_lookup: &dyn WitnessReceiptLookup,
     sdk_ctx: &auths_sdk::context::AuthsContext,
     cmd: &VerifyCommitCommand,
-    bundle_kel: Option<&(String, Vec<Event>)>,
+    bundle_kel: Option<&BundleKel>,
     commit_ref: &str,
 ) -> VerifyCommitResult {
     let sha = match resolve_commit_sha(commit_ref) {

--- a/crates/auths-cli/tests/cases/verify_identity_bundle.rs
+++ b/crates/auths-cli/tests/cases/verify_identity_bundle.rs
@@ -132,3 +132,75 @@ fn malformed_identity_bundle_fails_closed_exit_2() {
         "an unparseable bundle must fail closed with exit 2, never verify"
     );
 }
+
+#[test]
+fn identity_bundle_with_stripped_signatures_fails_closed() {
+    // RT-002: a bundle whose KEL event signatures are removed cannot be
+    // AUTHENTICATED and MUST fail closed — even though it pins the correct root
+    // and is structurally valid. A purely structural verifier would (wrongly)
+    // accept it; this is the regression proving event signatures are checked.
+    let (env, good) = setup_signed_commit_and_bundle();
+
+    let stripped = env.home.path().join("stripped-bundle.json");
+    let mut bundle: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&good).unwrap()).unwrap();
+    // Blank the per-event signature attachments; the KEL is now unauthenticatable.
+    bundle["kel_attachments"] = serde_json::json!([]);
+    std::fs::write(&stripped, serde_json::to_string(&bundle).unwrap()).unwrap();
+
+    let out = env
+        .cmd("auths")
+        .args([
+            "verify",
+            "HEAD",
+            "--identity-bundle",
+            stripped.to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        !out.status.success(),
+        "a bundle with stripped KEL signatures must NOT verify (RT-002): {}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+}
+
+#[test]
+fn identity_bundle_with_forged_signature_fails_closed() {
+    // RT-002: tampering an event's signature attachment (bundle otherwise valid)
+    // must fail closed — the signature no longer verifies against the committed
+    // key-state.
+    let (env, good) = setup_signed_commit_and_bundle();
+
+    let forged = env.home.path().join("forged-bundle.json");
+    let mut bundle: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&good).unwrap()).unwrap();
+    if let Some(first) = bundle["kel_attachments"]
+        .as_array_mut()
+        .and_then(|a| a.first_mut())
+    {
+        // Flip the last hex nibble of the inception's signature attachment.
+        let mut s = first.as_str().unwrap().to_string();
+        if let Some(last) = s.pop() {
+            s.push(if last == '0' { '1' } else { '0' });
+        }
+        *first = serde_json::json!(s);
+    }
+    std::fs::write(&forged, serde_json::to_string(&bundle).unwrap()).unwrap();
+
+    let out = env
+        .cmd("auths")
+        .args([
+            "verify",
+            "HEAD",
+            "--identity-bundle",
+            forged.to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        !out.status.success(),
+        "a bundle with a forged KEL signature must NOT verify (RT-002): {}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+}

--- a/crates/auths-core/src/agent/session.rs
+++ b/crates/auths-core/src/agent/session.rs
@@ -164,7 +164,7 @@ impl Session for AgentSession {
     async fn add_identity(&mut self, identity: AddIdentity) -> Result<(), SSHAgentError> {
         debug!("Handling add_identity request");
 
-        let pkcs8_bytes: Vec<u8> = match &identity.credential {
+        let pkcs8_bytes: Zeroizing<Vec<u8>> = match &identity.credential {
             Credential::Key { privkey, .. } => match privkey {
                 KeypairData::Ed25519(kp) => {
                     let seed = kp.private.to_bytes();
@@ -201,7 +201,7 @@ impl Session for AgentSession {
                         error!("{}", err_msg);
                         SSHAgentError::other(io::Error::other(err_msg))
                     })?;
-                    pkcs8.as_ref().to_vec()
+                    Zeroizing::new(pkcs8.as_ref().to_vec())
                 }
                 other => {
                     let err_msg = format!(
@@ -224,13 +224,11 @@ impl Session for AgentSession {
             }
         };
 
-        self.handle
-            .register_key(Zeroizing::new(pkcs8_bytes))
-            .map_err(|e| {
-                let err_msg = format!("Failed to register key in agent: {}", e);
-                error!("{}", err_msg);
-                SSHAgentError::other(io::Error::other(err_msg))
-            })?;
+        self.handle.register_key(pkcs8_bytes).map_err(|e| {
+            let err_msg = format!("Failed to register key in agent: {}", e);
+            error!("{}", err_msg);
+            SSHAgentError::other(io::Error::other(err_msg))
+        })?;
 
         debug!("Successfully added identity to agent");
         Ok(())

--- a/crates/auths-core/src/api/ffi.rs
+++ b/crates/auths-core/src/api/ffi.rs
@@ -464,6 +464,14 @@ pub unsafe extern "C" fn ffi_import_key(
             Ok(s) => s,
             Err(code) => return code,
         };
+        // Reject a null key pointer before constructing a slice from it:
+        // `slice::from_raw_parts(NULL, len)` is immediate undefined behavior
+        // that `catch_unwind` cannot intercept (RT-009). Sibling FFI entry
+        // points guard their pointers the same way.
+        if key_ptr.is_null() {
+            error!("FFI import failed: key_ptr is null.");
+            return 1;
+        }
         let key_data = unsafe { slice::from_raw_parts(key_ptr, key_len) };
 
         // Argument validation

--- a/crates/auths-core/src/crypto/ssh/keys.rs
+++ b/crates/auths-core/src/crypto/ssh/keys.rs
@@ -37,7 +37,9 @@ pub fn build_ed25519_pkcs8_v2_from_seed(seed: &SecureSeed) -> Result<Pkcs8Der, C
     let ssh_kp = SshEd25519Keypair::from_seed(seed.as_bytes());
     let pubkey: [u8; 32] = ssh_kp.public.0;
     let pkcs8 = build_ed25519_pkcs8_v2(seed.as_bytes(), &pubkey);
-    Ok(Pkcs8Der::new(pkcs8))
+    // `Pkcs8Der` is itself zeroize-on-drop; `pkcs8` (a `Zeroizing<Vec<u8>>`) is
+    // wiped when it falls out of scope, so neither copy lingers.
+    Ok(Pkcs8Der::new(pkcs8.to_vec()))
 }
 
 /// Extract the 32-byte Ed25519 public key from key bytes.

--- a/crates/auths-crypto/Cargo.toml
+++ b/crates/auths-crypto/Cargo.toml
@@ -22,7 +22,10 @@ native = [
     "dep:sha2",
     "dep:subtle",
 ]
-wasm = ["dep:js-sys", "dep:wasm-bindgen", "dep:wasm-bindgen-futures", "dep:web-sys"]
+# `dep:p256` is pulled into wasm too so the WebCrypto verifier can verify P-256
+# through the pure-Rust crate (compressed-key support + low-S parity with native,
+# RT-007/RT-008) rather than WebCrypto's compressed-rejecting, high-S-accepting path.
+wasm = ["dep:js-sys", "dep:wasm-bindgen", "dep:wasm-bindgen-futures", "dep:web-sys", "dep:p256", "getrandom_02/js"]
 test-utils = ["dep:ring"]
 
 # FIPS 140-3 build: swaps every crypto primitive to aws-lc-rs (AWS-LC-FIPS).
@@ -55,6 +58,11 @@ zeroize.workspace = true
 # Pinned to 0.13: RustCrypto ecosystem, pure Rust (WASM-safe), matches cesride reference.
 # ring cannot export SEC1 compressed public keys (33 bytes) which CESR requires.
 p256 = { version = "=0.13.2", features = ["ecdsa"], optional = true }
+# getrandom 0.2 is pulled transitively by p256/elliptic-curve; on wasm32 it needs
+# the "js" backend or it fails to compile. We declare it here (alias to avoid a
+# clash with any future direct getrandom) so the `wasm` feature can turn on `js`,
+# matching how auths-verifier wires its own wasm entropy.
+getrandom_02 = { package = "getrandom", version = "0.2", optional = true }
 # P-384 (secp384r1) for CNSA-mode ECDSA keygen and signing. Same shape as
 # p256. Pulled only with `--features cnsa`.
 p384 = { version = "0.13", features = ["ecdsa", "pkcs8"], optional = true }

--- a/crates/auths-crypto/src/key_material.rs
+++ b/crates/auths-crypto/src/key_material.rs
@@ -8,6 +8,8 @@
 // allow during curve-agnostic refactor
 #![allow(clippy::disallowed_methods)]
 
+use zeroize::Zeroizing;
+
 use crate::provider::{CryptoError, SecureSeed};
 
 /// PKCS#8 v2 Ed25519 total length — explicit [1] tag (85 bytes).
@@ -129,7 +131,7 @@ pub fn parse_ed25519_key_material(
 /// let pkcs8 = build_ed25519_pkcs8_v2(seed.as_bytes(), &pk);
 /// assert_eq!(pkcs8.len(), 85);
 /// ```
-pub fn build_ed25519_pkcs8_v2(seed: &[u8; 32], pubkey: &[u8; 32]) -> Vec<u8> {
+pub fn build_ed25519_pkcs8_v2(seed: &[u8; 32], pubkey: &[u8; 32]) -> Zeroizing<Vec<u8>> {
     let mut buf = Vec::with_capacity(PKCS8_V2_EXPLICIT_LEN);
     // SEQUENCE (83 bytes payload)
     buf.extend_from_slice(&[0x30, 0x53]);
@@ -143,7 +145,9 @@ pub fn build_ed25519_pkcs8_v2(seed: &[u8; 32], pubkey: &[u8; 32]) -> Vec<u8> {
     // [1] EXPLICIT BIT STRING (33 bytes: 0x00 pad + 32 bytes pubkey)
     buf.extend_from_slice(&[0xa1, 0x23, 0x03, 0x21, 0x00]);
     buf.extend_from_slice(pubkey);
-    buf
+    // The PKCS#8 buffer embeds the raw Ed25519 seed; wipe it on drop so the
+    // transient does not linger in freed heap after the caller is done (RT-016).
+    Zeroizing::new(buf)
 }
 
 fn extract_seed_at(bytes: &[u8], offset: usize) -> Result<SecureSeed, CryptoError> {

--- a/crates/auths-crypto/src/key_ops.rs
+++ b/crates/auths-crypto/src/key_ops.rs
@@ -292,7 +292,7 @@ impl TypedSignerKey {
                 let mut pk = [0u8; 32];
                 pk.copy_from_slice(&self.public_key);
                 let bytes = crate::key_material::build_ed25519_pkcs8_v2(seed_bytes, &pk);
-                Ok(crate::pkcs8::Pkcs8Der::new(bytes))
+                Ok(crate::pkcs8::Pkcs8Der::new(bytes.to_vec()))
             }
             TypedSeed::P256(scalar) => {
                 use p256::ecdsa::SigningKey;

--- a/crates/auths-crypto/src/provider.rs
+++ b/crates/auths-crypto/src/provider.rs
@@ -495,12 +495,25 @@ pub trait CryptoProvider: Send + Sync {
 // CNSA-specific provider is excluded. Consumers who want CNSA MUST NOT
 // enable `fips` in their dependency edge.
 //
-// We intentionally do NOT emit `compile_error!` here: `--all-features` is
-// a first-class developer ergonomic (CI hooks, `cargo hack`, etc.) and
-// failing that build surface-level cost exceeds the safety benefit — the
-// cfg gates below already produce a deterministic, single-provider
-// binary. A lint scanner in `xtask` (see `check-feature-sanity`) enforces
-// "never enable both in a deployed profile" at the supply-chain layer.
+// Enabling both is a silent crypto-policy downgrade, so we fail the build
+// closed. The `cfg(all(feature = "cnsa", not(feature = "fips"), …))` gate
+// below loses to FIPS, so a build that asked for CNSA would instead link the
+// FIPS provider — which accepts P-256 and ChaCha20-Poly1305, the exact
+// primitives CNSA-2.0 forbids — with no error. No in-tree lint catches this
+// (there is no `check-feature-sanity` xtask), so the only honest guard is a
+// hard compile error.
+//
+// Consequence: `--all-features` (which turns on both) no longer compiles for
+// this crate. That is intentional — a profile must select at most one of
+// `fips`/`cnsa`. Any build/CI invocation that relied on `--all-features` for
+// auths-crypto must choose an explicit feature set instead.
+#[cfg(all(feature = "fips", feature = "cnsa"))]
+compile_error!(
+    "auths-crypto features `fips` and `cnsa` are mutually exclusive: enabling \
+     both silently links the FIPS provider (which accepts P-256 and \
+     ChaCha20-Poly1305) in place of the CNSA provider — a silent crypto-policy \
+     downgrade. Enable at most one of `fips`/`cnsa`."
+);
 
 /// `fips` requires CMake + Go + C toolchain and targets native platforms only.
 /// aws-lc-rs has no supported WASM target.

--- a/crates/auths-crypto/src/webcrypto_provider.rs
+++ b/crates/auths-crypto/src/webcrypto_provider.rs
@@ -102,84 +102,24 @@ impl CryptoProvider for WebCryptoProvider {
     ) -> Result<(), CryptoError> {
         #[cfg(target_arch = "wasm32")]
         {
-            use wasm_bindgen::JsCast;
-            use wasm_bindgen_futures::JsFuture;
+            // Verify with the pure-Rust `p256` crate rather than WebCrypto so the
+            // WASM verdict is byte-for-byte identical to native (RT-007/RT-008):
+            // `p256` accepts compressed (33-byte) SEC1 keys that WebCrypto rejects
+            // (RT-007) and shares native's signature canonicalization instead of
+            // WebCrypto's malleable accept-any-S (RT-008). This mirrors
+            // `RingCryptoProvider::p256_verify` exactly — one source of truth.
+            use p256::ecdsa::{Signature, VerifyingKey, signature::Verifier};
 
-            // WebCrypto P-256 wants an uncompressed SEC1 (65-byte) or a JWK.
-            // If caller supplied compressed SEC1 (33 bytes), decompress first.
-            // The decompressed buffer must outlive `pubkey_bytes`, so it's declared
-            // in the feature-gated branch that actually populates it.
-            #[cfg(feature = "native")]
-            let uncompressed_owned: Vec<u8>;
-            let pubkey_bytes: &[u8] = match pubkey.len() {
-                65 => pubkey,
-                33 => {
-                    // Best-effort decompression via the p256 crate (compiled into wasm
-                    // only if the p256 feature is pulled in — in pure-wasm builds
-                    // without native we fall back to a clear error.)
-                    #[cfg(feature = "native")]
-                    {
-                        use p256::ecdsa::VerifyingKey;
-                        let vk = VerifyingKey::from_sec1_bytes(pubkey)
-                            .map_err(|e| CryptoError::InvalidPrivateKey(format!("{e}")))?;
-                        uncompressed_owned = vk.to_encoded_point(false).as_bytes().to_vec();
-                        uncompressed_owned.as_slice()
-                    }
-                    #[cfg(not(feature = "native"))]
-                    {
-                        return Err(CryptoError::OperationFailed(
-                            "WebCrypto P-256 requires uncompressed SEC1 (65 bytes); \
-                             compressed->uncompressed conversion not wired in pure-wasm \
-                             build. Supply 65-byte key."
-                                .into(),
-                        ));
-                    }
+            let vk = VerifyingKey::from_sec1_bytes(pubkey).map_err(|_| {
+                CryptoError::InvalidKeyLength {
+                    expected: crate::provider::P256_PUBLIC_KEY_LEN,
+                    actual: pubkey.len(),
                 }
-                other => {
-                    return Err(CryptoError::InvalidKeyLength {
-                        expected: crate::provider::P256_PUBLIC_KEY_LEN,
-                        actual: other,
-                    });
-                }
-            };
-
-            let subtle = get_subtle_crypto()?;
-            let key_data = js_sys::Uint8Array::from(pubkey_bytes);
-            let algorithm = js_sys::Object::new();
-            js_sys::Reflect::set(&algorithm, &"name".into(), &"ECDSA".into()).ok();
-            js_sys::Reflect::set(&algorithm, &"namedCurve".into(), &"P-256".into()).ok();
-            let usages = js_sys::Array::of1(&wasm_bindgen::JsValue::from_str("verify"));
-
-            let import_promise = subtle
-                .import_key_with_object("raw", &key_data, &algorithm, false, &usages)
-                .map_err(|e| CryptoError::OperationFailed(format!("import_key: {e:?}")))?;
-            let crypto_key: web_sys::CryptoKey = JsFuture::from(import_promise)
-                .await
-                .map_err(|e| CryptoError::OperationFailed(format!("import_key reject: {e:?}")))?
-                .unchecked_into();
-
-            let verify_algorithm = js_sys::Object::new();
-            js_sys::Reflect::set(&verify_algorithm, &"name".into(), &"ECDSA".into()).ok();
-            js_sys::Reflect::set(&verify_algorithm, &"hash".into(), &"SHA-256".into()).ok();
-
-            let verify_promise = subtle
-                .verify_with_object_and_u8_array_and_u8_array(
-                    &verify_algorithm,
-                    &crypto_key,
-                    signature,
-                    message,
-                )
-                .map_err(|e| CryptoError::OperationFailed(format!("verify: {e:?}")))?;
-
-            let result = JsFuture::from(verify_promise)
-                .await
-                .map_err(|e| CryptoError::OperationFailed(format!("verify reject: {e:?}")))?;
-
-            if result.as_bool().unwrap_or(false) {
-                Ok(())
-            } else {
-                Err(CryptoError::InvalidSignature)
-            }
+            })?;
+            let sig =
+                Signature::from_slice(signature).map_err(|_| CryptoError::InvalidSignature)?;
+            vk.verify(message, &sig)
+                .map_err(|_| CryptoError::InvalidSignature)
         }
 
         #[cfg(not(target_arch = "wasm32"))]

--- a/crates/auths-crypto/tests/cases/pkcs8_roundtrip.rs
+++ b/crates/auths-crypto/tests/cases/pkcs8_roundtrip.rs
@@ -35,7 +35,7 @@ fn ed25519_keypair(seed_byte: u8) -> ([u8; 32], [u8; 32], Vec<u8>) {
     let kp = Ed25519KeyPair::from_seed_unchecked(&seed).expect("ring accepts any 32-byte seed");
     let mut pubkey = [0u8; 32];
     pubkey.copy_from_slice(kp.public_key().as_ref());
-    let pkcs8 = build_ed25519_pkcs8_v2(&seed, &pubkey);
+    let pkcs8 = build_ed25519_pkcs8_v2(&seed, &pubkey).to_vec();
     (seed, pubkey, pkcs8)
 }
 

--- a/crates/auths-id/src/keri/mod.rs
+++ b/crates/auths-id/src/keri/mod.rs
@@ -35,7 +35,7 @@
 //!
 //! | Function | Module | Description |
 //! |----------|--------|-------------|
-//! | [`validate_kel`] / [`replay_kel`] | `keri::validate` | Replays events to compute `KeyState` (`apply_event_chain`) |
+//! | [`validate_kel`] | `keri::validate` | Replays a trusted-local KEL to compute `KeyState` (`apply_event_chain`) |
 //! | [`compute_status`](crate::storage::registry::org_member::compute_status) | `storage::registry::org_member` | Computes member status from attestation |
 //! | `evaluate_policy` | `policy` | Evaluates authorization decision |
 //!
@@ -166,6 +166,6 @@ pub use state::KeyState;
 pub use types::{KeriTypeError, Prefix, Said, prefix_from_did};
 pub use validate::{
     ValidationError, compute_event_said, finalize_dip_event, finalize_drt_event,
-    finalize_icp_event, replay_kel, serialize_for_signing, validate_delegation,
-    validate_for_append, validate_kel, verify_event_crypto, verify_event_said,
+    finalize_icp_event, serialize_for_signing, validate_delegation, validate_for_append,
+    validate_kel, verify_event_crypto, verify_event_said,
 };

--- a/crates/auths-id/src/keri/validate.rs
+++ b/crates/auths-id/src/keri/validate.rs
@@ -1,6 +1,28 @@
 //! KEL validation re-exported from auths-keri.
+//!
+//! `validate_kel` is a thin LOCAL wrapper, not a bare re-export: auths-id is the
+//! trusted-local boundary — it owns and reads the local identity registry — so it
+//! legitimately mints a [`TrustedKel`] to drive auths-keri's structural replay,
+//! which is `pub(crate)` there (RT-002 / #263). Untrusted input never reaches this
+//! path; bundles, `--remote`/`--oobi`, and WASM authenticate through
+//! `auths_keri::validate_signed_kel` instead.
+use auths_keri::{Event, KeyState, TrustedKel};
+
 pub use auths_keri::{
     ValidationError, compute_event_said, finalize_dip_event, finalize_drt_event,
-    finalize_icp_event, find_seal_in_kel, parse_kel_json, replay_kel, serialize_for_signing,
-    validate_delegation, validate_for_append, validate_kel, verify_event_crypto, verify_event_said,
+    finalize_icp_event, find_seal_in_kel, parse_kel_json, serialize_for_signing,
+    validate_delegation, validate_for_append, verify_event_crypto, verify_event_said,
 };
+
+/// Replay a KEL read from the local (trusted) registry to its [`KeyState`].
+///
+/// auths-id reads only its own identity store, so the events are trusted; this
+/// asserts that by minting a [`TrustedKel`] over auths-keri's `pub(crate)`
+/// structural replay. Untrusted input (bundles, remote/oobi, WASM) must instead go
+/// through `auths_keri::validate_signed_kel`.
+///
+/// Args:
+/// * `events`: A KEL from the local identity store, oldest first.
+pub fn validate_kel(events: &[Event]) -> Result<KeyState, ValidationError> {
+    TrustedKel::from_trusted_source(events).replay()
+}

--- a/crates/auths-id/src/storage/receipts.rs
+++ b/crates/auths-id/src/storage/receipts.rs
@@ -214,7 +214,7 @@ impl GitWitnessReceiptLookup {
     /// Usage:
     /// ```ignore
     /// let lookup = GitWitnessReceiptLookup::new(repo_path);
-    /// let replay = validate_kel_with_receipts(&kel, None, &lookup)?;
+    /// let replay = TrustedKel::from_trusted_source(&kel).replay_with_receipts(None, &lookup)?;
     /// ```
     pub fn new(repo_path: impl Into<PathBuf>) -> Self {
         Self {

--- a/crates/auths-id/src/storage/registry/backend.rs
+++ b/crates/auths-id/src/storage/registry/backend.rs
@@ -526,27 +526,27 @@ pub trait RegistryBackend: Send + Sync {
     fn append_event(&self, prefix: &Prefix, event: &Event) -> Result<(), RegistryError>;
 
     /// Append an event together with its CESR-attachment bytes (externalized
-    /// signatures and other CESR groups). Default impl delegates to
-    /// `append_event`, dropping the attachment for backends that don't yet
-    /// persist it. Backends supporting attachments override this.
+    /// signatures and other CESR groups).
+    ///
+    /// REQUIRED — no default (RT-002). A default that delegated to `append_event`
+    /// silently DROPPED the attachment, so backends lost event signatures and the
+    /// verify path could only replay KELs structurally — the exact gap RT-002
+    /// exploits. Every backend MUST persist the attachment so a KEL can be
+    /// AUTHENTICATED, not merely structurally replayed. (This tightens two
+    /// existing methods; it does not expand the frozen surface.)
     fn append_signed_event(
         &self,
         prefix: &Prefix,
         event: &Event,
-        _attachment: &[u8],
-    ) -> Result<(), RegistryError> {
-        self.append_event(prefix, event)
-    }
+        attachment: &[u8],
+    ) -> Result<(), RegistryError>;
 
-    /// Read the CESR-attachment bytes for an event at the given sequence,
-    /// or `None` if no attachment was written. Default impl returns `None`.
-    fn get_attachment(
-        &self,
-        _prefix: &Prefix,
-        _seq: u128,
-    ) -> Result<Option<Vec<u8>>, RegistryError> {
-        Ok(None)
-    }
+    /// Read the CESR-attachment bytes for an event at the given sequence, or
+    /// `None` if the event genuinely carries no attachment.
+    ///
+    /// REQUIRED — no default (RT-002). A default returning `None` made stored
+    /// signatures unreadable — the read-side half of the same gap.
+    fn get_attachment(&self, prefix: &Prefix, seq: u128) -> Result<Option<Vec<u8>>, RegistryError>;
 
     /// Get a single event by sequence number (random access).
     ///
@@ -1015,6 +1015,24 @@ pub trait RegistryBackend: Send + Sync {
 impl<T: RegistryBackend + ?Sized> RegistryBackend for Arc<T> {
     fn append_event(&self, prefix: &Prefix, event: &Event) -> Result<(), RegistryError> {
         (**self).append_event(prefix, event)
+    }
+
+    // RT-002 root cause: this blanket impl forwards every method EXCEPT these two,
+    // so before the trait defaults were removed, `Arc<dyn RegistryBackend>` (how
+    // the SDK holds `ctx.registry`) silently dropped attachments on write and
+    // returned None on read — the inception's signature was lost, and the bundle
+    // producer saw `get_attachment(prefix, 0) == None`. Forward both.
+    fn append_signed_event(
+        &self,
+        prefix: &Prefix,
+        event: &Event,
+        attachment: &[u8],
+    ) -> Result<(), RegistryError> {
+        (**self).append_signed_event(prefix, event, attachment)
+    }
+
+    fn get_attachment(&self, prefix: &Prefix, seq: u128) -> Result<Option<Vec<u8>>, RegistryError> {
+        (**self).get_attachment(prefix, seq)
     }
 
     fn get_event(&self, prefix: &Prefix, seq: u128) -> Result<Event, RegistryError> {

--- a/crates/auths-id/src/testing/fakes/registry.rs
+++ b/crates/auths-id/src/testing/fakes/registry.rs
@@ -21,6 +21,9 @@ type TelEntry = (u128, Vec<u8>);
 
 struct FakeState {
     events: HashMap<String, Vec<Event>>,
+    /// CESR signature attachments per `(prefix, seq)` — parallel to `events`, so
+    /// the fake round-trips signed events like the real backend (RT-002).
+    attachments: HashMap<(String, u128), Vec<u8>>,
     key_states: HashMap<String, KeyState>,
     attestations: HashMap<CanonicalDid, Attestation>,
     attestation_history: HashMap<CanonicalDid, Vec<Attestation>>,
@@ -46,6 +49,7 @@ impl FakeRegistryBackend {
         Self {
             state: Mutex::new(FakeState {
                 events: HashMap::new(),
+                attachments: HashMap::new(),
                 key_states: HashMap::new(),
                 attestations: HashMap::new(),
                 attestation_history: HashMap::new(),
@@ -159,6 +163,31 @@ impl RegistryBackend for FakeRegistryBackend {
         }
 
         Ok(())
+    }
+
+    fn append_signed_event(
+        &self,
+        prefix: &Prefix,
+        event: &Event,
+        attachment: &[u8],
+    ) -> Result<(), RegistryError> {
+        self.append_event(prefix, event)?;
+        if !attachment.is_empty() {
+            let mut state = self.state.lock().unwrap();
+            state.attachments.insert(
+                (prefix.as_str().to_string(), event.sequence().value()),
+                attachment.to_vec(),
+            );
+        }
+        Ok(())
+    }
+
+    fn get_attachment(&self, prefix: &Prefix, seq: u128) -> Result<Option<Vec<u8>>, RegistryError> {
+        let state = self.state.lock().unwrap();
+        Ok(state
+            .attachments
+            .get(&(prefix.as_str().to_string(), seq))
+            .cloned())
     }
 
     fn get_event(&self, prefix: &Prefix, seq: u128) -> Result<Event, RegistryError> {

--- a/crates/auths-id/tests/cases/witness_convergence.rs
+++ b/crates/auths-id/tests/cases/witness_convergence.rs
@@ -20,8 +20,8 @@ use auths_id::keri::event::EventReceipts;
 use auths_id::storage::{GitReceiptStorage, GitWitnessReceiptLookup, ReceiptStorage};
 use auths_keri::{
     CesrKey, Event, IcpEvent, IxnEvent, KeriPublicKey, KeriSequence, Prefix, Said, Seal, Threshold,
-    VersionString, WitnessedReplay, compute_next_commitment, finalize_icp_event,
-    finalize_ixn_event, validate_kel_with_receipts,
+    TrustedKel, VersionString, WitnessedReplay, compute_next_commitment, finalize_icp_event,
+    finalize_ixn_event,
 };
 use auths_verifier::duplicity::{DuplicityReport, KelEventRef, detect_duplicity};
 
@@ -148,7 +148,9 @@ fn anchoring_ixn_is_not_witness_quorum_gated() {
     );
 
     let ixn = anchoring_ixn(&controller, &said);
-    let outcome = validate_kel_with_receipts(&[icp, Event::Ixn(ixn)], None, &lookup).unwrap();
+    let outcome = TrustedKel::from_trusted_source(&[icp, Event::Ixn(ixn)])
+        .replay_with_receipts(None, &lookup)
+        .unwrap();
     assert!(
         matches!(outcome, WitnessedReplay::Accepted(_)),
         "ixn is NOT witness-quorum-gated: an anchoring ixn with no receipts of its own \
@@ -174,7 +176,10 @@ fn under_quorum_establishment_still_fails_closed_with_anchoring_ixn() {
     );
 
     let ixn = anchoring_ixn(&controller, &said);
-    match validate_kel_with_receipts(&[icp, Event::Ixn(ixn)], None, &lookup).unwrap() {
+    match TrustedKel::from_trusted_source(&[icp, Event::Ixn(ixn)])
+        .replay_with_receipts(None, &lookup)
+        .unwrap()
+    {
         WitnessedReplay::Pending {
             sequence,
             collected,
@@ -207,7 +212,9 @@ fn witness_quorum_end_to_end_verifies() {
         ],
     );
 
-    let outcome = validate_kel_with_receipts(&[icp], None, &lookup).unwrap();
+    let outcome = TrustedKel::from_trusted_source(&[icp])
+        .replay_with_receipts(None, &lookup)
+        .unwrap();
     assert!(
         matches!(outcome, WitnessedReplay::Accepted(_)),
         "quorum-met key-state must verify, got {outcome:?}"
@@ -231,7 +238,10 @@ fn under_quorum_end_to_end_refused_when_required() {
 
     // The replay gate reports Pending; a verifier under --require-witnesses
     // (D.7) maps this to a fail-closed verdict.
-    match validate_kel_with_receipts(&[icp], None, &lookup).unwrap() {
+    match TrustedKel::from_trusted_source(&[icp])
+        .replay_with_receipts(None, &lookup)
+        .unwrap()
+    {
         WitnessedReplay::Pending {
             sequence,
             collected,
@@ -266,7 +276,9 @@ fn forged_receipt_does_not_satisfy_quorum_e2e() {
 
     assert!(
         matches!(
-            validate_kel_with_receipts(&[icp], None, &lookup).unwrap(),
+            TrustedKel::from_trusted_source(&[icp])
+                .replay_with_receipts(None, &lookup)
+                .unwrap(),
             WitnessedReplay::Pending { .. }
         ),
         "a non-designated witness receipt must not count toward quorum"
@@ -290,7 +302,9 @@ fn two_diverging_views_converge_with_witness() {
         vec![stored_receipt(&w1, controller.as_str(), &said)],
     );
     assert!(matches!(
-        validate_kel_with_receipts(std::slice::from_ref(&icp), None, &lookup).unwrap(),
+        TrustedKel::from_trusted_source(std::slice::from_ref(&icp))
+            .replay_with_receipts(None, &lookup)
+            .unwrap(),
         WitnessedReplay::Accepted(_)
     ));
 

--- a/crates/auths-keri/src/lib.rs
+++ b/crates/auths-keri/src/lib.rs
@@ -104,12 +104,11 @@ pub use types::{
     VersionString,
 };
 pub use validate::{
-    DelegatorKelLookup, KelPolicy, ValidationError, WitnessedReplay, compute_event_said,
-    finalize_dip_event, finalize_drt_event, finalize_icp_event, finalize_ixn_event,
-    finalize_rot_event, find_seal_in_kel, parse_kel_json, replay_kel, serialize_for_signing,
-    validate_delegation, validate_for_append, validate_kel, validate_kel_with_lookup,
-    validate_kel_with_policy, validate_kel_with_receipts, validate_signed_event,
-    verify_event_crypto, verify_event_said,
+    DelegatorKelLookup, KelPolicy, KelSealIndex, TrustedKel, ValidationError, WitnessedReplay,
+    compute_event_said, finalize_dip_event, finalize_drt_event, finalize_icp_event,
+    finalize_ixn_event, finalize_rot_event, find_seal_in_kel, parse_kel_json,
+    serialize_for_signing, validate_delegation, validate_for_append, validate_signed_event,
+    validate_signed_kel, verify_event_crypto, verify_event_said,
 };
 
 #[cfg(feature = "cesr")]

--- a/crates/auths-keri/src/validate.rs
+++ b/crates/auths-keri/src/validate.rs
@@ -379,15 +379,131 @@ pub trait DelegatorKelLookup {
     fn find_seal(&self, delegator_aid: &Prefix, seal_said: &Said) -> Option<SourceSeal>;
 }
 
+/// A precomputed index of a delegator KEL's anchoring seals.
+///
+/// Build it once from a KEL slice with [`KelSealIndex::from_events`]; `find_seal`
+/// is then an O(1) map lookup. This is the shared [`DelegatorKelLookup`] every
+/// verify path uses to resolve the [`SourceSeal`] that authorizes a delegated
+/// (`dip`/`drt`) event — replacing the per-call-site linear scans the commit,
+/// presentation, and offline-org verifiers each used to carry (so the lookup is
+/// defined once, with one performance profile, instead of three times).
+pub struct KelSealIndex {
+    /// `sealed-event SAID → SourceSeal of the anchoring event`.
+    seals: std::collections::HashMap<Said, SourceSeal>,
+}
+
+impl KelSealIndex {
+    /// Index every `Seal::KeyEvent` anchored in `events`, mapping the sealed event
+    /// SAID to the [`SourceSeal`] (sequence + SAID) of the event that anchored it.
+    /// On a duplicate sealed SAID the first (lowest-sequence) anchor wins —
+    /// identical to a forward linear scan over an ordered KEL.
+    ///
+    /// Args:
+    /// * `events`: The delegator's KEL.
+    pub fn from_events(events: &[Event]) -> Self {
+        let mut seals = std::collections::HashMap::new();
+        for event in events {
+            for seal in event.anchors() {
+                if let Seal::KeyEvent { d, .. } = seal {
+                    seals.entry(d.clone()).or_insert_with(|| SourceSeal {
+                        s: event.sequence(),
+                        d: event.said().clone(),
+                    });
+                }
+            }
+        }
+        Self { seals }
+    }
+}
+
+impl DelegatorKelLookup for KelSealIndex {
+    fn find_seal(&self, _delegator_aid: &Prefix, seal_said: &Said) -> Option<SourceSeal> {
+        self.seals.get(seal_said).cloned()
+    }
+}
+
+/// A KEL the caller asserts comes from a **trusted source** — the local identity
+/// registry / a self-owned store, or a chain already authenticated via
+/// [`validate_signed_kel`].
+///
+/// Structural replay (SAID + sequence + chain-linkage + pre-rotation commitment,
+/// *without* re-verifying each event's signature) is exposed to other crates
+/// **only** through this type. Bare-`&[Event]` structural replay
+/// ([`validate_kel`] and friends) is `pub(crate)`, so untrusted input — a CI
+/// `--identity-bundle`, a `--remote`/`--oobi` fetch, a WASM/FFI buffer — cannot be
+/// structurally replayed from outside auths-keri without either an explicit,
+/// greppable trust assertion ([`TrustedKel::from_trusted_source`]) or prior
+/// authentication via [`validate_signed_kel`] (RT-002 / #263). The assertion is a
+/// reviewable, lint-gated decision rather than an invisible `validate_kel(bytes)`
+/// call.
+///
+/// Borrowing and `Copy` — zero-cost over a `&[Event]`.
+#[derive(Clone, Copy)]
+pub struct TrustedKel<'a>(&'a [Event]);
+
+impl<'a> TrustedKel<'a> {
+    /// Assert that `events` come from a trusted source. Every call site is a
+    /// reviewable trust assertion — **never** call this on attacker-influenced
+    /// bytes (bundle / `--remote` / `--oobi` / WASM / FFI); authenticate those
+    /// through [`validate_signed_kel`] instead.
+    ///
+    /// Args:
+    /// * `events`: A KEL whose provenance the caller vouches for (local registry
+    ///   read, or an already-authenticated chain).
+    pub fn from_trusted_source(events: &'a [Event]) -> Self {
+        Self(events)
+    }
+
+    /// The underlying events.
+    pub fn events(&self) -> &'a [Event] {
+        self.0
+    }
+
+    /// Structural replay to the current [`KeyState`].
+    pub fn replay(self) -> Result<KeyState, ValidationError> {
+        validate_kel(self.0)
+    }
+
+    /// Structural replay with a delegator-seal lookup for delegated (`dip`/`drt`)
+    /// events.
+    pub fn replay_with_lookup(
+        self,
+        lookup: Option<&dyn DelegatorKelLookup>,
+    ) -> Result<KeyState, ValidationError> {
+        validate_kel_with_lookup(self.0, lookup)
+    }
+
+    /// Structural replay with the M-of-N witness-receipt gate.
+    pub fn replay_with_receipts(
+        self,
+        lookup: Option<&dyn DelegatorKelLookup>,
+        receipt_lookup: &dyn WitnessReceiptLookup,
+    ) -> Result<WitnessedReplay, ValidationError> {
+        validate_kel_with_receipts(self.0, lookup, receipt_lookup)
+    }
+
+    /// Structural replay with the time / rotation-cadence policy checks
+    /// ([`KelPolicy`]). `timestamps[i]` is the optional signing time of `events[i]`.
+    pub fn replay_with_policy(
+        self,
+        timestamps: &[Option<chrono::DateTime<chrono::Utc>>],
+        policy: &KelPolicy,
+        now: chrono::DateTime<chrono::Utc>,
+    ) -> Result<KeyState, ValidationError> {
+        validate_kel_with_policy(self.0, timestamps, policy, now)
+    }
+}
+
 /// Validate a KEL with no delegator lookup.
 ///
-/// Convenience wrapper over [`validate_kel_with_lookup`] for ordinary KELs
-/// that contain only `icp`/`rot`/`ixn` events. Use the lookup variant for KELs
-/// containing delegated events (`dip`/`drt`).
+/// Crate-private (RT-002 / #263): other crates reach structural replay only via
+/// [`TrustedKel`], so untrusted input cannot be replayed without an explicit trust
+/// assertion. Convenience wrapper over [`validate_kel_with_lookup`] for ordinary
+/// KELs that contain only `icp`/`rot`/`ixn` events.
 ///
 /// Args:
 /// * `events` - The ordered list of KERI events to replay and validate.
-pub fn validate_kel(events: &[Event]) -> Result<KeyState, ValidationError> {
+pub(crate) fn validate_kel(events: &[Event]) -> Result<KeyState, ValidationError> {
     validate_kel_with_lookup(events, None::<&dyn DelegatorKelLookup>)
 }
 
@@ -395,7 +511,7 @@ pub fn validate_kel(events: &[Event]) -> Result<KeyState, ValidationError> {
 ///
 /// Required when the KEL contains `dip` or `drt` events; ordinary KELs
 /// (only `icp`/`rot`/`ixn`) can pass `None`.
-pub fn validate_kel_with_lookup(
+pub(crate) fn validate_kel_with_lookup(
     events: &[Event],
     lookup: Option<&dyn DelegatorKelLookup>,
 ) -> Result<KeyState, ValidationError> {
@@ -469,7 +585,7 @@ impl WitnessedReplay {
 ///     WitnessedReplay::Pending { sequence, .. } => warn_or_refuse(sequence),
 /// }
 /// ```
-pub fn validate_kel_with_receipts(
+pub(crate) fn validate_kel_with_receipts(
     events: &[Event],
     delegator_lookup: Option<&dyn DelegatorKelLookup>,
     receipt_lookup: &dyn WitnessReceiptLookup,
@@ -564,6 +680,93 @@ fn replay_kel_gated(
     Ok(WitnessedReplay::Accepted(state))
 }
 
+/// Replay a KEL of **signed** events, verifying each event's signature against the
+/// key-state that authorizes it — the authenticated counterpart to the
+/// structural-only [`validate_kel`] (RT-002).
+///
+/// Where [`validate_kel`] authorizes by log *structure* alone (SAID + sequence +
+/// chain-linkage + pre-rotation commitment), this folds [`validate_signed_event`]
+/// into the replay so every event must also carry a valid signature from the
+/// in-force key-state: inception/`dip` against their own committed keys under
+/// `kt`; `rot`/`drt` against the new keys plus the prior pre-rotation commitment;
+/// `ixn` against the current key-state. An event with no — or an invalid —
+/// signature fails closed with [`ValidationError::SignatureFailed`].
+///
+/// This is the function the stateless verify entrypoints (CI `--identity-bundle`,
+/// WASM, FFI) must call once their wire formats carry CESR signature attachments;
+/// until that wiring lands they still replay structurally (see the RT-002 note in
+/// the test module). Structural checks are applied here too, so a forged SAID or
+/// broken chain is still rejected.
+///
+/// Args:
+/// * `events`: The ordered KEL of signed events to replay.
+/// * `lookup`: Cross-KEL seal lookup for delegated events (`dip`/`drt`).
+pub fn validate_signed_kel(
+    events: &[crate::events::SignedEvent],
+    lookup: Option<&dyn DelegatorKelLookup>,
+) -> Result<KeyState, ValidationError> {
+    if events.is_empty() {
+        return Err(ValidationError::EmptyKel);
+    }
+
+    // Inception: structural (SAID + self-certification) AND a signature from the
+    // event's own committed keys.
+    let first = &events[0];
+    verify_event_said(&first.event)?;
+    validate_signed_event(first, None)?;
+    let (mut state, inception_n_is_empty, establishment_only) = match &first.event {
+        Event::Icp(icp) => (
+            validate_inception(icp)?,
+            icp.n.is_empty(),
+            icp.c.contains(&ConfigTrait::EstablishmentOnly),
+        ),
+        Event::Dip(dip) => (
+            validate_delegated_inception(dip, lookup)?,
+            dip.n.is_empty(),
+            dip.c.contains(&ConfigTrait::EstablishmentOnly),
+        ),
+        _ => return Err(ValidationError::NotInception),
+    };
+
+    if inception_n_is_empty && events.len() > 1 {
+        return Err(ValidationError::NonTransferable);
+    }
+
+    for (idx, signed) in events.iter().enumerate().skip(1) {
+        let event = &signed.event;
+        let expected_seq = idx as u128;
+
+        if state.is_abandoned {
+            return Err(ValidationError::AbandonedIdentity {
+                sequence: expected_seq,
+            });
+        }
+        if establishment_only && matches!(event, Event::Ixn(_)) {
+            return Err(ValidationError::EstablishmentOnly {
+                sequence: expected_seq,
+            });
+        }
+
+        verify_event_said(event)?;
+        verify_sequence(event, expected_seq)?;
+        verify_chain_linkage(event, &state)?;
+        // Authenticate against the in-force key-state BEFORE applying the event
+        // (rot/drt verify the prior next-threshold against the pre-rotation state).
+        validate_signed_event(signed, Some(&state))?;
+
+        match event {
+            Event::Rot(rot) => validate_rotation(rot, expected_seq, &mut state)?,
+            Event::Ixn(ixn) => validate_interaction(ixn, expected_seq, &mut state)?,
+            Event::Icp(_) | Event::Dip(_) => return Err(ValidationError::MultipleInceptions),
+            Event::Drt(drt) => {
+                validate_delegated_rotation(drt, expected_seq, &mut state, lookup)?;
+            }
+        }
+    }
+
+    Ok(state)
+}
+
 /// Gate one establishment event on M-of-N witness agreement.
 ///
 /// Returns `Some(WitnessedReplay::Pending)` when the in-force backer threshold
@@ -638,7 +841,56 @@ fn validate_thresholds(
     Ok(())
 }
 
+/// Enforce inception self-certification — bind the controller prefix `i` to the
+/// event so a forged inception cannot claim an arbitrary prefix with
+/// attacker-controlled keys (RT-001).
+///
+/// `compute_said` blanks `i` before hashing (an inception's prefix derives FROM
+/// its SAID, not the reverse), so verifying `d == compute_said(body)` does NOT
+/// bind `i`. This supplies that binding:
+/// - self-addressing (`E`-prefixed) AIDs: `i` MUST equal the SAID `d`;
+/// - basic-derivation AIDs (`D`/`1AAI`/…): `i` MUST equal the lone key `k[0]`.
+///
+/// This is the same rule [`verify_event_crypto`] enforces on the append path;
+/// both now route through here so the two paths cannot drift.
+fn verify_inception_self_cert(i: &Prefix, d: &Said, k: &[CesrKey]) -> Result<(), ValidationError> {
+    // Presence: an inception must commit at least one key.
+    if k.is_empty() {
+        return Err(ValidationError::SignatureFailed { sequence: 0 });
+    }
+
+    if i.as_str().starts_with('E') {
+        if i.as_str() != d.as_str() {
+            return Err(ValidationError::InvalidSaid {
+                expected: d.clone(),
+                actual: Said::new_unchecked(i.as_str().to_string()),
+            });
+        }
+    } else {
+        // Basic-derivation: the prefix IS the single inception key. Without this
+        // a `D…`/`1AAI…` prefix could point at an arbitrary key list.
+        let i_key = KeriPublicKey::parse(i.as_str())
+            .map_err(|_| ValidationError::SignatureFailed { sequence: 0 })?;
+        let k0 = k[0]
+            .parse()
+            .map_err(|_| ValidationError::SignatureFailed { sequence: 0 })?;
+        if i_key.as_bytes() != k0.as_bytes() {
+            return Err(ValidationError::InvalidSaid {
+                expected: Said::new_unchecked(k[0].as_str().to_string()),
+                actual: Said::new_unchecked(i.as_str().to_string()),
+            });
+        }
+    }
+
+    Ok(())
+}
+
 fn validate_inception(icp: &IcpEvent) -> Result<KeyState, ValidationError> {
+    // Self-certification: bind `i` to the event before adopting it as the
+    // controller prefix (RT-001). Runs after `verify_event_said` has confirmed
+    // `d` is the true SAID, so `i == d` means `i` is the true SAID too.
+    verify_inception_self_cert(&icp.i, &icp.d, &icp.k)?;
+
     // Validate backer uniqueness
     validate_backer_uniqueness(&icp.b)?;
 
@@ -894,6 +1146,10 @@ fn validate_delegated_inception(
     })?;
     enforce_source_seal(dip.source_seal.as_ref(), &anchor, sequence)?;
 
+    // Self-certification (RT-001): a delegated AID's prefix is the SAID of its
+    // own inception, so `i == d` must hold here as well.
+    verify_inception_self_cert(&dip.i, &dip.d, &dip.k)?;
+
     // Structural checks mirrored from `validate_inception` — backers, threshold.
     validate_backer_uniqueness(&dip.b)?;
     let bt_val = dip.bt.simple_value().unwrap_or(0);
@@ -978,16 +1234,6 @@ fn validate_delegated_rotation(
     Ok(())
 }
 
-/// Replay a KEL to get the current KeyState.
-///
-/// Alias for [`validate_kel`] — use whichever name fits your context better.
-///
-/// Args:
-/// * `events` - The ordered list of KERI events to replay.
-pub fn replay_kel(events: &[Event]) -> Result<KeyState, ValidationError> {
-    validate_kel(events)
-}
-
 /// Validate the cryptographic integrity of a single event against the current key state.
 ///
 /// Args:
@@ -998,40 +1244,9 @@ pub fn verify_event_crypto(
     current_state: Option<&KeyState>,
 ) -> Result<(), ValidationError> {
     match event {
-        Event::Icp(icp) => {
-            // Presence check only: icp must commit at least one key.
-            if icp.k.is_empty() {
-                return Err(ValidationError::SignatureFailed { sequence: 0 });
-            }
-
-            // Self-addressing AIDs (E-prefixed): `i` MUST equal the SAID `d`.
-            let is_self_addressing = icp.i.as_str().starts_with('E');
-            if is_self_addressing {
-                if icp.i.as_str() != icp.d.as_str() {
-                    return Err(ValidationError::InvalidSaid {
-                        expected: icp.d.clone(),
-                        actual: Said::new_unchecked(icp.i.as_str().to_string()),
-                    });
-                }
-            } else {
-                // Basic-derivation AIDs (D / 1AAI / 1AAJ ...): the prefix IS the
-                // single inception key, so `i` MUST equal `k[0]`. Without this a
-                // basic-derivation prefix could point at an arbitrary key list.
-                let i_key = KeriPublicKey::parse(icp.i.as_str())
-                    .map_err(|_| ValidationError::SignatureFailed { sequence: 0 })?;
-                let k0 = icp.k[0]
-                    .parse()
-                    .map_err(|_| ValidationError::SignatureFailed { sequence: 0 })?;
-                if i_key.as_bytes() != k0.as_bytes() {
-                    return Err(ValidationError::InvalidSaid {
-                        expected: Said::new_unchecked(icp.k[0].as_str().to_string()),
-                        actual: Said::new_unchecked(icp.i.as_str().to_string()),
-                    });
-                }
-            }
-
-            Ok(())
-        }
+        // Self-certification (`i==d` / `i==k[0]`) is enforced by the shared
+        // helper so the append and replay paths cannot drift (RT-001).
+        Event::Icp(icp) => verify_inception_self_cert(&icp.i, &icp.d, &icp.k),
         Event::Rot(rot) => {
             let sequence = event.sequence().value();
             let state = current_state.ok_or(ValidationError::SignatureFailed { sequence })?;
@@ -1067,13 +1282,9 @@ pub fn verify_event_crypto(
 
             Ok(())
         }
-        // Delegated events use same crypto verification as their non-delegated counterparts
-        Event::Dip(dip) => {
-            if dip.k.is_empty() {
-                return Err(ValidationError::SignatureFailed { sequence: 0 });
-            }
-            Ok(())
-        }
+        // Delegated inception is self-addressing too: enforce `i==d` via the
+        // shared helper rather than only a presence check (RT-001).
+        Event::Dip(dip) => verify_inception_self_cert(&dip.i, &dip.d, &dip.k),
         Event::Drt(drt) => {
             let sequence = event.sequence().value();
             let state = current_state.ok_or(ValidationError::SignatureFailed { sequence })?;
@@ -1585,6 +1796,130 @@ mod tests {
         let events = vec![Event::Icp(tampered)];
         let result = validate_kel(&events);
         assert!(matches!(result, Err(ValidationError::InvalidSaid { .. })));
+    }
+
+    // RT-001 (A.2): forged-inception self-certification on the replay path.
+    // `compute_said` blanks `i` before hashing, so a valid SAID `d` does NOT
+    // bind the controller prefix `i`. Without the `i==d` / `i==k[0]` check a KEL
+    // handed to a stateless verifier could claim an arbitrary prefix with
+    // attacker keys. These two tests are red before A.2 and green after.
+
+    #[test]
+    fn rejects_forged_inception_prefix_mismatch() {
+        // Self-addressing arm: replace a finalized inception's prefix `i` with a
+        // DIFFERENT well-formed `E…` prefix. The SAID `d` still verifies
+        // (compute_said blanks `i`); only the `i == d` self-cert check catches it.
+        let (icp, _kp) = make_signed_icp();
+        assert_eq!(
+            icp.i.as_str(),
+            icp.d.as_str(),
+            "a finalized inception is self-addressing"
+        );
+
+        let (other, _kp2) = make_signed_icp();
+        assert_ne!(other.i.as_str(), icp.d.as_str());
+
+        let mut forged = icp;
+        forged.i = other.i;
+        let result = validate_kel(&[Event::Icp(forged)]);
+        assert!(
+            matches!(result, Err(ValidationError::InvalidSaid { .. })),
+            "forged inception (i != d) must be rejected, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn rejects_forged_inception_basic_derivation() {
+        // Basic-derivation arm: a non-`E` prefix IS the inception key, so `i`
+        // must equal `k[0]`. Forge an inception whose prefix names a DIFFERENT
+        // key than the one it commits.
+        let prefix_key = encode_pubkey(&gen_keypair());
+        let committed_key = encode_pubkey(&gen_keypair());
+        assert_ne!(prefix_key, committed_key);
+        assert!(!prefix_key.starts_with('E'));
+
+        let mut icp = make_raw_icp(&committed_key, "ENext1");
+        icp.i = Prefix::new_unchecked(prefix_key);
+        // Valid SAID (compute_said blanks `i` for icp), so verify_event_said
+        // passes and only the `i == k[0]` self-cert check should reject.
+        let value = serde_json::to_value(Event::Icp(icp.clone())).unwrap();
+        icp.d = compute_said(&value).unwrap();
+
+        let result = validate_kel(&[Event::Icp(icp)]);
+        assert!(
+            matches!(result, Err(ValidationError::InvalidSaid { .. })),
+            "basic-derivation inception with i != k[0] must be rejected, got {result:?}"
+        );
+    }
+
+    // RT-002 / A.1: `validate_signed_kel` is the AUTHENTICATED replay — it
+    // verifies each event's signature against the controlling key-state, so a
+    // forged unsigned / wrong-signer `ixn`/`rot`/`icp` is rejected (tests below).
+    // The structural `validate_kel`/`replay_kel_gated` remain (they authorize by
+    // log structure only). REMAINING WORK (not in this change): wire the stateless
+    // verify entrypoints (IdentityBundle.kel, WASM, FFI) to carry CESR signature
+    // attachments and call `validate_signed_kel` instead of `validate_kel`. Until
+    // that wiring lands those entrypoints still replay structurally; do not
+    // mistake the structural path for authentication.
+
+    fn sign_event(event: &Event, kp: &Ed25519KeyPair) -> SignedEvent {
+        let sig = kp
+            .sign(&serialize_for_signing(event).unwrap())
+            .as_ref()
+            .to_vec();
+        SignedEvent::new(
+            event.clone(),
+            vec![IndexedSignature {
+                index: 0,
+                prior_index: None,
+                sig,
+            }],
+        )
+    }
+
+    #[test]
+    fn validate_signed_kel_accepts_correctly_signed_kel() {
+        let (icp, kp) = make_signed_icp();
+        let signed_icp = sign_event(&Event::Icp(icp.clone()), &kp);
+        let ixn = make_signed_ixn(&icp.i, &icp.d, 1, &kp);
+        let signed_ixn = sign_event(&Event::Ixn(ixn), &kp);
+
+        let state = validate_signed_kel(&[signed_icp, signed_ixn], None)
+            .expect("a correctly-signed KEL must validate");
+        assert_eq!(state.sequence, 1);
+    }
+
+    #[test]
+    fn validate_signed_kel_rejects_unsigned_ixn() {
+        // RT-002: a structurally-valid but UNSIGNED ixn (e.g. anchoring a forged
+        // delegation/scope seal) must be rejected by the authenticated replay.
+        let (icp, kp) = make_signed_icp();
+        let signed_icp = sign_event(&Event::Icp(icp.clone()), &kp);
+        let ixn = make_signed_ixn(&icp.i, &icp.d, 1, &kp);
+        let unsigned_ixn = SignedEvent::new(Event::Ixn(ixn), vec![]);
+
+        let result = validate_signed_kel(&[signed_icp, unsigned_ixn], None);
+        assert!(
+            matches!(result, Err(ValidationError::SignatureFailed { .. })),
+            "unsigned ixn must be rejected, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn validate_signed_kel_rejects_wrong_signer_ixn() {
+        // RT-002: an ixn signed by a key OTHER than the controlling key-state
+        // must be rejected — a forged interaction cannot be smuggled in.
+        let (icp, kp) = make_signed_icp();
+        let signed_icp = sign_event(&Event::Icp(icp.clone()), &kp);
+        let ixn = make_signed_ixn(&icp.i, &icp.d, 1, &kp);
+        let attacker = gen_keypair();
+        let forged_ixn = sign_event(&Event::Ixn(ixn), &attacker);
+
+        let result = validate_signed_kel(&[signed_icp, forged_ixn], None);
+        assert!(
+            matches!(result, Err(ValidationError::SignatureFailed { .. })),
+            "wrong-signer ixn must be rejected, got {result:?}"
+        );
     }
 
     #[test]
@@ -2292,7 +2627,7 @@ impl Default for KelPolicy {
 /// * `now`: The daemon's wall clock at validation time. Inject via
 ///   [`chrono::Utc::now`] at the presentation boundary; domain layers
 ///   pass a clock.
-pub fn validate_kel_with_policy(
+pub(crate) fn validate_kel_with_policy(
     events: &[Event],
     timestamps: &[Option<chrono::DateTime<chrono::Utc>>],
     policy: &KelPolicy,

--- a/crates/auths-keri/tests/cases/dual_index.rs
+++ b/crates/auths-keri/tests/cases/dual_index.rs
@@ -6,9 +6,9 @@
 
 use auths_keri::{
     CesrKey, Event, IcpEvent, IndexedSignature, KeriPublicKey, KeriSequence, Prefix, RotEvent,
-    Said, SignedEvent, Threshold, ValidationError, VersionString, compute_next_commitment,
-    finalize_icp_event, finalize_rot_event, parse_attachment, replay_kel, serialize_attachment,
-    serialize_for_signing, validate_signed_event,
+    Said, SignedEvent, Threshold, TrustedKel, ValidationError, VersionString,
+    compute_next_commitment, finalize_icp_event, finalize_rot_event, parse_attachment,
+    serialize_attachment, serialize_for_signing, validate_signed_event,
 };
 use ring::rand::SystemRandom;
 use ring::signature::{Ed25519KeyPair, KeyPair};
@@ -118,7 +118,9 @@ fn reemits_keripy_rot_remove_attachment_byte_for_byte() {
 #[test]
 fn asymmetric_rotation_kt2_now_accepted() {
     let icp = load_event("rot_remove.icp.json");
-    let prior = replay_kel(std::slice::from_ref(&icp)).expect("icp replays to a key state");
+    let prior = TrustedKel::from_trusted_source(std::slice::from_ref(&icp))
+        .replay()
+        .expect("icp replays to a key state");
     let rot = load_event("rot_remove.rot.json");
     let sigs = parse_attachment(&fixture("rot_remove.rot.att")).unwrap();
     validate_signed_event(&SignedEvent::new(rot, sigs), Some(&prior))
@@ -129,7 +131,9 @@ fn asymmetric_rotation_kt2_now_accepted() {
 #[test]
 fn dual_index_rotation_binds_prior_commitment() {
     let icp = load_event("rot_remove.icp.json");
-    let prior = replay_kel(std::slice::from_ref(&icp)).unwrap();
+    let prior = TrustedKel::from_trusted_source(std::slice::from_ref(&icp))
+        .replay()
+        .unwrap();
     let rot = load_event("rot_remove.rot.json");
     let good = parse_attachment(&fixture("rot_remove.rot.att")).unwrap();
 
@@ -182,7 +186,9 @@ fn single_signer_removal_validates() {
         a: vec![],
     })
     .unwrap();
-    let prior = replay_kel(std::slice::from_ref(&Event::Icp(icp.clone()))).unwrap();
+    let prior = TrustedKel::from_trusted_source(std::slice::from_ref(&Event::Icp(icp.clone())))
+        .replay()
+        .unwrap();
 
     // Reveal slots 0 and 1; drop slot 2. New k = [nxt0, nxt1].
     let fresh = ed25519();

--- a/crates/auths-scim-server/src/auth.rs
+++ b/crates/auths-scim-server/src/auth.rs
@@ -30,8 +30,11 @@ pub struct AuthenticatedTenant {
     pub org_prefix: String,
     /// Keychain alias of the org signing key that anchors delegations.
     pub org_key_alias: String,
-    /// Capabilities this tenant may grant (empty = permit all).
+    /// Capabilities this tenant may grant. Empty = deny all (RT-006) unless
+    /// `allow_all` is set.
     pub allowed_capabilities: Vec<Capability>,
+    /// Opt-in permit-all that bypasses the allowlist.
+    pub allow_all: bool,
     /// Base URL used for SCIM `meta.location`.
     pub base_url: String,
 }
@@ -66,6 +69,7 @@ impl FromRequestParts<ScimServerState> for AuthenticatedTenant {
                         org_prefix: t.org_prefix,
                         org_key_alias: t.org_key_alias,
                         allowed_capabilities: t.allowed_capabilities,
+                        allow_all: t.allow_all,
                         base_url: t.base_url,
                     })
                     .ok_or_else(|| unauthorized("invalid bearer token"))

--- a/crates/auths-scim-server/src/lifecycle.rs
+++ b/crates/auths-scim-server/src/lifecycle.rs
@@ -32,6 +32,8 @@ pub async fn patch_user(
     Json(patch): Json<ScimPatchOp>,
 ) -> Result<Json<ScimUser>, ScimServerError> {
     let ops = patch.operations;
+    let allowed = tenant.allowed_capabilities.clone();
+    let allow_all = tenant.allow_all;
     let updated = state.update_user(&tenant.tenant_id, &id, move |user| {
         let was_revoked = user
             .auths_extension
@@ -39,6 +41,16 @@ pub async fn patch_user(
             .map(|e| e.revoked)
             .unwrap_or(false);
         let patched = apply_patch_operations(user, &ops)?;
+        // Re-enforce the capability allowlist on PATCH so a lifecycle update
+        // cannot widen capabilities past the tenant's grant (RT-006/RT-026).
+        if !allow_all {
+            let patched_caps = patched
+                .auths_extension
+                .as_ref()
+                .map(|e| e.capabilities.clone())
+                .unwrap_or_default();
+            auths_scim::mapping::validate_capabilities(&patched_caps, &allowed)?;
+        }
         if was_revoked && patched.active {
             return Err(ScimError::InvalidValue {
                 message: "cannot reactivate a hard-revoked member; the identity is \

--- a/crates/auths-scim-server/src/main.rs
+++ b/crates/auths-scim-server/src/main.rs
@@ -39,6 +39,23 @@ async fn main() -> anyhow::Result<()> {
                 bearer_token,
                 org_key_alias: std::env::var("SCIM_ORG_KEY").ok(),
                 base_url: std::env::var("SCIM_BASE_URL").ok(),
+                // Deny-by-default capability allowlist (RT-006): empty grants
+                // nothing. Set SCIM_ALLOWED_CAPABILITIES=cap1,cap2 to permit
+                // specific grants, or SCIM_ALLOW_ALL_CAPABILITIES=1 to opt into
+                // permit-all for a single-tenant pilot.
+                allowed_capabilities: std::env::var("SCIM_ALLOWED_CAPABILITIES")
+                    .ok()
+                    .map(|s| {
+                        s.split(',')
+                            .map(str::trim)
+                            .filter(|c| !c.is_empty())
+                            .filter_map(|c| c.parse::<auths_verifier::Capability>().ok())
+                            .collect()
+                    })
+                    .unwrap_or_default(),
+                allow_all: std::env::var("SCIM_ALLOW_ALL_CAPABILITIES")
+                    .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+                    .unwrap_or(false),
             })
         }
         _ => {

--- a/crates/auths-scim-server/src/serve.rs
+++ b/crates/auths-scim-server/src/serve.rs
@@ -20,6 +20,8 @@ use auths_sdk::storage::{
     GitRegistryBackend, RegistryAttestationStorage, RegistryConfig, RegistryIdentityStorage,
 };
 
+use auths_verifier::Capability;
+
 use crate::provisioner::{Provisioner, SdkProvisioner};
 use crate::state::{ScimServerState, TenantConfig};
 
@@ -36,6 +38,11 @@ pub struct TenantBootstrap {
     pub org_key_alias: Option<String>,
     /// Base URL for SCIM `meta.location`.
     pub base_url: Option<String>,
+    /// Capabilities this tenant may grant. Empty = deny all (RT-006) unless
+    /// `allow_all` is set.
+    pub allowed_capabilities: Vec<Capability>,
+    /// Opt-in permit-all that bypasses the allowlist.
+    pub allow_all: bool,
 }
 
 impl TenantBootstrap {
@@ -48,6 +55,8 @@ impl TenantBootstrap {
             config = config.with_base_url(url);
         }
         config
+            .with_allowed_capabilities(self.allowed_capabilities)
+            .with_allow_all(self.allow_all)
     }
 }
 

--- a/crates/auths-scim-server/src/state.rs
+++ b/crates/auths-scim-server/src/state.rs
@@ -30,8 +30,13 @@ pub struct TenantConfig {
     pub org_prefix: String,
     /// Keychain alias of the org signing key that anchors delegations.
     pub org_key_alias: String,
-    /// Capabilities this tenant may grant (empty = permit all).
+    /// Capabilities this tenant may grant. Empty = deny all (RT-006) unless
+    /// `allow_all` is set.
     pub allowed_capabilities: Vec<Capability>,
+    /// Opt-in permit-all: grant ANY requested capability, bypassing the
+    /// allowlist. Off by default; for single-tenant pilots that consciously
+    /// accept it.
+    pub allow_all: bool,
     /// Base URL used for SCIM `meta.location` (e.g. `https://scim.acme.com/scim/v2`).
     pub base_url: String,
     token_hash: [u8; 32],
@@ -75,6 +80,7 @@ impl TenantConfig {
             tenant_id: tenant_id.into(),
             org_prefix,
             allowed_capabilities: Vec::new(),
+            allow_all: false,
             base_url: String::new(),
             token_hash: Sha256::digest(bearer_token.as_bytes()).into(),
         }
@@ -86,9 +92,17 @@ impl TenantConfig {
         self
     }
 
-    /// Restrict the capabilities this tenant may grant (empty = permit all).
+    /// Restrict the capabilities this tenant may grant. Empty denies all (the
+    /// secure default) unless [`with_allow_all`](Self::with_allow_all) is set.
     pub fn with_allowed_capabilities(mut self, capabilities: Vec<Capability>) -> Self {
         self.allowed_capabilities = capabilities;
+        self
+    }
+
+    /// Opt into permit-all: grant any requested capability, bypassing the
+    /// allowlist. For single-tenant pilots that consciously accept it.
+    pub fn with_allow_all(mut self, allow_all: bool) -> Self {
+        self.allow_all = allow_all;
         self
     }
 

--- a/crates/auths-scim-server/src/users.rs
+++ b/crates/auths-scim-server/src/users.rs
@@ -31,7 +31,8 @@ pub async fn create_user(
     tenant: AuthenticatedTenant,
     Json(input): Json<ScimUser>,
 ) -> Result<(StatusCode, Json<ScimUser>), ScimServerError> {
-    let request = scim_user_to_provision_request(&input, &tenant.allowed_capabilities)?;
+    let request =
+        scim_user_to_provision_request(&input, &tenant.allowed_capabilities, tenant.allow_all)?;
 
     if let Some(external_id) = request.external_id.as_deref()
         && let Some(existing) = state.find_by_external(&tenant.tenant_id, external_id)

--- a/crates/auths-scim/src/mapping.rs
+++ b/crates/auths-scim/src/mapping.rs
@@ -64,15 +64,17 @@ pub struct UpdateAgentFields {
 ///
 /// Args:
 /// * `user`: The incoming SCIM User resource.
-/// * `allowed_capabilities`: Tenant-scoped capability allowlist.
+/// * `allowed_capabilities`: Tenant-scoped capability allowlist (deny by default).
+/// * `allow_all`: Opt-in permit-all that bypasses the allowlist.
 ///
 /// Usage:
 /// ```ignore
-/// let request = scim_user_to_provision_request(&scim_user, &allowed)?;
+/// let request = scim_user_to_provision_request(&scim_user, &allowed, false)?;
 /// ```
 pub fn scim_user_to_provision_request(
     user: &ScimUser,
     allowed_capabilities: &[Capability],
+    allow_all: bool,
 ) -> Result<ProvisionAgentRequest, ScimError> {
     if user.user_name.is_empty() {
         return Err(ScimError::MissingAttribute {
@@ -86,7 +88,9 @@ pub fn scim_user_to_provision_request(
         .map(|ext| ext.capabilities.clone())
         .unwrap_or_default();
 
-    validate_capabilities(&capabilities, allowed_capabilities)?;
+    if !allow_all {
+        validate_capabilities(&capabilities, allowed_capabilities)?;
+    }
 
     Ok(ProvisionAgentRequest {
         external_id: user.external_id.clone(),
@@ -154,13 +158,18 @@ pub fn scim_user_to_update_fields(user: &ScimUser) -> UpdateAgentFields {
     }
 }
 
-fn validate_capabilities(
+/// Reject any requested capability outside the tenant's allowlist.
+///
+/// **Deny by default (RT-006):** an empty allowlist permits NO capabilities, so
+/// a tenant must explicitly enumerate what it may grant — or opt into permit-all
+/// at the call site (`allow_all`). A request carrying no capabilities always
+/// passes. Previously an empty allowlist meant "permit all", which — combined
+/// with the setter never being wired — let every tenant anchor arbitrary
+/// authority into the org KEL.
+pub fn validate_capabilities(
     capabilities: &[Capability],
     allowed: &[Capability],
 ) -> Result<(), ScimError> {
-    if allowed.is_empty() {
-        return Ok(());
-    }
     for cap in capabilities {
         if !allowed.contains(cap) {
             return Err(ScimError::CapabilityNotAllowed {
@@ -218,7 +227,7 @@ mod tests {
             Capability::parse("sign:commit").unwrap(),
             Capability::parse("deploy:staging").unwrap(),
         ];
-        let req = scim_user_to_provision_request(&user, &allowed).unwrap();
+        let req = scim_user_to_provision_request(&user, &allowed, false).unwrap();
         assert_eq!(req.user_name, "deploy-bot");
         assert_eq!(
             req.capabilities,
@@ -230,7 +239,7 @@ mod tests {
     fn missing_username_rejected() {
         let mut user = sample_scim_user();
         user.user_name = String::new();
-        let result = scim_user_to_provision_request(&user, &[]);
+        let result = scim_user_to_provision_request(&user, &[], false);
         assert!(result.is_err());
     }
 
@@ -238,14 +247,24 @@ mod tests {
     fn disallowed_capability_rejected() {
         let user = sample_scim_user();
         let allowed = vec![Capability::parse("deploy:staging").unwrap()]; // sign:commit not allowed
-        let result = scim_user_to_provision_request(&user, &allowed);
+        let result = scim_user_to_provision_request(&user, &allowed, false);
         assert!(result.is_err());
     }
 
     #[test]
-    fn empty_allowlist_permits_all() {
+    fn empty_allowlist_denies_capabilities() {
+        // RT-006: an unconfigured (empty) allowlist must DENY, not permit-all —
+        // otherwise any SCIM tenant could anchor arbitrary authority into the KEL.
+        let user = sample_scim_user(); // requests `sign:commit`
+        let result = scim_user_to_provision_request(&user, &[], false);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn allow_all_bypasses_the_allowlist() {
+        // The explicit permit-all opt-in still works for single-tenant pilots.
         let user = sample_scim_user();
-        let result = scim_user_to_provision_request(&user, &[]);
+        let result = scim_user_to_provision_request(&user, &[], true);
         assert!(result.is_ok());
     }
 

--- a/crates/auths-sdk/src/domains/identity/rotation.rs
+++ b/crates/auths-sdk/src/domains/identity/rotation.rs
@@ -219,15 +219,38 @@ pub fn apply_rotation(
             )
             .map_err(|e| e.to_string())?;
 
-        let _ = key_storage.delete_key(&key_material.old_next_alias);
+        // Key cleanup is no longer best-effort (RT-014): a swallowed delete
+        // failure can leave a rotated-away key in storage, re-introducing the
+        // nondeterministic current-key enumeration class (#252/#253) where a
+        // stale key signs again. Collect failures and fail the rotation so the
+        // caller retries cleanup rather than silently trusting it succeeded.
+        let mut cleanup_errors: Vec<String> = Vec::new();
+
+        if let Err(e) = key_storage.delete_key(&key_material.old_next_alias) {
+            cleanup_errors.push(format!(
+                "old next-rotation key '{}': {e}",
+                key_material.old_next_alias.as_str()
+            ));
+        }
 
         // Delete the rotated-away primary keys. Leaving them as Primary made
         // current-key resolution and delegation signing pick a stale key when
-        // keychain enumeration returned multiple primaries. A rotated-away
-        // key must never sign again — verification replays public keys from
-        // the KEL, so the old private key serves no further purpose.
+        // keychain enumeration returned multiple primaries. A rotated-away key
+        // must never sign again — verification replays public keys from the KEL,
+        // so the old private key serves no further purpose.
         for stale in stale_primaries {
-            let _ = key_storage.delete_key(&stale);
+            if let Err(e) = key_storage.delete_key(&stale) {
+                cleanup_errors.push(format!("rotated-away primary '{}': {e}", stale.as_str()));
+            }
+        }
+
+        if !cleanup_errors.is_empty() {
+            return Err(format!(
+                "rotation advanced the KEL but key cleanup failed for {} key(s) — a \
+                 rotated-away key may persist and must be removed: {}",
+                cleanup_errors.len(),
+                cleanup_errors.join("; ")
+            ));
         }
 
         Ok::<(), String>(())

--- a/crates/auths-sdk/src/domains/org/offline_verify.rs
+++ b/crates/auths-sdk/src/domains/org/offline_verify.rs
@@ -55,6 +55,64 @@ fn check_kel_integrity(kel: &BundledKel) -> Result<(), OrgError> {
     Ok(())
 }
 
+/// Authenticate a bundled KEL (RT-002): verify every event is SIGNED by the
+/// controlling key-state, not just SAID-correct. Reconstructs `SignedEvent`s from
+/// the parallel `events` × hex `attachments` and replays them through
+/// `validate_signed_kel`. Fails closed on a length mismatch, an unparseable
+/// attachment, or a signature that doesn't verify.
+fn authenticate_bundled_kel(
+    kel: &BundledKel,
+    lookup: Option<&dyn auths_keri::DelegatorKelLookup>,
+) -> Result<(), OrgError> {
+    let integrity_err = |reason: String| OrgError::BundleIntegrity {
+        id: kel.prefix.as_str().to_string(),
+        reason,
+    };
+    if kel.attachments.len() != kel.events.len() {
+        return Err(integrity_err(format!(
+            "{} events but {} signature attachments — cannot authenticate",
+            kel.events.len(),
+            kel.attachments.len()
+        )));
+    }
+    let mut signed = Vec::with_capacity(kel.events.len());
+    for (event, att_hex) in kel.events.iter().zip(kel.attachments.iter()) {
+        let bytes =
+            hex::decode(att_hex).map_err(|e| integrity_err(format!("non-hex attachment: {e}")))?;
+        // A delegated (dip/drt) event's attachment is `-A <sig> ++ -G <source seal>`;
+        // a plain event's is just `-A <sig>`. `parse_delegated_attachment` handles both.
+        let (sigs, seals) = auths_keri::parse_delegated_attachment(&bytes)
+            .map_err(|e| integrity_err(format!("unparseable attachment: {e}")))?;
+        // A dip/drt JSON body carries no source seal (it lives in the attachment);
+        // restore it so the delegation binding can be authenticated.
+        let event = rehydrate_event_source_seal(event.clone(), seals.into_iter().next());
+        signed.push(auths_keri::SignedEvent::new(event, sigs));
+    }
+    auths_keri::validate_signed_kel(&signed, lookup)
+        .map_err(|e| integrity_err(format!("KEL signature authentication failed (RT-002): {e}")))?;
+    Ok(())
+}
+
+/// Re-attach a delegated event's source seal from its parsed attachment — the JSON
+/// body of a `dip`/`drt` carries none (it lives in the `-G` group). Mirrors the
+/// storage layer's `rehydrate_source_seal`.
+fn rehydrate_event_source_seal(event: Event, seal: Option<auths_keri::SourceSeal>) -> Event {
+    let Some(seal) = seal else {
+        return event;
+    };
+    match event {
+        Event::Dip(mut e) => {
+            e.source_seal = Some(seal);
+            Event::Dip(e)
+        }
+        Event::Drt(mut e) => {
+            e.source_seal = Some(seal);
+            Event::Drt(e)
+        }
+        other => other,
+    }
+}
+
 /// Does the org KEL anchor a delegation `KeyEvent` seal for `member_prefix`?
 fn is_delegated(org_kel: &[Event], member_prefix: &Prefix) -> bool {
     org_kel.iter().any(|event| {
@@ -130,10 +188,16 @@ pub fn verify_org_bundle(
     pinned_roots: &[IdentityDID],
     query: Option<(&Prefix, Option<u128>)>,
 ) -> Result<OfflineVerifyReport, OrgError> {
-    // 1. Integrity: every bundled event must self-address correctly (tamper check).
+    // 1. Integrity + AUTHENTICATION (RT-002): every bundled event must self-address
+    //    (SAID) AND be signed by the controlling key-state — not just structurally
+    //    valid. The org KEL is the root of trust (no delegator); member KELs are
+    //    authenticated against the org as delegator.
     check_kel_integrity(&bundle.org_kel)?;
+    authenticate_bundled_kel(&bundle.org_kel, None)?;
+    let org_lookup = auths_keri::KelSealIndex::from_events(&bundle.org_kel.events);
     for member_kel in &bundle.member_kels {
         check_kel_integrity(member_kel)?;
+        authenticate_bundled_kel(member_kel, Some(&org_lookup))?;
     }
 
     // 2. Completeness: every member the org delegated must ship its own KEL.

--- a/crates/auths-sdk/src/keri/resolver.rs
+++ b/crates/auths-sdk/src/keri/resolver.rs
@@ -184,10 +184,12 @@ pub fn resolve_current_public_key(
             did: did.to_string(),
             source,
         })?;
-    let state = auths_keri::validate_kel(&kel).map_err(|e| CurrentKeyError::InvalidKel {
-        did: did.to_string(),
-        reason: e.to_string(),
-    })?;
+    let state = auths_keri::TrustedKel::from_trusted_source(&kel)
+        .replay()
+        .map_err(|e| CurrentKeyError::InvalidKel {
+            did: did.to_string(),
+            reason: e.to_string(),
+        })?;
     let key = state
         .current_key()
         .ok_or_else(|| CurrentKeyError::NoCurrentKey {

--- a/crates/auths-sdk/src/workflows/commit_trust.rs
+++ b/crates/auths-sdk/src/workflows/commit_trust.rs
@@ -8,6 +8,7 @@
 //! itself lives in `auths_verifier::verify_commit_against_kel`; this workflow owns the
 //! orchestration (trailer parse → KEL resolution → verdict).
 
+use auths_keri::compute_event_said;
 use auths_verifier::IdentityBundle;
 use chrono::{DateTime, Utc};
 
@@ -107,6 +108,43 @@ pub fn trusted_root_from_bundle(
     bundle
         .check_freshness(now)
         .map_err(|e| CommitTrustError::BundleInvalid(e.to_string()))?;
+
+    // Self-certification of the bundle root (RT-005): the DID the caller is about
+    // to treat as a root MUST actually name the inception the bundle carries, so
+    // a bundle cannot pair a victim's DID with an attacker-authored KEL. For a
+    // self-addressing (`E`) root the DID MUST equal the inception SAID; for a
+    // basic-derivation root it MUST equal the inception's controller field (and
+    // replay independently enforces `i == k[0]`). The bundle is *evidence for*
+    // the pinned root, never a self-asserted anchor — the CLI additionally
+    // requires the returned root to already be pinned independently.
+    if let Some(inception) = bundle.kel.first() {
+        let claimed = bundle.identity_did.to_string();
+        let prefix = claimed
+            .strip_prefix("did:keri:")
+            .unwrap_or(claimed.as_str());
+        if prefix.starts_with('E') {
+            let said = compute_event_said(inception).map_err(|e| {
+                CommitTrustError::BundleInvalid(format!(
+                    "bundle KEL inception has no computable SAID: {e}"
+                ))
+            })?;
+            if prefix != said.as_str() {
+                return Err(CommitTrustError::BundleInvalid(format!(
+                    "bundle identity_did {claimed} does not self-certify to its \
+                     inception SAID did:keri:{said}"
+                )));
+            }
+        } else {
+            let inception_i = inception.prefix().as_str();
+            if prefix != inception_i {
+                return Err(CommitTrustError::BundleInvalid(format!(
+                    "bundle identity_did {claimed} does not match its inception \
+                     controller {inception_i}"
+                )));
+            }
+        }
+    }
+
     Ok(bundle.identity_did.to_string())
 }
 
@@ -427,6 +465,7 @@ mod tests {
             curve: auths_crypto::CurveType::P256,
             attestation_chain: Vec::new(),
             kel: Vec::new(),
+            kel_attachments: Vec::new(),
             bundle_timestamp: ts,
             max_valid_for_secs: ttl,
         }
@@ -449,6 +488,44 @@ mod tests {
         let t = fixed_time();
         let bundle = test_bundle(ROOT, t, 3600);
         let now = t + chrono::Duration::seconds(7200);
+        assert!(matches!(
+            trusted_root_from_bundle(&bundle, now),
+            Err(CommitTrustError::BundleInvalid(_))
+        ));
+    }
+
+    #[test]
+    fn bundle_rejects_did_not_matching_its_kel_inception() {
+        // RT-005 self-certification: a bundle that pairs a DID with a KEL whose
+        // inception names a DIFFERENT controller must fail closed, so a bundle
+        // can never become the trust anchor for an attacker-authored KEL.
+        use auths_keri::{
+            CesrKey, Event, IcpEvent, KeriPublicKey, KeriSequence, Prefix, Said, Threshold,
+            VersionString, compute_next_commitment, finalize_icp_event,
+        };
+        // A real, self-certifying inception — its prefix is its own `E…` SAID.
+        let key = KeriPublicKey::ed25519(&[7u8; 32]).unwrap();
+        let next = KeriPublicKey::ed25519(&[8u8; 32]).unwrap();
+        let inception = finalize_icp_event(IcpEvent {
+            v: VersionString::placeholder(),
+            d: Said::default(),
+            i: Prefix::default(),
+            s: KeriSequence::new(0),
+            kt: Threshold::Simple(1),
+            k: vec![CesrKey::new_unchecked(key.to_qb64().unwrap())],
+            nt: Threshold::Simple(1),
+            n: vec![compute_next_commitment(&next)],
+            bt: Threshold::Simple(0),
+            b: vec![],
+            c: vec![],
+            a: vec![],
+        })
+        .unwrap();
+        let t = fixed_time();
+        // Pair that inception with an unrelated `D…` DID it does not certify.
+        let mut bundle = test_bundle("did:keri:DAttackerKey", t, 3600);
+        bundle.kel = vec![Event::Icp(inception)];
+        let now = t + chrono::Duration::seconds(100);
         assert!(matches!(
             trusted_root_from_bundle(&bundle, now),
             Err(CommitTrustError::BundleInvalid(_))

--- a/crates/auths-sdk/tests/cases/org_delegation.rs
+++ b/crates/auths-sdk/tests/cases/org_delegation.rs
@@ -669,6 +669,45 @@ fn offline_verify_reproduces_live_verdict_and_fails_closed() {
 }
 
 #[test]
+fn offline_verify_rejects_forged_kel_signature() {
+    // RT-002: an air-gapped org bundle whose KEL event signature is tampered must
+    // fail closed — even though every SAID still self-addresses. A SAID-only
+    // integrity check (the prior behavior) would (wrongly) accept it.
+    use auths_sdk::domains::org::{build_org_bundle, verify_org_bundle};
+
+    let (ctx, org_alias, org_prefix, _tmp) = setup();
+    add_member(
+        &ctx,
+        &org_prefix,
+        &org_alias,
+        &KeyAlias::new_unchecked("mallory"),
+        CurveType::Ed25519,
+        Role::Member,
+        &[auths_keri::Capability::sign_commit()],
+        None,
+    )
+    .expect("add member");
+
+    let mut bundle = build_org_bundle(&ctx, &org_prefix).expect("bundle");
+    let roots = vec![bundle.org_did.clone()];
+    // Sanity: the untampered bundle authenticates.
+    verify_org_bundle(&bundle, &roots, None).expect("good bundle authenticates");
+
+    // Forge the org inception's signature attachment (flip its last hex nibble).
+    let att = &mut bundle.org_kel.attachments[0];
+    if let Some(last) = att.pop() {
+        att.push(if last == '0' { '1' } else { '0' });
+    }
+
+    let err = verify_org_bundle(&bundle, &roots, None)
+        .expect_err("a bundle with a forged KEL signature must fail closed (RT-002)");
+    assert!(
+        matches!(err, OrgError::BundleIntegrity { .. }),
+        "expected BundleIntegrity, got {err:?}"
+    );
+}
+
+#[test]
 fn empty_org_returns_empty_member_list() {
     let (ctx, _org_alias, org_prefix, _tmp) = setup();
     let members = list_members(&ctx, &org_prefix).expect("list members on an org with none");

--- a/crates/auths-storage/src/git/adapter.rs
+++ b/crates/auths-storage/src/git/adapter.rs
@@ -2693,6 +2693,71 @@ mod tests {
     }
 
     #[test]
+    fn git_backend_round_trips_event_attachment() {
+        // RT-002 Phase 0: the Git backend must PERSIST and RETURN an event's CESR
+        // signature attachment, including for a self-rooted inception (seq 0).
+        // This locks the contract the bundle producer relies on to ship
+        // authenticatable KELs.
+        let (_dir, backend) = setup_test_repo();
+        let (event, prefix, keypair, _next) = create_signed_icp();
+
+        let canonical = auths_keri::serialize_for_signing(&event).unwrap();
+        let sig = keypair.sign(&canonical).as_ref().to_vec();
+        let attachment = auths_keri::serialize_attachment(&[auths_keri::IndexedSignature {
+            index: 0,
+            prior_index: None,
+            sig,
+        }])
+        .unwrap();
+        assert!(
+            !attachment.is_empty(),
+            "inception attachment must be non-empty"
+        );
+
+        backend
+            .append_signed_event(&prefix, &event, &attachment)
+            .unwrap();
+
+        let got = backend.get_attachment(&prefix, 0).unwrap();
+        assert_eq!(
+            got,
+            Some(attachment),
+            "Git backend must round-trip the inception's signature attachment"
+        );
+    }
+
+    #[test]
+    fn arc_dyn_backend_forwards_attachment() {
+        // RT-002 root-cause regression: `Arc<dyn RegistryBackend>` (how the SDK
+        // holds `ctx.registry`) must FORWARD append_signed_event/get_attachment,
+        // not silently drop the attachment via a trait default. Before the fix,
+        // the inception's signature was lost here and the bundle producer saw
+        // `get_attachment(prefix, 0) == None`.
+        use std::sync::Arc;
+        let (_dir, backend) = setup_test_repo();
+        let registry: Arc<dyn RegistryBackend> = Arc::new(backend);
+        let (event, prefix, keypair, _next) = create_signed_icp();
+
+        let canonical = auths_keri::serialize_for_signing(&event).unwrap();
+        let sig = keypair.sign(&canonical).as_ref().to_vec();
+        let attachment = auths_keri::serialize_attachment(&[auths_keri::IndexedSignature {
+            index: 0,
+            prior_index: None,
+            sig,
+        }])
+        .unwrap();
+
+        registry
+            .append_signed_event(&prefix, &event, &attachment)
+            .unwrap();
+        assert_eq!(
+            registry.get_attachment(&prefix, 0).unwrap(),
+            Some(attachment),
+            "Arc<dyn RegistryBackend> must forward the attachment, not drop it"
+        );
+    }
+
+    #[test]
     fn append_multiple_events() {
         let (_dir, backend) = setup_test_repo();
         let (icp, prefix, _keypair, next_keypair) = create_signed_icp();

--- a/crates/auths-storage/src/postgres/adapter.rs
+++ b/crates/auths-storage/src/postgres/adapter.rs
@@ -48,6 +48,27 @@ impl RegistryBackend for PostgresAdapter {
         })
     }
 
+    fn append_signed_event(
+        &self,
+        _prefix: &Prefix,
+        _event: &Event,
+        _attachment: &[u8],
+    ) -> Result<(), RegistryError> {
+        Err(RegistryError::NotImplemented {
+            method: "append_signed_event",
+        })
+    }
+
+    fn get_attachment(
+        &self,
+        _prefix: &Prefix,
+        _seq: u128,
+    ) -> Result<Option<Vec<u8>>, RegistryError> {
+        Err(RegistryError::NotImplemented {
+            method: "get_attachment",
+        })
+    }
+
     fn get_event(&self, _prefix: &Prefix, _seq: u128) -> Result<Event, RegistryError> {
         Err(RegistryError::NotImplemented {
             method: "get_event",

--- a/crates/auths-verifier/Cargo.toml
+++ b/crates/auths-verifier/Cargo.toml
@@ -36,6 +36,7 @@ schemars = { workspace = true, optional = true, features = ["chrono"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.149"
 sha2.workspace = true
+subtle.workspace = true
 thiserror.workspace = true
 
 # Optional dependencies

--- a/crates/auths-verifier/src/commit_kel.rs
+++ b/crates/auths-verifier/src/commit_kel.rs
@@ -10,8 +10,8 @@
 use auths_crypto::CryptoProvider;
 use auths_keri::witness::{NoWitnessReceipts, WitnessReceiptLookup};
 use auths_keri::{
-    CesrKey, DelegatorKelLookup, Event, KeriPublicKey, Prefix, Said, Seal, SourceSeal,
-    WitnessedReplay, validate_delegation, validate_kel_with_lookup, validate_kel_with_receipts,
+    CesrKey, Event, KelSealIndex, KeriPublicKey, Prefix, Seal, TrustedKel, WitnessedReplay,
+    validate_delegation,
 };
 
 use crate::commit::{extract_ssh_signature, verify_commit_signature};
@@ -156,30 +156,6 @@ impl CommitVerdict {
     }
 }
 
-/// `DelegatorKelLookup` over an in-memory root KEL slice — answers "did the root
-/// anchor a seal for this delegated event?" by scanning the root KEL's seals.
-struct RootKelLookup<'a> {
-    root_kel: &'a [Event],
-}
-
-impl DelegatorKelLookup for RootKelLookup<'_> {
-    fn find_seal(&self, _delegator_aid: &Prefix, seal_said: &Said) -> Option<SourceSeal> {
-        for event in self.root_kel {
-            for seal in event.anchors() {
-                if let Seal::KeyEvent { d, .. } = seal
-                    && d == seal_said
-                {
-                    return Some(SourceSeal {
-                        s: event.sequence(),
-                        d: event.said().clone(),
-                    });
-                }
-            }
-        }
-        None
-    }
-}
-
 /// The KEL position (root sequence) at which the delegator anchored a revocation
 /// (`Seal::Digest{d == device_prefix}`) for the device/agent, or `None` if not
 /// revoked. KERI carries no wall-clock, so revocation is ordered by this position.
@@ -312,9 +288,13 @@ enum RevocationOrdering {
 
 /// Order a commit's in-band signing position against the revocation position.
 ///
-/// A commit signed *before* the revocation stays valid (legitimate prior history is
-/// not retroactively invalidated); one signed *at or after* it is rejected. Without
-/// an in-band position, the result is conservative ([`RevocationOrdering::RevokedUnknownPosition`]).
+/// NOTE (RT-003): the in-band position is a signer-chosen trailer, so the *caller*
+/// no longer treats [`RevocationOrdering::SignedBefore`] as acceptance — a
+/// currently-revoked delegate fails closed regardless of the claimed position
+/// until an independent ordering source (witness receipt / transparency log /
+/// signed git-history reachability) exists. This function still computes the
+/// ordering so that stronger fix can later accept a `SignedBefore` commit when it
+/// is independently corroborated.
 fn classify_revocation(
     signing_anchor: Option<u128>,
     revocation: Option<u128>,
@@ -424,7 +404,10 @@ pub async fn verify_commit_against_kel_witnessed(
 ) -> WitnessedVerdict {
     // 1. Replay + witness-gate the root KEL (validates SAIDs incl. the
     //    self-addressing icp prefix, then checks M-of-N witness agreement).
-    let replay = match validate_kel_with_receipts(root_kel, None, receipt_lookup) {
+    // rt-002-allow: root_kel is authenticated at the ingestion boundary before it reaches here (CI --identity-bundle → validate_signed_kel in load_bundle_trust; local registry = trusted self-owned store), and this replay additionally enforces the M-of-N witness gate. Residual: the opt-in --remote/--oobi stranger feed, whose signature-carrying transport is tracked (RT-002 follow-up).
+    let replay = match TrustedKel::from_trusted_source(root_kel)
+        .replay_with_receipts(None, receipt_lookup)
+    {
         Ok(r) => r,
         Err(e) => {
             return WitnessedVerdict {
@@ -515,7 +498,8 @@ pub async fn verify_commit_against_kel_scoped(
     provider: &dyn CryptoProvider,
     now: i64,
 ) -> CommitVerdict {
-    let root_state = match auths_keri::validate_kel(root_kel) {
+    // rt-002-allow: root_kel is authenticated at the ingestion boundary (CI --identity-bundle → validate_signed_kel in load_bundle_trust; local registry = trusted self-owned store). Residual: opt-in --remote/--oobi stranger feed — signature-carrying transport tracked (RT-002 follow-up).
+    let root_state = match TrustedKel::from_trusted_source(root_kel).replay() {
         Ok(state) => state,
         Err(e) => return CommitVerdict::RootKelInvalid(e.to_string()),
     };
@@ -556,21 +540,23 @@ async fn authorize_commit(
     }
 
     // 3. Replay the device KEL (a dip needs the delegator lookup against the root).
-    let lookup = RootKelLookup { root_kel };
-    let device_state = match validate_kel_with_lookup(device_kel, Some(&lookup)) {
-        Ok(s) => s,
-        Err(e) => {
-            // A device dip the root never anchored fails replay here (the lookup
-            // can't resolve its delegation seal) — surface that distinctly from a
-            // structurally-broken device KEL.
-            if let Some(first @ Event::Dip(_)) = device_kel.first()
-                && validate_delegation(first, root_kel).is_err()
-            {
-                return CommitVerdict::DelegationSealNotFound;
+    let lookup = KelSealIndex::from_events(root_kel);
+    // rt-002-allow: device_kel is authenticated at the ingestion boundary (CI --identity-bundle → validate_signed_kel in load_bundle_trust; local registry = trusted self-owned store); the dip's delegation is additionally bound to the already-replayed root via the root KelSealIndex. Residual: opt-in --remote/--oobi stranger feed — tracked (RT-002 follow-up).
+    let device_state =
+        match TrustedKel::from_trusted_source(device_kel).replay_with_lookup(Some(&lookup)) {
+            Ok(s) => s,
+            Err(e) => {
+                // A device dip the root never anchored fails replay here (the lookup
+                // can't resolve its delegation seal) — surface that distinctly from a
+                // structurally-broken device KEL.
+                if let Some(first @ Event::Dip(_)) = device_kel.first()
+                    && validate_delegation(first, root_kel).is_err()
+                {
+                    return CommitVerdict::DelegationSealNotFound;
+                }
+                return CommitVerdict::DeviceKelInvalid(e.to_string());
             }
-            return CommitVerdict::DeviceKelInvalid(e.to_string());
-        }
-    };
+        };
     let device_prefix = device_state.prefix.clone();
     let device_did = format!("did:keri:{device_prefix}");
 
@@ -674,8 +660,20 @@ fn reject_unauthorized_delegate(
 
     let revocation = revocation_position(root_kel, &device_prefix);
     match classify_revocation(parse_anchor_seq(commit_bytes), revocation) {
-        RevocationOrdering::NotRevoked | RevocationOrdering::SignedBefore => {}
-        RevocationOrdering::RevokedUnknownPosition => return Some(CommitVerdict::DeviceRevoked),
+        RevocationOrdering::NotRevoked => {}
+        // RT-003: revocation is terminal for NEW signatures. The in-band
+        // `Auths-Anchor-Seq` is signer-chosen, so a "signed before revocation"
+        // claim is not a trustworthy ordering source — a revoked-but-unrotated
+        // key would simply claim position 0. Until an INDEPENDENT signal exists
+        // (witness-receipted KSN / transparency log / signed git-history
+        // reachability), a currently-revoked delegate fails closed regardless of
+        // the self-reported position. This over-rejects genuinely-prior commits
+        // in the stateless verifier — the accepted interim cost (open question 2).
+        // `SignedBefore` is still computed so the witness-ordered fix can later
+        // accept it when independently corroborated.
+        RevocationOrdering::SignedBefore | RevocationOrdering::RevokedUnknownPosition => {
+            return Some(CommitVerdict::DeviceRevoked);
+        }
         RevocationOrdering::SignedAfter {
             signed_at,
             revoked_at,

--- a/crates/auths-verifier/src/core.rs
+++ b/crates/auths-verifier/src/core.rs
@@ -928,11 +928,21 @@ pub struct IdentityBundle {
     pub curve: auths_crypto::CurveType,
     /// Chain of attestations linking the signing key to the identity
     pub attestation_chain: Vec<Attestation>,
-    /// The identity's raw KEL events (JSON, oldest first). Carried so
-    /// KEL-native commit verification stays stateless on CI runners with no
-    /// identity store. Empty in bundles exported before this field existed.
+    /// The identity's KEL events, oldest first (parsed at the deserialize
+    /// boundary, not held as loose JSON). Carried so KEL-native commit
+    /// verification stays stateless on CI runners with no identity store. Empty
+    /// in bundles exported before this field existed. Wire form is unchanged — a
+    /// JSON array of event objects.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub kel: Vec<serde_json::Value>,
+    pub kel: Vec<auths_keri::Event>,
+    /// The CESR signature attachment (hex) for each `kel` event, in the same
+    /// order. Lets a stateless verifier AUTHENTICATE the bundle's KEL — verify
+    /// each event is signed by the controlling key-state — not just replay it
+    /// structurally (RT-002). A bundle whose `kel_attachments` length differs
+    /// from `kel`, or whose signatures don't verify, fails closed. Empty in
+    /// pre-RT-002 bundles.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub kel_attachments: Vec<String>,
     /// UTC timestamp when this bundle was created
     pub bundle_timestamp: DateTime<Utc>,
     /// Maximum age in seconds before this bundle is considered stale
@@ -1840,6 +1850,7 @@ mod tests {
             curve: Default::default(),
             attestation_chain: vec![],
             kel: vec![],
+            kel_attachments: vec![],
             bundle_timestamp: DateTime::parse_from_rfc3339("2099-01-01T00:00:00Z")
                 .unwrap()
                 .with_timezone(&Utc),
@@ -1890,6 +1901,7 @@ mod tests {
             curve: Default::default(),
             attestation_chain: vec![attestation],
             kel: vec![],
+            kel_attachments: vec![],
             bundle_timestamp: DateTime::parse_from_rfc3339("2099-01-01T00:00:00Z")
                 .unwrap()
                 .with_timezone(&Utc),

--- a/crates/auths-verifier/src/credential.rs
+++ b/crates/auths-verifier/src/credential.rs
@@ -28,8 +28,8 @@ use auths_keri::witness::agreement::WitnessAgreement;
 use crate::software_verify::verify_with_key_sync;
 use crate::{CanonicalDid, Capability, IdentityDID};
 use auths_keri::{
-    Acdc, CesrKey, Event, KeriPublicKey, KeyState, Prefix, Said, TelEvent, Threshold,
-    compute_capability_schema_said, validate_kel,
+    Acdc, CesrKey, Event, KeriPublicKey, KeyState, Prefix, Said, TelEvent, Threshold, TrustedKel,
+    compute_capability_schema_said,
 };
 use chrono::{DateTime, Utc};
 
@@ -240,7 +240,8 @@ pub fn verify_credential_sync(
         return CredentialVerdict::IssuerKelDuplicitous;
     }
 
-    let issuer_state = match validate_kel(issuer_kel) {
+    // rt-002-allow: issuer_kel is supplied by the caller from the local trusted registry / an already-authenticated bundle, and the ACDC + TEL lifecycle anchors below are bound to this issuer key-state. Residual: untrusted WASM credential input — a signature-carrying presentation format is the tracked RT-002 follow-up.
+    let issuer_state = match TrustedKel::from_trusted_source(issuer_kel).replay() {
         Ok(state) => state,
         Err(_) => return CredentialVerdict::RegistryNotEstablished,
     };
@@ -626,7 +627,8 @@ fn replay_to_seq(issuer_kel: &[Event], seq: u128) -> Option<KeyState> {
         .take_while(|e| e.sequence().value() <= seq)
         .cloned()
         .collect();
-    validate_kel(&subset).ok()
+    // rt-002-allow: re-replays a prefix of issuer_kel that the verify_credential entrypoint already authenticated (same trust basis), to recover a historical key-state at `seq`; introduces no new untrusted input.
+    TrustedKel::from_trusted_source(&subset).replay().ok()
 }
 
 /// Decode a CESR verkey into a curve-tagged key, or `None` if it is undecodable.

--- a/crates/auths-verifier/src/presentation.rs
+++ b/crates/auths-verifier/src/presentation.rs
@@ -34,11 +34,9 @@
 //!   once `now` passes `not_after`.
 
 use auths_crypto::CryptoProvider;
-use auths_keri::{
-    CesrKey, DelegatorKelLookup, Event, KeriPublicKey, KeyState, Prefix, Said, Seal, SourceSeal,
-    validate_kel_with_lookup,
-};
+use auths_keri::{CesrKey, Event, KelSealIndex, KeriPublicKey, KeyState, TrustedKel};
 use chrono::{DateTime, Utc};
+use subtle::ConstantTimeEq;
 
 use crate::credential::{CredentialVerdict, SignedAcdc, verify_credential_sync};
 use crate::software_verify::verify_with_key_sync;
@@ -52,35 +50,6 @@ const ROLE_FIELD: &str = "role";
 /// the F.4 issuance path. Surfaced on a `Valid` verdict for the F.6 bridge.
 const EXPIRY_FIELD: &str = "expiry";
 
-/// `DelegatorKelLookup` over an in-memory delegator KEL slice — answers "did the
-/// delegator anchor a seal for this delegated subject event?" by scanning its seals.
-///
-/// A credential subject (`a.i`) is typically a delegated device/agent whose `dip`/`drt`
-/// events are anchored in its delegator's KEL. Replaying the subject KEL to recover its
-/// *current* signing key therefore needs the delegator's anchoring seals; this provides
-/// them purely (no git/network), keeping the verify path WASM-safe.
-struct DelegatorSeals<'a> {
-    delegator_kel: &'a [Event],
-}
-
-impl DelegatorKelLookup for DelegatorSeals<'_> {
-    fn find_seal(&self, _delegator_aid: &Prefix, seal_said: &Said) -> Option<SourceSeal> {
-        for event in self.delegator_kel {
-            for seal in event.anchors() {
-                if let Seal::KeyEvent { d, .. } = seal
-                    && d == seal_said
-                {
-                    return Some(SourceSeal {
-                        s: event.sequence(),
-                        d: event.said().clone(),
-                    });
-                }
-            }
-        }
-        None
-    }
-}
-
 /// Replay the subject KEL to its current key-state, supplying delegator seals if needed.
 ///
 /// A non-delegated subject KEL (only `icp`/`rot`/`ixn`) replays with no lookup; a
@@ -88,10 +57,11 @@ impl DelegatorKelLookup for DelegatorSeals<'_> {
 /// `subject_delegator_kel`. An empty delegator KEL with a delegated subject yields a
 /// replay error (`SubjectKelInvalid`), which is the correct fail-closed outcome.
 fn replay_subject(subject_kel: &[Event], subject_delegator_kel: &[Event]) -> Option<KeyState> {
-    let lookup = DelegatorSeals {
-        delegator_kel: subject_delegator_kel,
-    };
-    validate_kel_with_lookup(subject_kel, Some(&lookup)).ok()
+    let lookup = KelSealIndex::from_events(subject_delegator_kel);
+    // rt-002-allow: subject_kel/delegator_kel are supplied by the caller from the local trusted registry / an authenticated bundle, and the presentation signature is bound to the resulting subject key-state. Residual: untrusted WASM presentation input — signature-carrying transport is the tracked RT-002 follow-up.
+    TrustedKel::from_trusted_source(subject_kel)
+        .replay_with_lookup(Some(&lookup))
+        .ok()
 }
 
 /// The presentation binding mode carried in a [`PresentationEnvelope`].
@@ -396,7 +366,12 @@ fn check_binding(
 ) -> Option<PresentationVerdict> {
     match (binding, expected_challenge) {
         (PresentationBinding::Challenge { nonce }, Some(expected)) => {
-            (nonce.as_slice() != expected).then_some(PresentationVerdict::NonceMismatchOrConsumed)
+            // Constant-time comparison: a short-circuiting `!=` leaks how many
+            // leading bytes matched via response timing, which can recover the
+            // nonce byte-by-byte across attempts (RT-015). `ct_eq` short-circuits
+            // only on length (not secret) and compares contents in constant time.
+            (!bool::from(nonce.as_slice().ct_eq(expected)))
+                .then_some(PresentationVerdict::NonceMismatchOrConsumed)
         }
         (PresentationBinding::Ttl { not_after, .. }, None) => {
             (now >= *not_after).then_some(PresentationVerdict::Expired)

--- a/crates/auths-verifier/src/verify.rs
+++ b/crates/auths-verifier/src/verify.rs
@@ -212,7 +212,8 @@ pub async fn verify_device_link(
     now: DateTime<Utc>,
     provider: &dyn CryptoProvider,
 ) -> DeviceLinkVerification {
-    let key_state = match auths_keri::validate_kel(events) {
+    // rt-002-allow: `events` is the device-link KEL supplied by the caller from the local trusted registry / an authenticated bundle, and the attestation signature is bound to the resulting key-state. Residual: the untrusted WASM verifyDeviceLink boundary — its authenticated counterpart is validateKelJson (which now routes through validate_signed_kel); a signature-carrying verifyDeviceLink input is the tracked RT-002 follow-up.
+    let key_state = match auths_keri::TrustedKel::from_trusted_source(events).replay() {
         Ok(ks) => ks,
         Err(e) => return DeviceLinkVerification::failure(format!("KEL verification failed: {e}")),
     };

--- a/crates/auths-verifier/src/wasm.rs
+++ b/crates/auths-verifier/src/wasm.rs
@@ -351,37 +351,71 @@ async fn verify_chain_with_witnesses_internal(
     Ok(report)
 }
 
-/// Verifies a KERI Key Event Log and returns the resulting key state as JSON.
+/// Authenticates a KERI Key Event Log and returns the resulting key state as JSON.
+///
+/// Every event must carry a valid CESR signature from its controlling key-state:
+/// `kel_json` is the JSON array of events and `attachments_json` a parallel JSON
+/// array of hex-encoded CESR signature attachments (one per event). The KEL is
+/// replayed through [`validate_signed_kel`](auths_keri::validate_signed_kel), so a
+/// forged or unsigned KEL fails closed (RT-002) — the structural-only
+/// `validate_kel` is deliberately NOT exposed across this untrusted boundary. A
+/// delegated (`dip`/`drt`) KEL also fails closed here, because a single-KEL
+/// entrypoint cannot supply the delegator's anchoring seals; resolve those through
+/// the bundle/org path that carries the delegator KEL alongside it.
 ///
 /// Args:
 /// * `kel_json`: JSON array of KEL events (inception, rotation, interaction).
+/// * `attachments_json`: JSON array of hex CESR signature attachments, one per event.
 ///
 /// Usage:
 /// ```ignore
-/// let key_state_json = validateKelJson("[{\"v\":\"KERI10JSON\",\"t\":\"icp\",...}]").await?;
+/// let key_state_json = validateKelJson(kelJson, attachmentsJson).await?;
 /// ```
 #[wasm_bindgen(js_name = validateKelJson)]
-pub async fn wasm_validate_kel_json(kel_json: &str) -> Result<String, JsValue> {
-    console_log!("WASM: Verifying KEL...");
+pub async fn wasm_validate_kel_json(
+    kel_json: &str,
+    attachments_json: &str,
+) -> Result<String, JsValue> {
+    console_log!("WASM: Authenticating KEL...");
 
-    if kel_json.len() > MAX_JSON_BATCH_SIZE {
+    if kel_json.len() > MAX_JSON_BATCH_SIZE || attachments_json.len() > MAX_JSON_BATCH_SIZE {
         return Err(JsValue::from_str(&format!(
-            "KEL JSON too large: {} bytes, max {}",
-            kel_json.len(),
-            MAX_JSON_BATCH_SIZE
+            "KEL input too large: max {MAX_JSON_BATCH_SIZE} bytes per field"
         )));
     }
 
     let events = auths_keri::parse_kel_json(kel_json)
         .map_err(|e| JsValue::from_str(&format!("Failed to parse KEL JSON: {}", e)))?;
+    let attachments: Vec<String> = serde_json::from_str(attachments_json)
+        .map_err(|e| JsValue::from_str(&format!("Failed to parse attachments JSON: {}", e)))?;
 
-    let key_state = auths_keri::validate_kel(&events)
-        .map_err(|e| JsValue::from_str(&format!("KEL verification failed: {}", e)))?;
+    // An absent/short attachment list is an UNAUTHENTICATED KEL — refuse it rather
+    // than fall back to a structural-only replay (that fallback is exactly RT-002).
+    if attachments.len() != events.len() {
+        return Err(JsValue::from_str(&format!(
+            "KEL/attachment length mismatch ({} events vs {} attachments): the KEL is \
+             unauthenticated, refusing (RT-002)",
+            events.len(),
+            attachments.len()
+        )));
+    }
 
-    console_log!(
-        "WASM: KEL verification successful, sequence: {}",
-        key_state.sequence
-    );
+    let signed: Vec<auths_keri::SignedEvent> = events
+        .into_iter()
+        .zip(attachments.iter())
+        .map(|(event, att_hex)| {
+            let bytes = hex::decode(att_hex)
+                .map_err(|e| JsValue::from_str(&format!("Invalid attachment hex: {}", e)))?;
+            let sigs = auths_keri::parse_attachment(&bytes)
+                .map_err(|e| JsValue::from_str(&format!("Invalid CESR attachment: {}", e)))?;
+            Ok(auths_keri::SignedEvent::new(event, sigs))
+        })
+        .collect::<Result<_, JsValue>>()?;
+
+    let key_state = auths_keri::validate_signed_kel(&signed, None)
+        .map_err(|e| JsValue::from_str(&format!("KEL authentication failed: {}", e)))?;
+
+    console_log!("WASM: KEL authenticated, sequence: {}", key_state.sequence);
 
     serde_json::to_string(&key_state)
         .map_err(|e| JsValue::from_str(&format!("Failed to serialize key state: {}", e)))

--- a/crates/auths-verifier/tests/cases/commit_kel.rs
+++ b/crates/auths-verifier/tests/cases/commit_kel.rs
@@ -458,11 +458,15 @@ async fn commit_after_revocation_rejected() {
 }
 
 #[tokio::test]
-async fn commit_before_revocation_passes_revocation_check() {
-    // Same revoked delegate, but the commit's in-band position (1) precedes the
-    // revocation (2): the revocation gate does NOT reject it — it proceeds to the
-    // signature check (this hand-built commit is unsigned, so `Unsigned`), proving
-    // legitimate prior history is not retroactively invalidated.
+async fn revoked_delegate_with_self_reported_prior_position_fails_closed() {
+    // RT-003 interim: the in-band `Auths-Anchor-Seq` is signer-chosen, so a
+    // "signed before revocation" claim (position 1 < revocation 2) is NOT a
+    // trustworthy ordering source — a revoked-but-unrotated key would simply
+    // claim a low position. Until an independent ordering signal exists
+    // (witness-receipted KSN / transparency log / signed git-history
+    // reachability), a currently-revoked delegate fails closed regardless of the
+    // self-reported position. (This over-rejects genuinely-prior history in the
+    // stateless verifier — the accepted interim cost.)
     let f = build(&fixture_device_key(), true, true, None);
     let commit = format!(
         "feat: earlier commit\n\nAuths-Id: {}\n{}\n",
@@ -477,14 +481,7 @@ async fn commit_before_revocation_passes_revocation_check() {
         &RingCryptoProvider,
     )
     .await;
-    assert!(
-        !matches!(
-            verdict,
-            CommitVerdict::SignedAfterRevocation { .. } | CommitVerdict::DeviceRevoked
-        ),
-        "a before-revocation commit must pass the revocation gate, got {verdict:?}"
-    );
-    assert_eq!(verdict, CommitVerdict::Unsigned);
+    assert_eq!(verdict, CommitVerdict::DeviceRevoked, "got {verdict:?}");
 }
 
 /// Build a delegated-agent fixture whose delegator anchors a scope/expiry seal for

--- a/crates/auths-verifier/tests/cases/kel_verification.rs
+++ b/crates/auths-verifier/tests/cases/kel_verification.rs
@@ -25,7 +25,7 @@ fn parse_kel_json_returns_empty_vec_for_empty_array() {
 
 #[test]
 fn validate_kel_rejects_empty_events() {
-    let result = auths_keri::validate_kel(&[]);
+    let result = auths_keri::TrustedKel::from_trusted_source(&[]).replay();
     assert!(result.is_err());
     match result.unwrap_err() {
         ValidationError::EmptyKel => {}

--- a/crates/xtask/src/check_verify_path_completeness.rs
+++ b/crates/xtask/src/check_verify_path_completeness.rs
@@ -1,0 +1,172 @@
+//! RT-002 verify-path completeness enforcement via tree-sitter.
+//!
+//! The stateless/embedded verify path must AUTHENTICATE a KEL — verify each
+//! event's signature against the controlling key-state via `validate_signed_kel`
+//! — not merely replay it structurally (`validate_kel*` / `replay_kel`, which
+//! check SAID + sequence + chain + commitment but never the signatures). A
+//! structural-only replay on an untrusted-input verify path is exactly the
+//! RT-002 forge: a hand-crafted, unsigned KEL replays to an attacker-chosen
+//! key-state and verifies.
+//!
+//! This lint bans the structural-only replays in the verifier + CLI-verify
+//! surfaces so a NEW untrusted-input entrypoint cannot silently reintroduce the
+//! class. A site that legitimately replays an already-authenticated or
+//! trusted-local KEL must carry an explicit `// rt-002-allow: <reason>`
+//! annotation (on the call line or a preceding comment line) documenting why
+//! structural replay is sound there — turning every exception into a reviewed,
+//! grep-able decision.
+
+use std::path::{Path, PathBuf};
+use walkdir::WalkDir;
+
+/// Structural-only KEL replays (and the trust assertion that unlocks them) — must
+/// not be reached from an untrusted-input verify path without an `rt-002-allow:`
+/// justification.
+///
+/// Post-#263, the bare `validate_kel*` replays are `pub(crate)` in auths-keri, so a
+/// verify-path crate can only structurally replay by minting a
+/// `TrustedKel::from_trusted_source(..)` — that explicit trust assertion is now the
+/// primary thing to gate here. The old `validate_kel*` names are kept for defence in
+/// depth (they can no longer be called cross-crate, but banning them is harmless).
+const BANNED_METHODS: &[&str] = &[
+    "from_trusted_source",
+    "validate_kel",
+    "validate_kel_with_lookup",
+    "validate_kel_with_receipts",
+    "replay_kel",
+];
+
+/// Verify-path surfaces where an untrusted KEL could be replayed.
+const BANNED_PATHS: &[&str] = &[
+    "crates/auths-verifier/src/",
+    "crates/auths-cli/src/commands/verify_commit.rs",
+];
+
+const EXEMPT_PATHS: &[&str] = &["/tests/", "/testing/", "/fakes/"];
+
+/// The inline marker that grandfathers a reviewed structural-replay site.
+const ALLOW_MARKER: &str = "rt-002-allow";
+
+struct Violation {
+    file: PathBuf,
+    line: usize,
+    col: usize,
+    name: String,
+}
+
+pub fn run(workspace_root: &Path) -> anyhow::Result<()> {
+    let mut parser = tree_sitter::Parser::new();
+    parser
+        .set_language(&tree_sitter_rust::LANGUAGE.into())
+        .expect("failed to set tree-sitter-rust language");
+
+    let mut violations = Vec::new();
+    let mut files_checked = 0u32;
+
+    for entry in WalkDir::new(workspace_root)
+        .into_iter()
+        .filter_entry(|e| {
+            let name = e.file_name().to_string_lossy();
+            if e.file_type().is_dir() {
+                return name != "target" && name != ".git" && name != "node_modules";
+            }
+            name.ends_with(".rs")
+        })
+        .filter_map(|e| e.ok())
+    {
+        let path = entry.path();
+        if path.extension().is_none_or(|ext| ext != "rs") {
+            continue;
+        }
+        let rel = path.strip_prefix(workspace_root).unwrap_or(path);
+        let rel_str = rel.to_string_lossy();
+
+        if !BANNED_PATHS.iter().any(|p| rel_str.starts_with(p)) {
+            continue;
+        }
+        if EXEMPT_PATHS.iter().any(|e| rel_str.contains(e)) {
+            continue;
+        }
+
+        let source = match std::fs::read_to_string(path) {
+            Ok(s) => s,
+            Err(_) => continue,
+        };
+        let tree = match parser.parse(&source, None) {
+            Some(t) => t,
+            None => continue,
+        };
+        files_checked += 1;
+        let lines: Vec<&str> = source.lines().collect();
+        check(tree.root_node(), &source, &lines, path, &mut violations);
+    }
+
+    if violations.is_empty() {
+        println!("verify-path-completeness check: {files_checked} files scanned, 0 violations");
+        Ok(())
+    } else {
+        println!(
+            "verify-path-completeness check: {} violation(s) in {} files",
+            violations.len(),
+            files_checked
+        );
+        for v in &violations {
+            let rel = v.file.strip_prefix(workspace_root).unwrap_or(&v.file);
+            println!(
+                "  {}:{}:{} — '{}' is a STRUCTURAL-only KEL replay on a verify path (RT-002). \
+                 Use `validate_signed_kel`, or add `// rt-002-allow: <why structural is sound here>`.",
+                rel.display(),
+                v.line,
+                v.col,
+                v.name
+            );
+        }
+        anyhow::bail!(
+            "{} verify-path-completeness violation(s): structural KEL replay reachable from an \
+             untrusted-input verify path. Authenticate via validate_signed_kel or annotate with \
+             rt-002-allow.",
+            violations.len()
+        )
+    }
+}
+
+fn check(
+    node: tree_sitter::Node,
+    source: &str,
+    lines: &[&str],
+    file: &Path,
+    violations: &mut Vec<Violation>,
+) {
+    let kind = node.kind();
+    if kind == "identifier" || kind == "field_identifier" {
+        let text = &source[node.byte_range()];
+        if BANNED_METHODS.contains(&text) {
+            if let Some(parent) = node.parent() {
+                let pk = parent.kind();
+                if pk == "call_expression" || pk == "field_expression" || pk == "scoped_identifier"
+                {
+                    let start = node.start_position();
+                    if !line_allowed(lines, start.row) {
+                        violations.push(Violation {
+                            file: file.to_path_buf(),
+                            line: start.row + 1,
+                            col: start.column + 1,
+                            name: text.to_string(),
+                        });
+                    }
+                }
+            }
+        }
+    }
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        check(child, source, lines, file, violations);
+    }
+}
+
+/// True if the call's line or one of the two preceding lines carries the
+/// `rt-002-allow` justification marker (`row` is 0-based).
+fn line_allowed(lines: &[&str], row: usize) -> bool {
+    let lo = row.saturating_sub(2);
+    (lo..=row).any(|i| lines.get(i).is_some_and(|l| l.contains(ALLOW_MARKER)))
+}

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -13,6 +13,7 @@ mod check_command_drift;
 mod check_constant_time;
 mod check_curve_agnostic;
 mod check_rfc6979;
+mod check_verify_path_completeness;
 mod gen_docs;
 mod gen_error_docs;
 mod gen_schema;
@@ -78,6 +79,10 @@ enum Command {
     /// Command-drift lint: fail if README.md or auths-cli string literals
     /// reference an `auths` command or long flag that doesn't exist.
     CheckCommandDrift,
+    /// RT-002 verify-path completeness: ban structural-only KEL replay
+    /// (`validate_kel*`/`replay_kel`) in the verifier + CLI-verify surfaces;
+    /// require `validate_signed_kel` or an explicit `rt-002-allow:` justification.
+    CheckVerifyPathCompleteness,
 }
 
 fn main() -> anyhow::Result<()> {
@@ -102,5 +107,8 @@ fn main() -> anyhow::Result<()> {
         Command::CheckRfc6979 => check_rfc6979::run(workspace_root()),
         Command::CheckAdmissionPolicy => check_admission_policy::run(workspace_root()),
         Command::CheckCommandDrift => check_command_drift::run(workspace_root()),
+        Command::CheckVerifyPathCompleteness => {
+            check_verify_path_completeness::run(workspace_root())
+        }
     }
 }

--- a/docs/prompts/red_team_2026_06_10.md
+++ b/docs/prompts/red_team_2026_06_10.md
@@ -7,6 +7,14 @@
 
 ---
 
+> **🔧 REMEDIATION STATUS — 2026-06-11 · branch `dev-security` · UNCOMMITTED (compile-verified, not yet committed).**
+> **✅ DONE (15):** A.0, A.2, A.3, A.4, A.5, B.1, B.2, C.1, C.3, C.4, D.1, E.1, E.2, F.3, F.4.
+> **✅ A.1 / RT-002 — CLOSED for every signature-carrying transport (2026-06-11).** Root cause was the `Arc<dyn RegistryBackend>` blanket impl silently dropping signature attachments via lossy trait defaults. Fixed across all backends (Git/Fake/Postgres/Arc now persist + expose attachments). Authenticated at every untrusted boundary whose wire format can carry CESR signatures: **(1) CI `--identity-bundle`** → `kel_attachments` + `validate_signed_kel` in `load_bundle_trust` (**5/5 e2e, incl. 2 negatives: stripped + forged → fail closed**); **(2) org air-gapped bundle** → `authenticate_bundled_kel` → `validate_signed_kel` over org + delegated member KELs in `offline_verify.rs` (forged-signature negative test; **closes #233**); **(3) WASM `validateKelJson`** → now takes `attachments_json`, routes through `validate_signed_kel`, fails closed on absent/short attachments.
+> **✅ A.0 — `check-verify-path-completeness` xtask lint LANDED + CI-wired.** Bans structural `validate_kel*`/`replay_kel` on the verifier + CLI-verify surfaces unless the site carries an `rt-002-allow:` justification. The 7 grandfathered sites (commit_kel ×3, credential ×2, presentation, verify) are KELs authenticated at the ingestion boundary (bundle → `validate_signed_kel`; local registry = trusted store) — each annotated.
+> **⏸ TRACKED RESIDUAL (#262):** the untrusted transports whose wire format carries **no** signatures today — `--oobi` (bare-event JSON body), `--remote` stranger git fetch (reconcile drops attachments), and WASM `verifyDeviceLink`/credential/presentation (bare `Vec<Event>` inputs). Each needs a signature-carrying format + `validate_signed_kel`; the lint's `rt-002-allow:` annotations point at #262. (Plan: `~/.claude/plans/do-you-need-to-warm-hummingbird.md`.)
+> Remaining M2/M3 tasks not started: C.2, C.5, E.3, E.4, D.2–D.5, F.1, F.2, F.5, 0.2, 0.3.
+> Notes: E.2 makes `auths-crypto`/`auths-core` `--all-features` fail by design (both pull `fips`+`cnsa`) — use targeted features. A.3 now over-rejects genuinely-prior commits from a *revoked* key in the stateless verifier (accepted interim cost until a witness/transparency ordering source exists) — check the agent-demo if it demonstrates revoked-key history.
+
 ## 1. Executive summary
 
 **Overall posture: Critical-risk.** The cryptographic verification core — the one
@@ -364,7 +372,7 @@ TASK D.1 (RT-016 `Zeroizing` return).
 
 ### Milestone 0 — Test & CI safety net (do first)
 
-#### TASK 0.1 — Adversarial KEL fixture corpus
+#### 🟡 PARTIAL — TASK 0.1 — Adversarial KEL fixture corpus
 **Severity:** CRITICAL (enables M1)
 **Fixes:** prerequisite for RT-001, RT-002, RT-003
 **Vulnerability:** There is no negative test asserting the verifier *rejects* a forged
@@ -403,7 +411,9 @@ anchor-seq. Without these, M1 fixes can regress silently.
 
 ### Milestone 1 — CRITICAL (Epic A: Verifier fail-closed hardening)
 
-#### TASK A.0 — Make the verify path signature-typed (retire the bug-class)
+#### ✅ DONE (lint) — TASK A.0 — Make the verify path signature-typed (retire the bug-class)
+> **2026-06-11:** BOTH halves landed. (1) The `check-verify-path-completeness` xtask lint is implemented + CI-wired. (2) The stronger **type-level** half is done (#263 P1): `validate_kel`/`_with_lookup`/`_with_receipts`/`_with_policy` are now `pub(crate)` in auths-keri and the `replay_kel` alias is removed; the only cross-crate structural-replay surface is `auths_keri::TrustedKel`, constructed via the explicit `TrustedKel::from_trusted_source(..)` (trusted-local) or implied by `validate_signed_kel` (authenticated). **Calling structural replay on bare `&[Event]` from outside auths-keri is now a compile error.** The lint switched to gating the `from_trusted_source` assertion on verify paths (defence in depth). auths-id mints `TrustedKel` once at its registry-read boundary; the 7 verifier sites assert it explicitly with `rt-002-allow:`. Full workspace builds + all touched suites green (auths-keri/id/verifier/sdk/cli).
+
 **Severity:** CRITICAL (structural prevention — this is what stops RT-001/002/005 *recurring*)
 **Fixes:** RT-002 class at the root (the durable counterpart to A.1's logic)
 **Vulnerability:** The bug-class behind all three CRITICALs is that a *structural-only* replay (`validate_kel`/`replay_kel_gated`) is **public** and is the function every untrusted-input entrypoint reaches for. As long as a structural-only API exists and is callable with bare `Event`s, the next new entrypoint (a future language port, a new FFI export) can forget the signature/`i==d` check and silently reintroduce the forge. A test catches an instance; only the type system retires the class.
@@ -414,7 +424,9 @@ anchor-seq. Without these, M1 fixes can regress silently.
 **Regression risk:** Medium — touches every verify entrypoint's signature. De-risk: land A.0+A.1 on one branch behind the M0 corpus; happy-path fixtures must stay green.
 **Depends on:** 0.1
 
-#### TASK A.1 — Verify KEL event signatures on every replay path
+#### ✅ DONE (signature-carrying transports) — TASK A.1 — Verify KEL event signatures on every replay path
+> **2026-06-11:** `validate_signed_kel` authenticates every untrusted boundary whose wire format carries CESR signatures — CI `--identity-bundle` (`load_bundle_trust`, 5/5 e2e incl. 2 negatives), org air-gapped bundle (`offline_verify.rs`, closes #233), and WASM `validateKelJson` (now takes `attachments_json`). Storage persists/exposes attachments on all backends. Residual untrusted transports with no signature-carrying format (`--oobi`, `--remote` stranger, WASM `verifyDeviceLink`/credential/presentation) are tracked in **#262**; their structural sites are `rt-002-allow:`-annotated and lint-gated.
+
 **Severity:** CRITICAL
 **Fixes:** RT-002 (and largely collapses RT-001/RT-005)
 **Vulnerability:** `validate_kel*`/`replay_kel_gated` authorize by log structure alone; no event is checked to be signed by the controlling key-state. `validate_signed_event` (the only signature-verifying function) has zero non-test callers. An attacker supplies a KEL with forged `icp`/`ixn`/`rot` events and the verifier replays them as authoritative.
@@ -438,7 +450,7 @@ anchor-seq. Without these, M1 fixes can regress silently.
 > rotation or re-opens the forge. Mirror `validate_signed_event` exactly; it already
 > encodes the dual-index logic.
 
-#### TASK A.2 — Enforce inception self-certification (`i == d`) on the replay path
+#### ✅ DONE — TASK A.2 — Enforce inception self-certification (`i == d`) on the replay path
 **Severity:** CRITICAL
 **Fixes:** RT-001
 **Vulnerability:** `validate_inception` adopts `icp.i` as the controller prefix without asserting `i == d`; `compute_said` blanks `i`, so the SAID does not bind the prefix. A forged inception claims any prefix with attacker keys.
@@ -455,7 +467,7 @@ anchor-seq. Without these, M1 fixes can regress silently.
 > **Trap to avoid:** basic-derivation (non-`E`) prefixes must check `i == k[0]`, not be
 > skipped — otherwise a `D…`/`1AAI…` prefix can still point at an arbitrary key list.
 
-#### TASK A.3 — Bind the signing position to a verifiable anchor (kill self-asserted anchor-seq)
+#### ✅ DONE (interim) — TASK A.3 — Bind the signing position to a verifiable anchor (kill self-asserted anchor-seq)
 **Severity:** CRITICAL
 **Fixes:** RT-003
 **Vulnerability:** Revocation ordering trusts `Auths-Anchor-Seq`, a trailer the signer writes. A revoked-but-unrotated key signs `Valid` commits forever by claiming a pre-revocation position.
@@ -478,7 +490,7 @@ anchor-seq. Without these, M1 fixes can regress silently.
 > the `SignedBefore` branch — that would invalidate legitimate historical commits;
 > replace its *input* with a non-attacker-controlled one.
 
-#### TASK A.4 — Stop self-pinning bundle roots without independent self-certification
+#### ✅ DONE — TASK A.4 — Stop self-pinning bundle roots without independent self-certification
 **Severity:** HIGH (CRITICAL in combination — closes the RT-001 delivery vehicle)
 **Fixes:** RT-005
 **Vulnerability:** `verify-commit --identity-bundle` pushes the bundle's own `identity_did` into `pinned_roots` after only a freshness check; trust anchor and evidence come from the same untrusted file.
@@ -489,7 +501,7 @@ anchor-seq. Without these, M1 fixes can regress silently.
 **Regression risk:** Low once A.1/A.2 land.
 **Depends on:** A.1, A.2
 
-#### TASK A.5 — Constant-time challenge-nonce comparison
+#### ✅ DONE — TASK A.5 — Constant-time challenge-nonce comparison
 **Severity:** MEDIUM (grouped here as a quick win on the verify path)
 **Fixes:** RT-015
 **Vulnerability:** The presentation challenge nonce is compared with a short-circuiting `!=`.
@@ -506,7 +518,7 @@ anchor-seq. Without these, M1 fixes can regress silently.
 
 #### Epic B — Network-service authz & resource bounds
 
-#### TASK B.1 — Wire the SCIM capability allowlist; empty must mean deny, not allow
+#### ✅ DONE — TASK B.1 — Wire the SCIM capability allowlist; empty must mean deny, not allow
 **Severity:** HIGH
 **Fixes:** RT-006 (and RT-026)
 **Vulnerability:** `validate_capabilities` treats an empty allowlist as permit-all, the setter is never called, and `TenantBootstrap` lacks the field — every tenant runs permit-all and can anchor arbitrary capabilities into the org KEL.
@@ -517,7 +529,7 @@ anchor-seq. Without these, M1 fixes can regress silently.
 **Regression risk:** Medium — flips a default; document the opt-in and update deployment kit.
 **Depends on:** none
 
-#### TASK B.2 — Bound batch revoke and load the root KEL once
+#### ✅ DONE — TASK B.2 — Bound batch revoke and load the root KEL once
 **Severity:** MEDIUM (grouped with B-epic)
 **Fixes:** RT-013
 **Vulnerability:** `batch_revoke_agents` does a full root-KEL walk per agent with no size cap and no body limit.
@@ -530,7 +542,7 @@ anchor-seq. Without these, M1 fixes can regress silently.
 
 #### Epic C — FFI & WASM memory-safety + parity
 
-#### TASK C.1 — Null-guard `ffi_import_key`
+#### ✅ DONE — TASK C.1 — Null-guard `ffi_import_key`
 **Severity:** HIGH (quick win)
 **Fixes:** RT-009
 **Vulnerability:** `slice::from_raw_parts(key_ptr, key_len)` with no null check → UB.
@@ -552,7 +564,7 @@ anchor-seq. Without these, M1 fixes can regress silently.
 **Regression risk:** Medium (changes wire acceptance — pre-launch, acceptable).
 **Depends on:** none
 
-#### TASK C.3 — WASM attestation path: decompress P-256 like native
+#### ✅ DONE — TASK C.3 — WASM attestation path: decompress P-256 like native
 **Severity:** HIGH
 **Fixes:** RT-007
 **Vulnerability:** The 33-byte compressed-key branch in `webcrypto_provider.rs` is `native`-only, so the WASM attestation/chain verifier rejects the preferred CESR key form.
@@ -563,7 +575,7 @@ anchor-seq. Without these, M1 fixes can regress silently.
 **Regression risk:** Low.
 **Depends on:** 0.2
 
-#### TASK C.4 — Enforce low-S in the WASM ECDSA path
+#### ✅ DONE — TASK C.4 — Enforce low-S in the WASM ECDSA path
 **Severity:** HIGH
 **Fixes:** RT-008
 **Vulnerability:** WebCrypto accepts high-S P-256 signatures that native rejects → malleability/verdict divergence.
@@ -587,7 +599,7 @@ anchor-seq. Without these, M1 fixes can regress silently.
 
 #### Epic E — Supply-chain & build integrity
 
-#### TASK E.1 — Add `--locked` to every build and publish
+#### ✅ DONE — TASK E.1 — Add `--locked` to every build and publish
 **Severity:** HIGH (quick win)
 **Fixes:** RT-011
 **Vulnerability:** Publish re-resolves deps, shipping a tree CI never tested.
@@ -598,7 +610,7 @@ anchor-seq. Without these, M1 fixes can regress silently.
 **Regression risk:** None.
 **Depends on:** none
 
-#### TASK E.2 — Add the missing FIPS/CNSA `compile_error!` (or implement `check-feature-sanity`)
+#### ✅ DONE — TASK E.2 — Add the missing FIPS/CNSA `compile_error!` (or implement `check-feature-sanity`)
 **Severity:** HIGH (quick win)
 **Fixes:** RT-012
 **Vulnerability:** Enabling both features silently degrades CNSA to FIPS primitives (accepts P-256/ChaCha); the documented xtask guard does not exist.
@@ -637,7 +649,7 @@ anchor-seq. Without these, M1 fixes can regress silently.
 
 #### Epic D — Secret handling
 
-#### TASK D.1 — Return `Zeroizing` PKCS#8 seed at the build boundary
+#### ✅ DONE — TASK D.1 — Return `Zeroizing` PKCS#8 seed at the build boundary
 **Severity:** MEDIUM (quick win)
 **Fixes:** RT-016
 **Files:** `crates/auths-crypto/src/key_material.rs:132-147`, `crates/auths-core/src/api/runtime.rs:379`, `crates/auths-core/src/crypto/ssh/keys.rs:39`.
@@ -709,7 +721,7 @@ anchor-seq. Without these, M1 fixes can regress silently.
 **Regression risk:** Low.
 **Depends on:** none
 
-#### TASK F.3 — Make rotation key-deletion observable; pin alias enumeration
+#### ✅ DONE — TASK F.3 — Make rotation key-deletion observable; pin alias enumeration
 **Severity:** MEDIUM
 **Fixes:** RT-014
 **Files:** `crates/auths-sdk/src/domains/identity/rotation.rs:222,229-231`.
@@ -719,7 +731,7 @@ anchor-seq. Without these, M1 fixes can regress silently.
 **Regression risk:** Low.
 **Depends on:** none
 
-#### TASK F.4 — Pin GitHub Actions to SHAs; add `--ignore-scripts`; `--frozen-lockfile`
+#### ✅ DONE — TASK F.4 — Pin GitHub Actions to SHAs; add `--ignore-scripts`; `--frozen-lockfile`
 **Severity:** LOW
 **Fixes:** RT-029, RT-030, RT-020
 **Files:** all `.github/workflows/*.yml`.

--- a/packages/auths-python/Cargo.lock
+++ b/packages/auths-python/Cargo.lock
@@ -542,6 +542,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "subtle",
  "thiserror 2.0.18",
 ]
 
@@ -5028,11 +5029,3 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
-
-[[patch.unused]]
-name = "radicle-core"
-version = "0.1.0"
-
-[[patch.unused]]
-name = "radicle-crypto"
-version = "0.14.0"

--- a/scripts/releases/2_crates.py
+++ b/scripts/releases/2_crates.py
@@ -107,7 +107,7 @@ def cargo_login_configured() -> bool:
         return False
     # Try a dry-run publish to check token — just verify cargo config exists
     result = subprocess.run(
-        ["cargo", "publish", "-p", "auths", "--dry-run"],
+        ["cargo", "publish", "-p", "auths", "--dry-run", "--locked"],
         capture_output=True,
         text=True,
         cwd=CARGO_TOML.parent,
@@ -120,7 +120,7 @@ def cargo_login_configured() -> bool:
 def publish_crate(crate_name: str) -> bool:
     print(f"  Publishing {crate_name}...", flush=True)
     result = subprocess.run(
-        ["cargo", "publish", "-p", crate_name],
+        ["cargo", "publish", "-p", crate_name, "--locked"],
         capture_output=True,
         text=True,
         cwd=CARGO_TOML.parent,


### PR DESCRIPTION
## Summary
Closes the red-team audit's systemic CRITICAL **RT-002** (stateless verify paths replayed KELs by structure only, never checking event signatures) plus the surrounding findings, and hardens the verify path at the type level (#263).

### RT-002 — authenticate KEL signatures at every untrusted boundary
- **Storage:** all `RegistryBackend` impls (Git/Fake/Postgres/Arc) persist + expose CESR signature attachments; the lossy trait defaults that silently dropped them (the root cause) are removed.
- **CI `--identity-bundle`:** `IdentityBundle` carries `kel_attachments`; `load_bundle_trust` authenticates via `validate_signed_kel` (+ stripped/forged-signature negative e2e).
- **Org air-gapped bundle:** `offline_verify` authenticates the org KEL + each delegated member KEL.
- **WASM `validateKelJson`:** takes attachments, routes through `validate_signed_kel`, fails closed.
- **A.0 lint:** `xtask check-verify-path-completeness` (CI-wired) gates structural replay on the verify surfaces.

### #263 — type-level hardening
- **P1:** `validate_kel*` are `pub(crate)`; the only cross-crate structural-replay surface is `auths_keri::TrustedKel`. **Bare-`&[Event]` structural replay outside auths-keri is now a compile error.**
- **P2:** `KelSealIndex` replaces three duplicate `DelegatorKelLookup` impls.
- **P3:** `IdentityBundle.kel` is `Vec<Event>` (not `Vec<serde_json::Value>`); named `BundleKel`.

### Other findings
A.2 (i==d on replay), A.3/A.4/A.5, B.1 (SCIM allowlist), B.2, C.1/C.3/C.4, D.1, E.1/E.2, F.3/F.4.

### Tooling
E.2's fips/cnsa `compile_error!` makes `--all-features` uncompilable, so the clippy hook + CI clippy/nextest now lint/test the bulk workspace `--all-features` minus the 5 dual-provider crypto crates, then exercise those 5 under each provider (fips, cnsa) separately.

### Merge note
The merge of `main` (0.1.3) resolved a `verify_commit.rs` trust-precedence conflict **in favor of the RT-005/A.4 fix**: a `--identity-bundle` is evidence-only and must match an independent pin; it never self-pins its own root (main's side had reverted to the self-pinning vuln — intentionally not taken).

Residuals tracked in #262 (remote/oobi/WASM signature-carrying transports) and #263 (P1 design follow-ups).
