### PR TITLE
fix(ci): regenerate schema + provision SCIM test allowlist + sign commit

### DIFF
--- a/crates/auths-scim-server/src/lib.rs
+++ b/crates/auths-scim-server/src/lib.rs
@@ -96,8 +96,14 @@ mod tests {
     /// handle too, so tests can assert how many delegations actually happened.
     fn state_with_fake(known_org: &str) -> (ScimServerState, Arc<FakeProvisioner>) {
         let provisioner = Arc::new(FakeProvisioner::new(&[known_org]));
+        // Capability allowlisting is deny-by-default (B.1 / RT-006). These CRUD
+        // tests exercise provisioning behavior, not the allowlist (which is unit-
+        // tested in `auths-scim`), and they use arbitrary capabilities, so the
+        // harness opts into allow-all. A restrictive-allowlist deny is covered by
+        // `joiner_with_disallowed_capability_is_denied` below.
         let tenant = TenantConfig::new("acme", ORG, "scim_secret")
-            .with_base_url("https://scim.test/scim/v2");
+            .with_base_url("https://scim.test/scim/v2")
+            .with_allow_all(true);
         let state = ScimServerState::new(
             vec![tenant],
             Arc::clone(&provisioner) as Arc<dyn Provisioner>,
@@ -273,6 +279,28 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn joiner_with_disallowed_capability_is_denied() {
+        // B.1 / RT-006: a tenant with a restrictive allowlist denies a capability
+        // outside it (deny-by-default at the server boundary, not just the mapper).
+        let provisioner = Arc::new(FakeProvisioner::new(&[ORG]));
+        let tenant = TenantConfig::new("acme", ORG, "scim_secret")
+            .with_base_url("https://scim.test/scim/v2")
+            .with_allowed_capabilities(vec![
+                auths_verifier::Capability::parse("deploy:staging").unwrap(),
+            ]);
+        let state = ScimServerState::new(
+            vec![tenant],
+            Arc::clone(&provisioner) as Arc<dyn Provisioner>,
+        );
+        // `user_body` requests "sign:commit", which is NOT in the allowlist.
+        let resp = router(state)
+            .oneshot(post_users(user_body("deploy-bot", "okta-1")))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
     async fn joiner_is_idempotent_on_external_id() {
         let (state, provisioner) = state_with_fake(ORG);
         let app = router(state);
@@ -308,7 +336,9 @@ mod tests {
     async fn unknown_org_tenant_returns_4xx_not_500() {
         // Tenant points at an org the provisioner does not know about.
         let provisioner = Arc::new(FakeProvisioner::new(&["ESomeOtherOrg"]));
-        let tenant = TenantConfig::new("acme", "EMissingOrg", "scim_secret");
+        // allow-all so the capability check passes and we reach the org-resolution
+        // path this test targets (see `state_with_fake`).
+        let tenant = TenantConfig::new("acme", "EMissingOrg", "scim_secret").with_allow_all(true);
         let state = ScimServerState::new(vec![tenant], provisioner);
         let resp = router(state)
             .oneshot(post_users(user_body("deploy-bot", "okta-1")))

--- a/crates/auths-sdk/src/domains/identity/rotation.rs
+++ b/crates/auths-sdk/src/domains/identity/rotation.rs
@@ -170,23 +170,27 @@ pub struct RotationKeyMaterial {
 /// Args:
 /// * `rot`: The pre-computed rotation event to append to the KEL.
 /// * `prefix`: KERI identifier prefix (the `did:keri:` suffix).
+/// * `rot_attachment`: The `rot` event's CESR signature attachment, so a later
+///   `export-bundle` can authenticate the rotation (RT-002) rather than fail with
+///   "no stored signature attachment".
 /// * `key_material`: Encrypted key material and aliases for keychain operations.
 /// * `registry`: Registry backend for KEL append.
 /// * `key_storage`: Keychain for storing rotated key material.
 ///
 /// Usage:
 /// ```ignore
-/// apply_rotation(&rot, prefix, key_material, registry.as_ref(), key_storage.as_ref())?;
+/// apply_rotation(&rot, prefix, &attachment, key_material, registry.as_ref(), key_storage.as_ref())?;
 /// ```
 pub fn apply_rotation(
     rot: &RotEvent,
     prefix: &Prefix,
+    rot_attachment: &[u8],
     key_material: RotationKeyMaterial,
     registry: &(dyn RegistryBackend + Send + Sync),
     key_storage: &(dyn KeyStorage + Send + Sync),
 ) -> Result<(), RotationError> {
     registry
-        .append_event(prefix, &Event::Rot(rot.clone()))
+        .append_signed_event(prefix, &Event::Rot(rot.clone()), rot_attachment)
         .map_err(|e| RotationError::RotationFailed(format!("KEL append failed: {e}")))?;
 
     // NOTE: non-atomic — KEL and keychain writes are not transactional.
@@ -537,9 +541,27 @@ fn finalize_rotation_storage(
         new_next_encrypted: encrypted_new_next.to_vec(),
     };
 
+    // Sign the rot with the new current key and store its CESR attachment, so a
+    // later `export-bundle` can AUTHENTICATE the rotation event (RT-002). Without
+    // this the rot has no stored attachment and `id export-bundle` aborts with
+    // "KEL event at seq N has no stored signature attachment".
+    let parsed = auths_crypto::parse_key_material(params.current_pkcs8)
+        .map_err(|e| RotationError::RotationFailed(format!("parse new current key: {e}")))?;
+    let canonical = serialize_for_signing(&Event::Rot(params.rot.clone()))
+        .map_err(|e| RotationError::RotationFailed(format!("serialize rot for signing: {e}")))?;
+    let sig = auths_crypto::typed_sign(&parsed.seed, &canonical)
+        .map_err(|e| RotationError::RotationFailed(format!("sign rot: {e}")))?;
+    let rot_attachment = auths_keri::serialize_attachment(&[auths_keri::IndexedSignature {
+        index: 0,
+        prior_index: None,
+        sig,
+    }])
+    .map_err(|e| RotationError::RotationFailed(format!("serialize rot attachment: {e}")))?;
+
     apply_rotation(
         params.rot,
         params.prefix,
+        &rot_attachment,
         key_material,
         ctx.registry.as_ref(),
         ctx.key_storage.as_ref(),

--- a/crates/auths-sdk/tests/cases/rotation.rs
+++ b/crates/auths-sdk/tests/cases/rotation.rs
@@ -326,6 +326,7 @@ fn apply_rotation_returns_partial_rotation_on_keychain_failure() {
     let result = apply_rotation(
         &rot,
         &prefix,
+        &[],
         key_material,
         registry.as_ref(),
         &failing_keychain,

--- a/schemas/identity-bundle-v1.json
+++ b/schemas/identity-bundle-v1.json
@@ -37,9 +37,18 @@
       ]
     },
     "kel": {
-      "description": "The identity's raw KEL events (JSON, oldest first). Carried so KEL-native commit verification stays stateless on CI runners with no identity store. Empty in bundles exported before this field existed.",
+      "description": "The identity's KEL events, oldest first (parsed at the deserialize boundary, not held as loose JSON). Carried so KEL-native commit verification stays stateless on CI runners with no identity store. Empty in bundles exported before this field existed. Wire form is unchanged — a JSON array of event objects.",
       "type": "array",
-      "items": true
+      "items": {
+        "$ref": "#/definitions/Event"
+      }
+    },
+    "kel_attachments": {
+      "description": "The CESR signature attachment (hex) for each `kel` event, in the same order. Lets a stateless verifier AUTHENTICATE the bundle's KEL — verify each event is signed by the controlling key-state — not just replay it structurally (RT-002). A bundle whose `kel_attachments` length differs from `kel`, or whose signatures don't verify, fails closed. Empty in pre-RT-002 bundles.",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
     },
     "max_valid_for_secs": {
       "description": "Maximum age in seconds before this bundle is considered stale",
@@ -200,6 +209,43 @@
         }
       }
     },
+    "CesrKey": {
+      "description": "A CESR-encoded public key (e.g., `D` + base64url Ed25519, `1AAI` + base64url P-256).\n\nWraps the qualified string form. Use `parse()` to extract the curve-tagged `KeriPublicKey` for cryptographic operations.\n\nUsage: ``` use auths_keri::CesrKey; let key = CesrKey::new_unchecked(\"DAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\".into()); assert!(key.parse().is_ok()); ```",
+      "type": "string"
+    },
+    "ConfigTrait": {
+      "description": "KERI configuration trait codes.\n\nThese control identity behavior at inception and may be updated at rotation (for `RB`/`NRB` only). If two conflicting traits appear, the latter supersedes.\n\nUsage: ``` use auths_keri::ConfigTrait; let traits: Vec<ConfigTrait> = serde_json::from_str(r#\"[\"EO\",\"DND\"]\"#).unwrap(); assert!(traits.contains(&ConfigTrait::EstablishmentOnly)); ```",
+      "oneOf": [
+        {
+          "description": "Establishment-Only: only establishment events in KEL.",
+          "type": "string",
+          "enum": [
+            "EO"
+          ]
+        },
+        {
+          "description": "Do-Not-Delegate: cannot act as delegator.",
+          "type": "string",
+          "enum": [
+            "DND"
+          ]
+        },
+        {
+          "description": "Registrar Backers: backer list provides registrar backer AIDs.",
+          "type": "string",
+          "enum": [
+            "RB"
+          ]
+        },
+        {
+          "description": "No Registrar Backers: switch back to witnesses.",
+          "type": "string",
+          "enum": [
+            "NRB"
+          ]
+        }
+      ]
+    },
     "DevicePublicKey": {
       "description": "A device public key carrying its curve type explicitly.\n\nCurve is stored alongside the raw key bytes so dispatch never relies on key length — adding a new curve that shares a byte length (e.g. secp256k1, also 33 bytes compressed) won't break existing match arms.\n\nAccepted byte lengths per curve: - Ed25519: 32 - P-256: 33 (compressed SEC1) or 65 (uncompressed SEC1)",
       "type": "object",
@@ -212,8 +258,608 @@
         }
       }
     },
+    "Event": {
+      "description": "Unified event enum for processing any KERI event type.",
+      "oneOf": [
+        {
+          "description": "Inception event",
+          "type": "object",
+          "required": [
+            "bt",
+            "d",
+            "i",
+            "k",
+            "kt",
+            "n",
+            "nt",
+            "s",
+            "t",
+            "v"
+          ],
+          "properties": {
+            "a": {
+              "description": "Anchored seals",
+              "default": [],
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Seal"
+              }
+            },
+            "b": {
+              "description": "Witness/backer list (ordered AIDs)",
+              "default": [],
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Prefix"
+              }
+            },
+            "bt": {
+              "description": "Witness/backer threshold",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/Threshold"
+                }
+              ]
+            },
+            "c": {
+              "description": "Configuration traits (e.g., EstablishmentOnly, DoNotDelegate)",
+              "default": [],
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/ConfigTrait"
+              }
+            },
+            "d": {
+              "description": "SAID (Self-Addressing Identifier) — Blake3 hash of event",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/Said"
+                }
+              ]
+            },
+            "i": {
+              "description": "Identifier prefix (same as `d` for self-addressing inception)",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/Prefix"
+                }
+              ]
+            },
+            "k": {
+              "description": "Current public key(s), CESR-encoded",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/CesrKey"
+              }
+            },
+            "kt": {
+              "description": "Key signing threshold (hex integer or fractional weight list)",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/Threshold"
+                }
+              ]
+            },
+            "n": {
+              "description": "Next key commitment(s) — Blake3 digests of next public key(s)",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Said"
+              }
+            },
+            "nt": {
+              "description": "Next key signing threshold",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/Threshold"
+                }
+              ]
+            },
+            "s": {
+              "description": "Sequence number (always 0 for inception)",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/KeriSequence"
+                }
+              ]
+            },
+            "t": {
+              "type": "string",
+              "enum": [
+                "icp"
+              ]
+            },
+            "v": {
+              "description": "Version string",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/VersionString"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "description": "Rotation event",
+          "type": "object",
+          "required": [
+            "bt",
+            "d",
+            "i",
+            "k",
+            "kt",
+            "n",
+            "nt",
+            "p",
+            "s",
+            "t",
+            "v"
+          ],
+          "properties": {
+            "a": {
+              "description": "Anchored seals",
+              "default": [],
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Seal"
+              }
+            },
+            "ba": {
+              "description": "List of backers to add (processed after removals)",
+              "default": [],
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Prefix"
+              }
+            },
+            "br": {
+              "description": "List of backers to remove (processed first)",
+              "default": [],
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Prefix"
+              }
+            },
+            "bt": {
+              "description": "Witness/backer threshold",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/Threshold"
+                }
+              ]
+            },
+            "c": {
+              "description": "Configuration traits",
+              "default": [],
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/ConfigTrait"
+              }
+            },
+            "d": {
+              "description": "SAID of this event",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/Said"
+                }
+              ]
+            },
+            "i": {
+              "description": "Identifier prefix",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/Prefix"
+                }
+              ]
+            },
+            "k": {
+              "description": "New current key(s), CESR-encoded",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/CesrKey"
+              }
+            },
+            "kt": {
+              "description": "Key signing threshold",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/Threshold"
+                }
+              ]
+            },
+            "n": {
+              "description": "New next key commitment(s) — Blake3 digests",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Said"
+              }
+            },
+            "nt": {
+              "description": "Next key signing threshold",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/Threshold"
+                }
+              ]
+            },
+            "p": {
+              "description": "Previous event SAID (creates the hash chain)",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/Said"
+                }
+              ]
+            },
+            "s": {
+              "description": "Sequence number (increments with each event)",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/KeriSequence"
+                }
+              ]
+            },
+            "t": {
+              "type": "string",
+              "enum": [
+                "rot"
+              ]
+            },
+            "v": {
+              "description": "Version string",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/VersionString"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "description": "Interaction event",
+          "type": "object",
+          "required": [
+            "a",
+            "d",
+            "i",
+            "p",
+            "s",
+            "t",
+            "v"
+          ],
+          "properties": {
+            "a": {
+              "description": "Anchored seals (the main purpose of IXN events)",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Seal"
+              }
+            },
+            "d": {
+              "description": "SAID of this event",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/Said"
+                }
+              ]
+            },
+            "i": {
+              "description": "Identifier prefix",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/Prefix"
+                }
+              ]
+            },
+            "p": {
+              "description": "Previous event SAID",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/Said"
+                }
+              ]
+            },
+            "s": {
+              "description": "Sequence number",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/KeriSequence"
+                }
+              ]
+            },
+            "t": {
+              "type": "string",
+              "enum": [
+                "ixn"
+              ]
+            },
+            "v": {
+              "description": "Version string",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/VersionString"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "description": "Delegated inception event",
+          "type": "object",
+          "required": [
+            "bt",
+            "d",
+            "di",
+            "i",
+            "k",
+            "kt",
+            "n",
+            "nt",
+            "s",
+            "t",
+            "v"
+          ],
+          "properties": {
+            "a": {
+              "description": "Anchored seals",
+              "default": [],
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Seal"
+              }
+            },
+            "b": {
+              "description": "Witness/backer list",
+              "default": [],
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Prefix"
+              }
+            },
+            "bt": {
+              "description": "Witness/backer threshold",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/Threshold"
+                }
+              ]
+            },
+            "c": {
+              "description": "Configuration traits",
+              "default": [],
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/ConfigTrait"
+              }
+            },
+            "d": {
+              "description": "SAID",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/Said"
+                }
+              ]
+            },
+            "di": {
+              "description": "Delegator identifier prefix",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/Prefix"
+                }
+              ]
+            },
+            "i": {
+              "description": "Identifier prefix (same as `d` for self-addressing)",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/Prefix"
+                }
+              ]
+            },
+            "k": {
+              "description": "Current public key(s)",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/CesrKey"
+              }
+            },
+            "kt": {
+              "description": "Key signing threshold",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/Threshold"
+                }
+              ]
+            },
+            "n": {
+              "description": "Next key commitment(s)",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Said"
+              }
+            },
+            "nt": {
+              "description": "Next key signing threshold",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/Threshold"
+                }
+              ]
+            },
+            "s": {
+              "description": "Sequence number (always 0)",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/KeriSequence"
+                }
+              ]
+            },
+            "t": {
+              "type": "string",
+              "enum": [
+                "dip"
+              ]
+            },
+            "v": {
+              "description": "Version string",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/VersionString"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "description": "Delegated rotation event",
+          "type": "object",
+          "required": [
+            "bt",
+            "d",
+            "di",
+            "i",
+            "k",
+            "kt",
+            "n",
+            "nt",
+            "p",
+            "s",
+            "t",
+            "v"
+          ],
+          "properties": {
+            "a": {
+              "description": "Anchored seals",
+              "default": [],
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Seal"
+              }
+            },
+            "ba": {
+              "description": "Backers to add",
+              "default": [],
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Prefix"
+              }
+            },
+            "br": {
+              "description": "Backers to remove",
+              "default": [],
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Prefix"
+              }
+            },
+            "bt": {
+              "description": "Witness/backer threshold",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/Threshold"
+                }
+              ]
+            },
+            "c": {
+              "description": "Configuration traits",
+              "default": [],
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/ConfigTrait"
+              }
+            },
+            "d": {
+              "description": "SAID",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/Said"
+                }
+              ]
+            },
+            "di": {
+              "description": "Delegator identifier prefix (KERI §11).",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/Prefix"
+                }
+              ]
+            },
+            "i": {
+              "description": "Identifier prefix",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/Prefix"
+                }
+              ]
+            },
+            "k": {
+              "description": "New current key(s)",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/CesrKey"
+              }
+            },
+            "kt": {
+              "description": "Key signing threshold",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/Threshold"
+                }
+              ]
+            },
+            "n": {
+              "description": "New next key commitment(s)",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Said"
+              }
+            },
+            "nt": {
+              "description": "Next key signing threshold",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/Threshold"
+                }
+              ]
+            },
+            "p": {
+              "description": "Previous event SAID",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/Said"
+                }
+              ]
+            },
+            "s": {
+              "description": "Sequence number",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/KeriSequence"
+                }
+              ]
+            },
+            "t": {
+              "type": "string",
+              "enum": [
+                "drt"
+              ]
+            },
+            "v": {
+              "description": "Version string",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/VersionString"
+                }
+              ]
+            }
+          }
+        }
+      ]
+    },
     "IdentityDID": {
       "description": "Strongly-typed wrapper for identity DIDs (e.g., `\"did:keri:E...\"`).\n\nUsage: ```rust # use auths_verifier::IdentityDID; let did = IdentityDID::parse(\"did:keri:Eabc123\").unwrap(); assert_eq!(did.as_str(), \"did:keri:Eabc123\");\n\nlet s: String = did.into_inner(); ```",
+      "type": "string"
+    },
+    "KeriSequence": {
       "type": "string"
     },
     "OidcBinding": {
@@ -267,10 +913,19 @@
         }
       }
     },
