### PR TITLE
verifier: enforce delegated-agent capabilities without requiring a timestamp

### DIFF
--- a/crates/auths-verifier/src/commit_kel.rs
+++ b/crates/auths-verifier/src/commit_kel.rs
@@ -773,9 +773,9 @@ async fn authorize_commit(
 /// Checks (in order): the delegation names THIS root; the delegate is not revoked
 /// (ordered by KEL position, KERI carries no wall-clock — signed-before stays valid,
 /// signed-at/after fails, unknown position is the conservative flat rejection); and
-/// the commit stays within the delegator-anchored scope and before any anchored
-/// expiry (only enforced when a signing time is injected and the delegator anchored a
-/// scope seal — never agent-self-asserted).
+/// the commit stays within the delegator-anchored scope (enforced whenever the
+/// delegator anchored a scope seal — never agent-self-asserted) and, when a signing
+/// time is injected, before any anchored expiry.
 fn reject_unauthorized_delegate(
     commit_bytes: &[u8],
     root_kel: &[Event],
@@ -829,10 +829,10 @@ fn reject_unauthorized_delegate(
         }
     }
 
-    if let Some(now) = now
-        && let Some(scope) = read_agent_scope_from_kel(root_kel, &device_prefix)
-    {
-        if let Some(expires_at) = scope.expires_at
+    if let Some(scope) = read_agent_scope_from_kel(root_kel, &device_prefix) {
+        // Expiry is time-dependent: only enforceable when a signing time is injected.
+        if let Some(now) = now
+            && let Some(expires_at) = scope.expires_at
             && now >= expires_at
         {
             return Some(CommitVerdict::AgentExpired {
@@ -841,6 +841,8 @@ fn reject_unauthorized_delegate(
                 signed_at: now,
             });
         }
+        // Capability attenuation is time-independent: a delegate may never exceed the
+        // delegator-anchored scope, so it is enforced whether or not a time is given.
         if !scope.capabilities.is_empty() {
             for claimed in parse_scope_claim(commit_bytes) {
                 if !scope.capabilities.iter().any(|c| c.as_str() == claimed) {

--- a/crates/auths-verifier/tests/cases/commit_kel.rs
+++ b/crates/auths-verifier/tests/cases/commit_kel.rs
@@ -630,3 +630,63 @@ async fn scope_is_delegator_anchored_not_self() {
         "a self-claimed capability outside the delegator scope must be rejected, got {verdict:?}"
     );
 }
+
+#[tokio::test]
+async fn agent_out_of_scope_rejected_without_a_timestamp() {
+    // Capability attenuation is time-independent: a commit claiming a capability the
+    // delegator never granted must be rejected even when no signing time is injected.
+    // The timestamped path already rejects it; the default no-timestamp path must too.
+    let f = build_scoped(
+        &fixture_device_key(),
+        AgentScope {
+            capabilities: vec![auths_verifier::Capability::sign_commit()],
+            expires_at: None,
+        },
+    );
+    let commit = format!("feat: x\n\nAuths-Id: {}\nAuths-Scope: admin\n", f.root_did);
+    let verdict = verify_commit_against_kel(
+        commit.as_bytes(),
+        &f.device_kel,
+        &f.root_kel,
+        std::slice::from_ref(&f.root_did),
+        &RingCryptoProvider,
+    )
+    .await;
+    assert!(
+        matches!(verdict, CommitVerdict::OutsideAgentScope { ref capability, .. } if capability == "admin"),
+        "an out-of-scope capability must be rejected even with no timestamp, got {verdict:?}"
+    );
+}
+
+#[tokio::test]
+async fn in_scope_agent_passes_the_scope_gate_without_a_timestamp() {
+    // The fix must reject only out-of-scope claims, not in-scope ones: an in-scope
+    // capability with no timestamp must pass the scope/expiry gate (it falls through
+    // to the signature check — the hand-built commit is unsigned, hence Unsigned).
+    let f = build_scoped(
+        &fixture_device_key(),
+        AgentScope {
+            capabilities: vec![auths_verifier::Capability::sign_commit()],
+            expires_at: Some(10_000),
+        },
+    );
+    let commit = format!(
+        "feat: x\n\nAuths-Id: {}\nAuths-Scope: sign_commit\n",
+        f.root_did
+    );
+    let verdict = verify_commit_against_kel(
+        commit.as_bytes(),
+        &f.device_kel,
+        &f.root_kel,
+        std::slice::from_ref(&f.root_did),
+        &RingCryptoProvider,
+    )
+    .await;
+    assert!(
+        !matches!(
+            verdict,
+            CommitVerdict::OutsideAgentScope { .. } | CommitVerdict::AgentExpired { .. }
+        ),
+        "an in-scope capability must pass the scope gate even with no timestamp, got {verdict:?}"
+    );
+}


### PR DESCRIPTION
The agent-scope check (a delegate may not exceed its delegator-anchored scope)
was nested inside `if let Some(now)`, so the default no-timestamp verification
path skipped it entirely — a key scoped to sign_commit could claim sign_release
and pass. Capability attenuation is time-independent: it is now enforced whenever
a scope is anchored, while only expiry remains gated on an injected signing time.
Adds adversarial tests: an out-of-scope claim is rejected with no timestamp, and
an in-scope claim still passes.

Auths-Id: did:keri:EB5cPHY0t-ejNC_rUzPS1dclTvd6kG-R9mQzjozCuGgd
Auths-Device: did:keri:EB5cPHY0t-ejNC_rUzPS1dclTvd6kG-R9mQzjozCuGgd
Auths-Anchor-Seq: 1
