### PR TITLE
fix: finish IdentityDID single-door + bump git2 to 0.21 (CI hotfix)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3411,15 +3411,14 @@ dependencies = [
 
 [[package]]
 name = "git2"
-version = "0.20.4"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b88256088d75a56f8ecfa070513a775dd9107f6530ef14919dac831af9cfe2b"
+checksum = "ddddbf932745a6be37109b6112d3ee09696106f848449069d3a57bba937ab82e"
 dependencies = [
  "bitflags",
  "libc",
  "libgit2-sys",
  "log",
- "url",
 ]
 
 [[package]]
@@ -4292,9 +4291,9 @@ checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.18.3+1.9.2"
+version = "0.18.5+1.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9b3acc4b91781bb0b3386669d325163746af5f6e4f73e6d2d630e09a35f3487"
+checksum = "005d6ae6eac1912906073e069f7db60b1fa98e052a68227824afe3e3a1c59ca2"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ bs58 = "0.5.1"
 base64 = "0.22.1"
 thiserror = "2"
 uuid = { version = "1", features = ["v4"] }
-git2 = { version = "0.20.4", default-features = false, features = ["vendored-libgit2"] }
+git2 = { version = "0.21.0", default-features = false, features = ["vendored-libgit2"] }
 glob = "0.3"
 parking_lot = "0.12"
 schemars = "0.8"

--- a/crates/auths-cli/src/commands/org.rs
+++ b/crates/auths-cli/src/commands/org.rs
@@ -535,7 +535,7 @@ pub fn handle_org(
                 now,
                 auths_sdk::attestation::AttestationInput {
                     rid: &rid,
-                    identity_did: &issuer_canonical,
+                    issuer: &issuer_canonical,
                     subject: &subject_device_did,
                     device_public_key: &device_pk_bytes,
                     device_curve,

--- a/crates/auths-cli/src/commands/status.rs
+++ b/crates/auths-cli/src/commands/status.rs
@@ -301,7 +301,7 @@ fn maybe_format_duplicity_warning(_report: &StatusReport) -> Option<String> {
         Err(_) => return None,
     };
     for r in refs.filter_map(|r| r.ok()) {
-        let Some(name) = r.name() else { continue };
+        let Ok(name) = r.name() else { continue };
         let Some(rest) = name.strip_prefix(prefix_str) else {
             continue;
         };

--- a/crates/auths-cli/src/errors/registry.rs
+++ b/crates/auths-cli/src/errors/registry.rs
@@ -343,6 +343,7 @@ pub fn explain(code: &str) -> Option<&'static str> {
         // --- auths-id (CacheError) ---
         "AUTHS-E4986" => Some("# AUTHS-E4986\n\n**Crate:** `auths-id`\n\n**Type:** `CacheError::Io`\n\n## Message\n\nI/O error: {0}\n"),
         "AUTHS-E4987" => Some("# AUTHS-E4987\n\n**Crate:** `auths-id`\n\n**Type:** `CacheError::Json`\n\n## Message\n\nJSON serialization error: {0}\n"),
+        "AUTHS-E4988" => Some("# AUTHS-E4988\n\n**Crate:** `auths-id`\n\n**Type:** `CacheError::InvalidDid`\n\n## Message\n\ninvalid DID: {0}\n\n## Suggestion\n\nThe DID must be a 'did:keri:' identity\n"),
 
         // --- auths-id (HookError) ---
         "AUTHS-E4991" => Some("# AUTHS-E4991\n\n**Crate:** `auths-id`\n\n**Type:** `HookError::Io`\n\n## Message\n\nIO error: {0}\n\n## Suggestion\n\nCheck file permissions on the Git hooks directory\n"),
@@ -753,6 +754,7 @@ pub fn all_codes() -> &'static [&'static str] {
         "AUTHS-E4984",
         "AUTHS-E4986",
         "AUTHS-E4987",
+        "AUTHS-E4988",
         "AUTHS-E4991",
         "AUTHS-E4992",
         "AUTHS-E5001",
@@ -906,6 +908,6 @@ mod tests {
 
     #[test]
     fn all_codes_count_matches_registry() {
-        assert_eq!(all_codes().len(), 367);
+        assert_eq!(all_codes().len(), 368);
     }
 }

--- a/crates/auths-cli/tests/cases/revocation.rs
+++ b/crates/auths-cli/tests/cases/revocation.rs
@@ -84,7 +84,7 @@ fn test_emergency_revoke_device() {
         .references()
         .unwrap()
         .filter_map(|r| r.ok())
-        .filter_map(|r| r.name().map(|n| n.to_string()))
+        .filter_map(|r| r.name().ok().map(|n| n.to_string()))
         .collect();
     let has_attestation_refs = refs.iter().any(|r| r.contains("auths"));
     assert!(

--- a/crates/auths-id/src/attestation/create.rs
+++ b/crates/auths-id/src/attestation/create.rs
@@ -44,7 +44,7 @@ pub struct AttestationInput<'a> {
     /// The issuer DID — `did:keri:` for an identity, or a `did:key:` for an
     /// ephemeral key acting as its own issuer. Typed as `&CanonicalDid` so both
     /// shapes are representable without an unvalidated construction.
-    pub identity_did: &'a CanonicalDid,
+    pub issuer: &'a CanonicalDid,
     /// The subject of the attestation — typed as `&CanonicalDid` so
     /// callers can supply either `did:key:` or `did:keri:` shapes. The
     /// wire format (`Attestation.subject`) is also `CanonicalDid`, so
@@ -100,7 +100,7 @@ pub fn create_signed_attestation(
 ) -> Result<Attestation, AttestationError> {
     let AttestationInput {
         rid,
-        identity_did,
+        issuer,
         subject,
         device_public_key,
         device_curve,
@@ -138,7 +138,7 @@ pub fn create_signed_attestation(
 
     // Build attestation with empty signatures first (ActionEnvelope pattern). The issuer is
     // already a CanonicalDid (did:keri for an identity, did:key for an ephemeral self-issuer).
-    let issuer_canonical = identity_did.clone();
+    let issuer_canonical = issuer.clone();
     #[allow(clippy::disallowed_methods)]
     // INVARIANT: subject is a validated CanonicalDid from the caller
     let subject_canonical = CanonicalDid::new_unchecked(subject.as_str());

--- a/crates/auths-id/src/attestation/load.rs
+++ b/crates/auths-id/src/attestation/load.rs
@@ -15,8 +15,8 @@ pub fn load_attestations_by_prefix(
 
     for reference in refs.filter_map(Result::ok) {
         let name = match reference.name() {
-            Some(name) => name,
-            None => continue,
+            Ok(name) => name,
+            Err(_) => continue,
         };
 
         if name.starts_with(ref_prefix) {

--- a/crates/auths-id/src/keri/anchor.rs
+++ b/crates/auths-id/src/keri/anchor.rs
@@ -412,11 +412,11 @@ pub fn verify_attestation_anchor_by_issuer<T: serde::Serialize>(
 mod tests {
     use super::*;
     use crate::keri::{Prefix, create_keri_identity_with_curve};
-    use auths_verifier::IdentityDID;
     use auths_core::crypto::signer::encrypt_keypair;
     use auths_core::signing::StorageSigner;
     use auths_core::storage::keychain::{KeyAlias, KeyRole, KeyStorage};
     use auths_core::testing::{IsolatedKeychainHandle, TestPassphraseProvider};
+    use auths_verifier::IdentityDID;
     use serde::{Deserialize, Serialize};
     use tempfile::TempDir;
 

--- a/crates/auths-id/src/storage/git_refs.rs
+++ b/crates/auths-id/src/storage/git_refs.rs
@@ -29,7 +29,7 @@ pub fn aggregate_canonical_refs(
         let refs = repo.references_glob(&format!("{}/refs/**", prefix))?;
 
         for r in refs.flatten() {
-            if let Some(name) = r.name()
+            if let Ok(name) = r.name()
                 && let Some(target) = r.target()
             {
                 // Use first seen version of each ref

--- a/crates/auths-id/src/storage/receipts.rs
+++ b/crates/auths-id/src/storage/receipts.rs
@@ -181,7 +181,7 @@ impl ReceiptStorage for GitReceiptStorage {
 
         for reference in repo.references()? {
             let reference = reference?;
-            if let Some(name) = reference.name()
+            if let Ok(name) = reference.name()
                 && name.starts_with(&prefix_path)
                 && let Some(said) = name.strip_prefix(&format!("{}/", prefix_path))
             {

--- a/crates/auths-id/tests/cases/attestation_input_golden.rs
+++ b/crates/auths-id/tests/cases/attestation_input_golden.rs
@@ -47,7 +47,7 @@ fn canonical_bytes_are_byte_stable_under_fixed_seed() {
 
     let input = AttestationInput {
         rid: "golden-rid",
-        identity_did: &identity_did,
+        issuer: &identity_did,
         subject: &subject,
         device_public_key: &pub_compressed,
         device_curve: auths_crypto::CurveType::P256,
@@ -100,7 +100,7 @@ fn canonical_bytes_digest_is_stable_across_invocations() {
 fn test_build_attestation(input: &AttestationInput<'_>) -> auths_verifier::core::Attestation {
     use auths_verifier::core::{Attestation, Ed25519Signature, ResourceId};
 
-    let issuer_canonical = input.identity_did.clone();
+    let issuer_canonical = input.issuer.clone();
     #[allow(clippy::disallowed_methods)]
     let subject_canonical = CanonicalDid::new_unchecked(input.subject.as_str());
 

--- a/crates/auths-id/tests/cases/lifecycle.rs
+++ b/crates/auths-id/tests/cases/lifecycle.rs
@@ -119,7 +119,7 @@ fn create_test_attestation(
         now,
         auths_id::attestation::create::AttestationInput {
             rid,
-            identity_did: &identity_did,
+            issuer: &identity_did,
             subject,
             device_public_key: device_pk,
             // Test fixture: ring Ed25519KeyPair pubkey (32 bytes by construction).

--- a/crates/auths-index/src/index.rs
+++ b/crates/auths-index/src/index.rs
@@ -763,9 +763,7 @@ mod tests {
             )
             .unwrap();
 
-        let err = index
-            .list_org_members_indexed("did:keri:EOrg")
-            .unwrap_err();
+        let err = index.list_org_members_indexed("did:keri:EOrg").unwrap_err();
         assert!(matches!(err, crate::error::IndexError::InvalidDid(_)));
     }
 }

--- a/crates/auths-index/src/rebuild.rs
+++ b/crates/auths-index/src/rebuild.rs
@@ -42,7 +42,7 @@ pub fn rebuild_attestations_from_git(
     {
         let refs_scan = repo.references()?;
         for reference in refs_scan.filter_map(|r| r.ok()) {
-            if let Some(name) = reference.name()
+            if let Ok(name) = reference.name()
                 && name.starts_with(DEPRECATED_ATTESTATION_PREFIX)
             {
                 return Err(IndexError::DeprecatedPrefix(
@@ -60,8 +60,8 @@ pub fn rebuild_attestations_from_git(
 
     for reference in refs.filter_map(|r| r.ok()) {
         let name = match reference.name() {
-            Some(name) => name,
-            None => continue,
+            Ok(name) => name,
+            Err(_) => continue,
         };
 
         // Check if this ref matches our attestation pattern

--- a/crates/auths-infra-git/src/audit.rs
+++ b/crates/auths-infra-git/src/audit.rs
@@ -86,7 +86,7 @@ impl GitLogProvider for Git2LogProvider {
                 author_name: author.name().unwrap_or("unknown").to_string(),
                 author_email: author.email().unwrap_or("").to_string(),
                 timestamp: format_commit_time(&commit),
-                message: commit.summary().unwrap_or("").to_string(),
+                message: commit.summary().ok().flatten().unwrap_or("").to_string(),
                 signature_status,
             });
         }

--- a/crates/auths-infra-git/src/helpers.rs
+++ b/crates/auths-infra-git/src/helpers.rs
@@ -52,7 +52,7 @@ pub(crate) fn list_refs_matching(
     let mut result = Vec::new();
     for reference in repo.references_glob(glob)? {
         let reference = reference?;
-        if let Some(name) = reference.name() {
+        if let Ok(name) = reference.name() {
             result.push(name.to_string());
         }
     }

--- a/crates/auths-mcp-core/src/budget.rs
+++ b/crates/auths-mcp-core/src/budget.rs
@@ -243,9 +243,9 @@ impl ReservedHolds {
 
     /// Total cents currently held (the `Σ(active holds)` term of `available`).
     pub fn reserved_cents(&self) -> Cents {
-        self.holds
-            .iter()
-            .fold(Cents::ZERO, |acc, h| acc.saturating_add(h.ceiling_cents.cents()))
+        self.holds.iter().fold(Cents::ZERO, |acc, h| {
+            acc.saturating_add(h.ceiling_cents.cents())
+        })
     }
 
     /// Take a hold for `ceiling` (the caller must have checked `available`
@@ -373,11 +373,7 @@ impl CrossRailBudget {
     /// refused [`SettleOutcome::RolledBack`] if the new cumulative would fall below the
     /// recorded high-water). The hold is released REGARDLESS of the monotonicity
     /// outcome so a rolled-back settle does not leak the reservation.
-    pub fn settle(
-        &mut self,
-        hold: Hold,
-        actual: Actual,
-    ) -> Result<SettleOutcome, BudgetError> {
+    pub fn settle(&mut self, hold: Hold, actual: Actual) -> Result<SettleOutcome, BudgetError> {
         // Release the auth-hold first: the slack (ceiling − actual) returns to
         // available, and a rolled-back settle below does not strand the reservation.
         self.holds.release(hold);
@@ -572,14 +568,24 @@ mod tests {
                 std::thread::spawn(move || {
                     // RESERVE under the lock — the pre-auth boundary. The guard drops at the
                     // end of this statement, releasing the lock before the "rail".
-                    let hold = match b.lock().unwrap().reserve(Ceiling::new(Cents::new(amount))).unwrap() {
+                    let hold = match b
+                        .lock()
+                        .unwrap()
+                        .reserve(Ceiling::new(Cents::new(amount)))
+                        .unwrap()
+                    {
                         ReserveOutcome::Reserved { hold, .. } => Some(hold),
                         ReserveOutcome::Refused { .. } => None,
                     };
                     match hold {
                         Some(hold) => {
                             std::thread::yield_now(); // "rail" touched WITHOUT the lock
-                            match b.lock().unwrap().settle(hold, Actual::new(Cents::new(amount))).unwrap() {
+                            match b
+                                .lock()
+                                .unwrap()
+                                .settle(hold, Actual::new(Cents::new(amount)))
+                                .unwrap()
+                            {
                                 SettleOutcome::Advanced { .. } => {
                                     settled.fetch_add(1, Ordering::SeqCst);
                                 }

--- a/crates/auths-mcp-core/src/money.rs
+++ b/crates/auths-mcp-core/src/money.rs
@@ -252,12 +252,18 @@ mod tests {
     fn atomic_usdc_produces_a_typed_ceiling_and_actual() {
         // The reserve ceiling rounds up; the settle actual is exact-or-refused — the same split as
         // the bare-cents conversions, but now carried in distinct types.
-        assert_eq!(AtomicUsdc::new(1_500_000).to_ceiling().cents(), Cents::new(150));
+        assert_eq!(
+            AtomicUsdc::new(1_500_000).to_ceiling().cents(),
+            Cents::new(150)
+        );
         assert_eq!(
             AtomicUsdc::new(1_500_000).to_actual().map(Actual::cents),
             Some(Cents::new(150))
         );
-        assert_eq!(AtomicUsdc::new(1_505_000).to_ceiling().cents(), Cents::new(151));
+        assert_eq!(
+            AtomicUsdc::new(1_505_000).to_ceiling().cents(),
+            Cents::new(151)
+        );
         assert_eq!(AtomicUsdc::new(1_505_000).to_actual(), None);
     }
 }

--- a/crates/auths-mcp-gateway/src/replay.rs
+++ b/crates/auths-mcp-gateway/src/replay.rs
@@ -309,7 +309,8 @@ async fn drive_call(
         if let Some(hold) = decision.hold {
             // Settle the ACTUAL the rail's response reports — for an extracted call this
             // is `charge.amount_captured` read from the response, not an agent number.
-            let (settle_verdict, new_cumulative) = gate.settle(budget, hold, Actual::new(cost.settle_cents))?;
+            let (settle_verdict, new_cumulative) =
+                gate.settle(budget, hold, Actual::new(cost.settle_cents))?;
             // A clean settle keeps Allowed; a rollback (replayed/stale total) flips the
             // verdict to usage-counter-rolled-back (the D8 monotonicity guard).
             verdict = settle_verdict;
@@ -362,14 +363,8 @@ async fn drive_call(
             } else {
                 auths_mcp_core::call_commit_binding(&proof_bytes)
             };
-            let (mut bytes, _sha) = chain.sign_settlement(
-                idx,
-                &call_binding,
-                rail_name,
-                settle,
-                charge,
-                cumulative,
-            )?;
+            let (mut bytes, _sha) =
+                chain.sign_settlement(idx, &call_binding, rail_name, settle, charge, cumulative)?;
             // Adversarial harness hook: when AUTHS_MCP_SETTLE_TAMPER is set, flip a byte of the
             // SIGNED settlement after signing — simulating an operator that alters the agent's
             // settled cost. The signature no longer matches, so the offline audit catches it.

--- a/crates/auths-rp/src/registry_sync.rs
+++ b/crates/auths-rp/src/registry_sync.rs
@@ -365,7 +365,7 @@ mod git {
             let r = r.map_err(|e| SyncError::Repository {
                 detail: format!("reading ref failed: {e}"),
             })?;
-            if let (Some(name), Some(oid)) = (r.name(), r.target()) {
+            if let (Ok(name), Some(oid)) = (r.name(), r.target()) {
                 tips.insert(name.to_string(), oid);
             }
         }

--- a/crates/auths-sdk/src/domains/agents/delegation.rs
+++ b/crates/auths-sdk/src/domains/agents/delegation.rs
@@ -226,7 +226,7 @@ fn record_delegation_attestation(
         now,
         AttestationInput {
             rid,
-            identity_did: &issuer_canonical,
+            issuer: &issuer_canonical,
             subject: &subject,
             device_public_key: &agent_pk,
             device_curve: agent_pk_curve,

--- a/crates/auths-sdk/src/domains/device/service.rs
+++ b/crates/auths-sdk/src/domains/device/service.rs
@@ -244,7 +244,7 @@ pub fn extend_device(
         now,
         auths_id::attestation::create::AttestationInput {
             rid: &identity.storage_id,
-            identity_did: &issuer_canonical,
+            issuer: &issuer_canonical,
             subject: &device_did_obj,
             device_public_key: latest.device_public_key.as_bytes(),
             device_curve: latest.device_public_key.curve(),
@@ -350,7 +350,7 @@ fn sign_attestation(
         now,
         auths_id::attestation::create::AttestationInput {
             rid,
-            identity_did: &issuer_canonical,
+            issuer: &issuer_canonical,
             subject: &params.device_did,
             device_public_key: params.device_public_key.as_bytes(),
             device_curve: params.device_public_key.curve(),

--- a/crates/auths-sdk/src/domains/identity/service.rs
+++ b/crates/auths-sdk/src/domains/identity/service.rs
@@ -167,9 +167,7 @@ fn initialize_agent(
         .clone()
         .map(IdentityDID::try_from)
         .transpose()
-        .map_err(|e| {
-            SetupError::InvalidSetupConfig(format!("invalid parent identity did: {e}"))
-        })?;
+        .map_err(|e| SetupError::InvalidSetupConfig(format!("invalid parent identity did: {e}")))?;
 
     let provisioning_config = AgentProvisioningConfig {
         agent_name: config.alias.to_string(),
@@ -340,7 +338,7 @@ fn bind_device(
         now,
         auths_id::attestation::create::AttestationInput {
             rid: &managed.storage_id,
-            identity_did: &issuer_canonical,
+            issuer: &issuer_canonical,
             subject: &device_did,
             device_public_key: &pk_bytes,
             device_curve: curve,

--- a/crates/auths-sdk/src/domains/org/service.rs
+++ b/crates/auths-sdk/src/domains/org/service.rs
@@ -280,7 +280,7 @@ pub fn create_org(
         now,
         AttestationInput {
             rid: &rid,
-            identity_did: &issuer_canonical,
+            issuer: &issuer_canonical,
             subject: &org_did,
             device_public_key: &org_pk_bytes,
             device_curve: org_curve,

--- a/crates/auths-sdk/src/domains/signing/service.rs
+++ b/crates/auths-sdk/src/domains/signing/service.rs
@@ -650,7 +650,7 @@ fn create_and_sign_attestation(
         now,
         auths_id::attestation::create::AttestationInput {
             rid: rid.as_str(),
-            identity_did: &issuer_canonical,
+            issuer: &issuer_canonical,
             subject,
             device_public_key: device_pk_bytes,
             device_curve,
@@ -815,7 +815,7 @@ pub fn sign_artifact_ephemeral(
         now,
         auths_id::attestation::create::AttestationInput {
             rid: rid.as_str(),
-            identity_did: &device_did,
+            issuer: &device_did,
             subject: &device_did,
             device_public_key: &pubkey_vec,
             device_curve: curve,
@@ -932,7 +932,7 @@ pub fn sign_artifact_raw(
         now,
         auths_id::attestation::create::AttestationInput {
             rid: rid.as_str(),
-            identity_did: &issuer_canonical,
+            issuer: &issuer_canonical,
             subject: &device_did,
             device_public_key: &pubkey,
             device_curve: curve,

--- a/crates/auths-sdk/src/workflows/platform.rs
+++ b/crates/auths-sdk/src/workflows/platform.rs
@@ -325,10 +325,9 @@ fn resolve_signing_key_alias(
     ctx: &AuthsContext,
     controller_did: &str,
 ) -> Result<KeyAlias, PlatformError> {
-    let identity_did =
-        IdentityDID::parse(controller_did).map_err(|e| PlatformError::Platform {
-            message: format!("invalid controller did: {e}"),
-        })?;
+    let identity_did = IdentityDID::parse(controller_did).map_err(|e| PlatformError::Platform {
+        message: format!("invalid controller did: {e}"),
+    })?;
     let aliases = ctx
         .key_storage
         .list_aliases_for_identity(&identity_did)

--- a/crates/auths-storage/src/git/adapter.rs
+++ b/crates/auths-storage/src/git/adapter.rs
@@ -1424,12 +1424,11 @@ impl RegistryBackend for GitRegistryBackend {
         let expected_issuer = expected_org_issuer(org);
         // The org's issuer DID is identical for every member file under this org,
         // so validate it once: did:keri:{org} for a non-empty org prefix.
-        let org_did = IdentityDID::parse(&expected_issuer).map_err(|e| {
-            RegistryError::InvalidPrefix {
+        let org_did =
+            IdentityDID::parse(&expected_issuer).map_err(|e| RegistryError::InvalidPrefix {
                 prefix: org.to_string(),
                 reason: e.to_string(),
-            }
-        })?;
+            })?;
 
         navigator.visit_dir(&members_parts, |filename| {
             // Strip .json extension
@@ -1591,19 +1590,17 @@ impl RegistryBackend for GitRegistryBackend {
 
         let members: Vec<MemberView> = indexed
             .into_iter()
-            .map(|m| {
-                MemberView {
-                    did: m.member_did.clone(),
-                    status: MemberStatus::Active,
-                    role: None,
-                    capabilities: vec![],
-                    issuer: m.issuer_did,
-                    rid: m.rid,
-                    revoked_at: m.revoked_at,
-                    expires_at: m.expires_at,
-                    timestamp: None,
-                    source_filename: String::new(),
-                }
+            .map(|m| MemberView {
+                did: m.member_did.clone(),
+                status: MemberStatus::Active,
+                role: None,
+                capabilities: vec![],
+                issuer: m.issuer_did,
+                rid: m.rid,
+                revoked_at: m.revoked_at,
+                expires_at: m.expires_at,
+                timestamp: None,
+                source_filename: String::new(),
             })
             .collect();
 

--- a/crates/auths-storage/src/git/standalone_attestation.rs
+++ b/crates/auths-storage/src/git/standalone_attestation.rs
@@ -189,7 +189,7 @@ impl AttestationSource for GitAttestationStorage {
                             }
                         };
 
-                        if let Some(full_ref_name) = reference.name() {
+                        if let Ok(full_ref_name) = reference.name() {
                             let prefix_to_strip = format!("{}/", pattern_base);
                             if let Some(suffix) = full_ref_name.strip_prefix(&prefix_to_strip)
                                 && let Some(sanitized_did) = suffix.strip_suffix("/signatures")

--- a/crates/auths-storage/src/git/tree_ops.rs
+++ b/crates/auths-storage/src/git/tree_ops.rs
@@ -140,7 +140,7 @@ impl<'a> TreeNavigator<'a> {
         };
 
         for entry in tree.iter() {
-            if let Some(name) = entry.name()
+            if let Ok(name) = entry.name()
                 && visitor(name).is_break()
             {
                 break;
@@ -222,7 +222,7 @@ impl TreeMutator {
         // First, get all existing children from base tree
         if let Some(tree) = base {
             for entry in tree.iter() {
-                if let Some(name) = entry.name() {
+                if let Ok(name) = entry.name() {
                     children.insert(
                         name.to_string(),
                         ChildEntry {

--- a/crates/auths-transparency/src/verify.rs
+++ b/crates/auths-transparency/src/verify.rs
@@ -1137,10 +1137,7 @@ mod tests {
             entry,
         };
 
-        (
-            vec![link(device_bind, 0), link(org_add_member, 1)],
-            root,
-        )
+        (vec![link(device_bind, 0), link(org_add_member, 1)], root)
     }
 
     #[test]
@@ -1153,10 +1150,7 @@ mod tests {
         bundle.delegation_chain = chain;
 
         let delegation = verify_delegation_chain(&bundle);
-        assert!(matches!(
-            delegation,
-            DelegationStatus::ChainVerified { .. }
-        ));
+        assert!(matches!(delegation, DelegationStatus::ChainVerified { .. }));
     }
 
     #[test]

--- a/crates/auths-verifier/tests/cases/ffi_smoke.rs
+++ b/crates/auths-verifier/tests/cases/ffi_smoke.rs
@@ -49,7 +49,13 @@ fn attestation_null_json_ptr() {
 fn attestation_null_pk_ptr() {
     let json = FIXTURE_ATTESTATION_JSON.as_bytes();
     let rc = unsafe {
-        ffi_verify_attestation_json(json.as_ptr(), json.len(), ptr::null(), 32, FFI_CURVE_ED25519)
+        ffi_verify_attestation_json(
+            json.as_ptr(),
+            json.len(),
+            ptr::null(),
+            32,
+            FFI_CURVE_ED25519,
+        )
     };
     assert_eq!(rc, ERR_VERIFY_NULL_ARGUMENT);
 }

--- a/deny.toml
+++ b/deny.toml
@@ -36,6 +36,7 @@ deny = [
     "jsonschema",
     "auths-monitor",
     "auths-sdk",
+    "murmur-relay",
   ], reason = "HTTP clients confined to adapter/binary layer (auths-monitor binary fetches checkpoints; auths-sdk reqwest is optional, behind the `mcp` feature)" },
 
   # dialoguer is a terminal UX dependency — CLI only
@@ -52,6 +53,7 @@ deny = [
     "auths-scim-server",
     "auths-checkpoint-cosigner",
     "auths-witness",
+    "murmur-relay",
   ], reason = "HTTP framework confined to adapter/server crates (scim-server is the SCIM provisioning server; checkpoint-cosigner and witness are HTTP service binaries)" },
 
   # git2 must not be a production dependency of auths-sdk or auths-core
@@ -73,6 +75,8 @@ ignore = [
   # rsa Marvin Attack (RUSTSEC-2023-0071) — transitive via ssh-key v0.6;
   # no fix available until ssh-key upgrades to rsa v0.10+
   "RUSTSEC-2023-0071",
+  # paste unmaintained (RUSTSEC-2024-0436) — transitive via rmcp; no safe upgrade available
+  "RUSTSEC-2024-0436",
 ]
 
 [sources]

--- a/docs/errors/AUTHS-E4988.md
+++ b/docs/errors/AUTHS-E4988.md
@@ -1,0 +1,13 @@
+# AUTHS-E4988
+
+**Crate:** `auths-id`
+
+**Type:** `CacheError::InvalidDid`
+
+## Message
+
+invalid DID: {0}
+
+## Suggestion
+
+The DID must be a 'did:keri:' identity

--- a/docs/errors/index.md
+++ b/docs/errors/index.md
@@ -253,6 +253,7 @@ All error codes emitted by the Auths CLI and libraries. Run `auths error <CODE>`
 | [AUTHS-E4984](AUTHS-E4984.md) | `auths-id` | `CredentialRegistryError::Storage` | registry storage error: {0} |
 | [AUTHS-E4986](AUTHS-E4986.md) | `auths-id` | `CacheError::Io` | I/O error: {0} |
 | [AUTHS-E4987](AUTHS-E4987.md) | `auths-id` | `CacheError::Json` | JSON serialization error: {0} |
+| [AUTHS-E4988](AUTHS-E4988.md) | `auths-id` | `CacheError::InvalidDid` | invalid DID: {0} |
 | [AUTHS-E4991](AUTHS-E4991.md) | `auths-id` | `HookError::Io` | IO error: {0} |
 | [AUTHS-E4992](AUTHS-E4992.md) | `auths-id` | `HookError::NotGitRepo` | Not a Git repository: {0} |
 | [AUTHS-E5001](AUTHS-E5001.md) | `auths-sdk` | `SetupError::IdentityAlreadyExists` | identity already exists: {did} |

--- a/docs/errors/registry.lock
+++ b/docs/errors/registry.lock
@@ -257,6 +257,7 @@ AUTHS-E4983 = auths-id::CredentialRegistryError::Anchor
 AUTHS-E4984 = auths-id::CredentialRegistryError::Storage
 AUTHS-E4986 = auths-id::CacheError::Io
 AUTHS-E4987 = auths-id::CacheError::Json
+AUTHS-E4988 = auths-id::CacheError::InvalidDid
 AUTHS-E4991 = auths-id::HookError::Io
 AUTHS-E4992 = auths-id::HookError::NotGitRepo
 AUTHS-E5001 = auths-sdk::SetupError::IdentityAlreadyExists

--- a/packages/auths-node/src/org.rs
+++ b/packages/auths-node/src/org.rs
@@ -178,11 +178,12 @@ pub fn create_org(
     let signer = StorageSigner::new(keychain);
     let org_did_device = CanonicalDid::from_public_key_did_key(&org_pk_bytes, org_curve);
 
+    let issuer_canonical = CanonicalDid::from(controller_did.clone());
     let attestation = create_signed_attestation(
         now,
         auths_sdk::attestation::AttestationInput {
             rid: &rid,
-            identity_did: &controller_did,
+            issuer: &issuer_canonical,
             subject: &org_did_device,
             device_public_key: &org_pk_bytes,
             device_curve: org_curve,

--- a/packages/auths-node/src/pairing.rs
+++ b/packages/auths-node/src/pairing.rs
@@ -228,8 +228,8 @@ pub async fn join_pairing_session(
         .load_identity()
         .map_err(|e| format_error("AUTHS_PAIRING_ERROR", e))?;
 
-    #[allow(clippy::disallowed_methods)] // INVARIANT: controller_did from storage
-    let controller_identity_did = IdentityDID::new_unchecked(managed.controller_did.to_string());
+    let controller_identity_did = IdentityDID::parse(managed.controller_did.as_str())
+        .map_err(|e| format_error("AUTHS_PAIRING_ERROR", e))?;
 
     let keychain = get_keychain(&env_config)?;
     let aliases = keychain

--- a/packages/auths-python/src/org.rs
+++ b/packages/auths-python/src/org.rs
@@ -164,11 +164,12 @@ pub fn create_org(
         let org_curve = org_resolved.curve();
         let org_did_device = CanonicalDid::from_public_key_did_key(&org_pk_bytes, org_curve);
 
+        let issuer_canonical = CanonicalDid::from(controller_did.clone());
         let attestation = create_signed_attestation(
             now,
             auths_sdk::attestation::AttestationInput {
                 rid: &rid,
-                identity_did: &controller_did,
+                issuer: &issuer_canonical,
                 subject: &org_did_device,
                 device_public_key: &org_pk_bytes,
                 device_curve: org_curve,

--- a/packages/auths-python/src/pairing.rs
+++ b/packages/auths-python/src/pairing.rs
@@ -238,9 +238,8 @@ pub fn join_pairing_session_ffi(
             .load_identity()
             .map_err(|e| PyRuntimeError::new_err(format!("[AUTHS_PAIRING_ERROR] {e}")))?;
 
-        #[allow(clippy::disallowed_methods)] // INVARIANT: controller_did from storage
-        let controller_identity_did =
-            IdentityDID::new_unchecked(managed.controller_did.to_string());
+        let controller_identity_did = IdentityDID::parse(managed.controller_did.as_str())
+            .map_err(|e| PyRuntimeError::new_err(format!("[AUTHS_PAIRING_ERROR] {e}")))?;
 
         let keychain = get_keychain(&passphrase_str, &repo_path_str)?;
         let aliases = keychain


### PR DESCRIPTION
## Why

CI on `main` went red on several independent gates after the IdentityDID single-door + money-typing merges. This hotfix closes all of them.

## What was failing & how it's fixed

### 1. IdentityDID single-door fallout in the SDK package bindings
The `pub(crate)` lock on `IdentityDID::new_unchecked` plus `AttestationInput`'s field becoming `CanonicalDid` broke `packages/auths-node` and `packages/auths-python` — **separate cargo workspaces** that the root `cargo --workspace` build never compiles, so the breakage slipped past the original sweep.
- `pairing.rs`: build the controller DID via the validated `IdentityDID::parse` instead of the now-private `new_unchecked`.
- `org.rs`: feed `AttestationInput.issuer` a `CanonicalDid`.

### 2. `AttestationInput.identity_did` → `issuer`
Renamed the field, keeping its `CanonicalDid` type. The issuer is a `did:keri:` identity **or** a `did:key:` ephemeral self-issuer — `CanonicalDid` models both, and it's already the wire type (`Attestation.issuer`). The old name implied "always an identity," which isn't true. All call sites updated.

### 3. git2 advisories — RUSTSEC-2026-0183 / RUSTSEC-2026-0184
Bumped `git2` 0.20.4 → 0.21.0 (the advisories' only remedy — no safe ignore). git2 0.21 makes `Reference::name()` fallible (`Result` instead of `Option`); migrated every ref-iteration call site accordingly.

### 4. `cargo deny`
- Registered `murmur-relay` (from the merged murmur work) as an `axum`/`reqwest` wrapper, alongside the other server crates — it's a relay server that legitimately needs an HTTP stack.
- Ignored `paste` (RUSTSEC-2024-0436): unmaintained, transitive via `rmcp`, no upgrade available.

### 5. `gen-error-docs` + `rustfmt`
Regenerated the error-code docs (incl. `AUTHS-E4988.md`) and ran rustfmt across the tree.

## Verification
Locally green before the git2 step: root `clippy --all-targets -D warnings`, both package workspaces, `cargo deny` (bans + non-git2 advisories), and fmt. The git2 0.21 `Reference::name()` migration is applied code-wise and is **left for CI to verify here** — local libgit2 rebuilds are slow, GitHub is faster.

The commit is SSH-signed (`auths:main`) and carries the `Auths-Id`/`Auths-Device` trailers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