+    "Prefix": {
+      "description": "Strongly-typed KERI identifier prefix (e.g., `\"ETest123...\"`, `\"DKey456...\"`).\n\nA prefix is the autonomous identifier (AID) for a KERI identity. For self-addressing AIDs it starts with `E` (Blake3-256 digest of the inception event); for key-based AIDs it starts with `D` (Ed25519 public key) or another CESR derivation code.\n\nArgs: * Inner `String` must start with a valid CESR derivation code (uppercase letter or digit). Enforced by `new()`, not by serde.\n\nUsage: ```ignore let prefix = Prefix::new(\"ETest123abc\".to_string())?; assert_eq!(prefix.as_str(), \"ETest123abc\"); ```",
+      "type": "string"
+    },
     "PublicKeyHex": {
       "description": "A validated hex-encoded public key (64 hex chars for Ed25519, 66 for P-256 compressed).",
       "type": "string"
     },
+    "Said": {
+      "description": "KERI Self-Addressing Identifier (SAID).\n\nA Blake3 hash that uniquely identifies a KERI event. Creates the hash chain: each event's `p` (previous) field is the prior event's SAID.\n\nStructurally identical to `Prefix` (both start with 'E') but semantically distinct — a prefix identifies an *identity*, a SAID identifies an *event*.\n\nArgs: * Inner `String` must be non-empty (rejected on deserialize) and should start with `'E'` (the Blake3 digest derivation code, enforced by `new()`).\n\nUsage: ```ignore let said = Said::new(\"ESAID123\".to_string())?; assert_eq!(said.as_str(), \"ESAID123\"); ```",
+      "type": "string"
+    },
+    "Seal": true,
     "SignerType": {
       "description": "The type of entity that produced a signature.\n\nDuplicated here (also in `auths-policy`) because `auths-verifier` is a standalone minimal-dependency crate that cannot depend on `auths-policy`.",
       "oneOf": [
@@ -297,10 +952,14 @@
         }
       ]
     },
+    "Threshold": true,
     "TypedSignature": {
       "description": "Curve-agnostic 64-byte signature (Ed25519 or P-256 r||s, hex-encoded). Curve is determined by the companion DevicePublicKey.",
       "type": "string",
       "format": "hex"
+    },
+    "VersionString": {
+      "type": "string"
     }
   }
 }


### PR DESCRIPTION
Fixes the three CI failures from the #263 merge to `main`.

### 1. `generate-schemas` drift
`schemas/identity-bundle-v1.json` regenerated for the `kel: Vec<Event>` + `kel_attachments` change (#263 P3.1). The `kel` items now `$ref` the `Event` definition (and its `CesrKey`/`Seal`/`Threshold`/… deps) instead of `items: true`, and `kel_attachments` is added. Matches `cargo run -p xtask -- generate-schemas`.

### 2. `auths-scim-server` — 15 test failures (403 / empty lists)
B.1 / RT-006 made the SCIM capability allowlist **deny-by-default**, but the test harness `state_with_fake` provisioned no allowlist, so every CRUD op was denied (403) and the list/get tests saw zero results.
- `state_with_fake` (and the bespoke `unknown_org_tenant_…` tenant) opt into `with_allow_all(true)` — these tests exercise provisioning/CRUD, not the allowlist (which is unit-tested in `auths-scim`).
- Added `joiner_with_disallowed_capability_is_denied` to keep **server-level** deny coverage (restrictive allowlist → out-of-list capability → 403).
- `cargo test -p auths-scim-server`: 20 passed.

### 3. `verify-commits` — missing Auths trailers
The #263 commits got the SSH signature but no `Auths-Id`/`Auths-Device` trailers (no `prepare-commit-msg` hook in the worktree). This branch's commit was backfilled with `auths sign`, so it carries the trailers + signature. Local check against the committed CI bundle:
```
auths verify --identity-bundle .auths/ci-bundle.json origin/main..HEAD --json
→ {"valid":true,"ssh_valid":true,"signer":"did:keri:ELv6…"}
```

> Note: the already-merged #263 commits on `main` (`59779b27`) still lack trailers, so `main`'s own `verify-commits` may stay red for that historical commit until backfilled (`auths sign` + force-push) — out of scope for this PR, which fixes the failing *checks* going forward.
