### PR TITLE
verifier: grade credential freshness against a fresher-tip oracle

### DIFF
--- a/crates/auths-verifier/src/contract.rs
+++ b/crates/auths-verifier/src/contract.rs
@@ -211,6 +211,7 @@ impl From<CredentialVerdict> for WireCredentialVerdict {
                 subject,
                 caps,
                 as_of,
+                ..
             } => WireCredentialVerdict::Valid {
                 issuer: issuer.as_str().to_string(),
                 subject: subject.as_str().to_string(),

--- a/crates/auths-verifier/src/credential.rs
+++ b/crates/auths-verifier/src/credential.rs
@@ -25,6 +25,7 @@ use auths_crypto::CryptoProvider;
 use auths_keri::witness::StoredReceipt;
 use auths_keri::witness::agreement::WitnessAgreement;
 
+use crate::freshness::{Freshness, FreshnessEvidence, FreshnessPolicy};
 use crate::software_verify::verify_with_key_sync;
 use crate::{CanonicalDid, Capability, IdentityDID};
 use auths_keri::{
@@ -90,6 +91,10 @@ pub enum CredentialVerdict {
         caps: Vec<Capability>,
         /// The KEL position the verdict is as-of: the tip `(seq)` of the given issuer KEL.
         as_of: u128,
+        /// How fresh this verdict is under the verifier's freshness policy (ADR 009). The
+        /// bare verifier is positional (no clock), so it sets [`Freshness::Unknown`]; a
+        /// caller with a freshness signal upgrades it via [`CredentialVerdict::with_freshness`].
+        freshness: Freshness,
     },
     /// The recomputed ACDC `d` (or nested `a.d`) did not match the embedded SAID.
     SaidMismatch,
@@ -132,6 +137,52 @@ impl CredentialVerdict {
     /// Whether the credential verified (`Valid`).
     pub fn is_valid(&self) -> bool {
         matches!(self, CredentialVerdict::Valid { .. })
+    }
+
+    /// This verdict's freshness (ADR 009). Only meaningful for `Valid`; a non-`Valid`
+    /// verdict reports [`Freshness::Stale`] since it is never trusted regardless.
+    pub fn freshness(&self) -> Freshness {
+        match self {
+            CredentialVerdict::Valid { freshness, .. } => *freshness,
+            _ => Freshness::Stale,
+        }
+    }
+
+    /// Re-classify a `Valid` verdict's freshness against a policy and the evidence of a fresher
+    /// source ([`FreshnessEvidence`] — a bundle age, or a fresher KEL tip). The bare verifier
+    /// emits `Unknown`; the relying party upgrades it here once it has a freshness oracle.
+    /// A no-op on non-`Valid` verdicts.
+    ///
+    /// Args:
+    /// * `policy`: the relying party's freshness policy.
+    /// * `evidence`: what the relying party knows about a source fresher than the slice.
+    pub fn with_freshness(self, policy: &FreshnessPolicy, evidence: FreshnessEvidence) -> Self {
+        match self {
+            CredentialVerdict::Valid {
+                issuer,
+                subject,
+                caps,
+                as_of,
+                ..
+            } => CredentialVerdict::Valid {
+                issuer,
+                subject,
+                caps,
+                as_of,
+                freshness: policy.classify(evidence),
+            },
+            other => other,
+        }
+    }
+
+    /// Whether this verdict is trusted under a freshness policy: it is `Valid` AND its
+    /// freshness clears the policy. A bare `Valid` is never trusted without freshness — the
+    /// relying party's policy (not the signer) decides the tolerance (ADR 009).
+    ///
+    /// Args:
+    /// * `policy`: the relying party's freshness policy.
+    pub fn is_trusted(&self, policy: &FreshnessPolicy) -> bool {
+        self.is_valid() && policy.trusts(self.freshness())
     }
 }
 
@@ -291,6 +342,9 @@ pub fn verify_credential_sync(
         subject,
         caps,
         as_of: issuer_state.sequence,
+        // Positional verification carries no clock; the relying party upgrades this via
+        // `with_freshness` once it has a freshness signal. Offline default → Unknown.
+        freshness: Freshness::Unknown,
     }
 }
 

--- a/crates/auths-verifier/src/freshness.rs
+++ b/crates/auths-verifier/src/freshness.rs
@@ -24,6 +24,28 @@ pub enum Freshness {
     Stale,
 }
 
+/// What the verifier knows about a source fresher than the supplied slice (ADR 009 D3–D5).
+/// The verifier reads no clock and no network — this is an INPUT supplied at the boundary
+/// (a bundle timestamp, a witness head, a transparency-log tip), the one model both the
+/// time-based (bundle) and positional (KEL/credential) call sites share.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FreshnessEvidence {
+    /// No source fresher than the supplied slice was available (offline) → `Unknown`.
+    Offline,
+    /// The age of the freshest available source (a witness-head / checkpoint timestamp);
+    /// time-based, used by bundle verification. Within the policy window → `Fresh`, beyond
+    /// it → `Stale`.
+    SourceAge(Duration),
+    /// A known-fresher tip handed to the verifier out of band (a witness head / log tip),
+    /// compared against the slice's `as_of`; positional, used by KEL/credential verification.
+    FresherTip {
+        /// The freshest tip sequence the verifier knows of.
+        latest_seq: u128,
+        /// The sequence the verified slice is as-of.
+        slice_as_of: u128,
+    },
+}
+
 /// The relying party's freshness tolerance. Verifier-set, never signer-set: a bundle
 /// producer states an age, but the verifier caps the trust window (ADR 009 D2 — this is what
 /// kills the "1-year bundle" anti-pattern).
@@ -59,25 +81,29 @@ impl FreshnessPolicy {
         }
     }
 
-    /// Classify the freshness of a verdict from the age of its freshness evidence.
+    /// Classify a verdict's freshness from the evidence of a fresher source.
     ///
-    /// `evidence_age` is `None` when no source fresher than the supplied slice is available
-    /// (offline) — that NAMES the oracle as [`Freshness::Unknown`], never a silent pass and
-    /// never a hard reject.
+    /// [`FreshnessEvidence::Offline`] NAMES the oracle as [`Freshness::Unknown`] — never a
+    /// silent pass and never a hard reject. A source within the window (or a slice at/beyond a
+    /// known-fresher tip) is [`Freshness::Fresh`]; one provably past it is [`Freshness::Stale`].
     ///
     /// Args:
-    /// * `evidence_age`: age of the freshness evidence (e.g. a bundle timestamp, or a
-    ///   witness/checkpoint head), or `None` when none is available.
+    /// * `evidence`: what the verifier was told about a source fresher than the slice.
     ///
     /// Usage:
     /// ```ignore
-    /// let f = policy.classify(Some(bundle_age));
+    /// let f = policy.classify(FreshnessEvidence::SourceAge(bundle_age));
     /// ```
-    pub fn classify(&self, evidence_age: Option<Duration>) -> Freshness {
-        match evidence_age {
-            None => Freshness::Unknown,
-            Some(age) if age <= self.max_age => Freshness::Fresh,
-            Some(_) => Freshness::Stale,
+    pub fn classify(&self, evidence: FreshnessEvidence) -> Freshness {
+        match evidence {
+            FreshnessEvidence::Offline => Freshness::Unknown,
+            FreshnessEvidence::SourceAge(age) if age <= self.max_age => Freshness::Fresh,
+            FreshnessEvidence::SourceAge(_) => Freshness::Stale,
+            FreshnessEvidence::FresherTip {
+                latest_seq,
+                slice_as_of,
+            } if latest_seq > slice_as_of => Freshness::Stale,
+            FreshnessEvidence::FresherTip { .. } => Freshness::Fresh,
         }
     }
 
@@ -103,16 +129,37 @@ mod tests {
         let p = FreshnessPolicy::default(); // 24h, tolerates unknown
         // Offline — no fresher source than the slice → Unknown (named), never a silent pass
         // and never a hard reject.
-        assert_eq!(p.classify(None), Freshness::Unknown);
-        // Within the window → Fresh.
+        assert_eq!(p.classify(FreshnessEvidence::Offline), Freshness::Unknown);
+        // A source within the window → Fresh; older than the window → Stale.
         assert_eq!(
-            p.classify(Some(Duration::from_secs(3600))),
+            p.classify(FreshnessEvidence::SourceAge(Duration::from_secs(3600))),
             Freshness::Fresh
         );
-        // Older than the window → Stale.
         assert_eq!(
-            p.classify(Some(Duration::from_secs(25 * 3600))),
+            p.classify(FreshnessEvidence::SourceAge(Duration::from_secs(25 * 3600))),
             Freshness::Stale
+        );
+    }
+
+    #[test]
+    fn classify_positional_slice_behind_a_fresher_tip_is_stale() {
+        let p = FreshnessPolicy::default();
+        // A slice behind a known-fresher tip → Stale (it cannot see the later events,
+        // including a revocation).
+        assert_eq!(
+            p.classify(FreshnessEvidence::FresherTip {
+                latest_seq: 5,
+                slice_as_of: 3,
+            }),
+            Freshness::Stale
+        );
+        // A slice at (or beyond) the known-fresher tip → Fresh.
+        assert_eq!(
+            p.classify(FreshnessEvidence::FresherTip {
+                latest_seq: 3,
+                slice_as_of: 3,
+            }),
+            Freshness::Fresh
         );
     }
 

--- a/crates/auths-verifier/tests/cases/credential.rs
+++ b/crates/auths-verifier/tests/cases/credential.rs
@@ -13,6 +13,7 @@ use auths_keri::{
     compute_capability_schema_said, compute_next_commitment, encode_tel_nonce, finalize_icp_event,
     finalize_ixn_event,
 };
+use auths_verifier::freshness::{Freshness, FreshnessEvidence, FreshnessPolicy};
 use auths_verifier::{CredentialVerdict, LifecycleEvent, SignedAcdc, VerifierWitnessPolicy};
 use chrono::{TimeZone, Utc};
 use ring::signature::{Ed25519KeyPair, KeyPair};
@@ -355,7 +356,13 @@ async fn valid_credential_verifies() {
                 subject,
                 caps,
                 as_of,
+                freshness,
             } => {
+                assert_eq!(
+                    freshness,
+                    Freshness::Unknown,
+                    "the offline verifier names freshness Unknown, never a bare Valid"
+                );
                 assert_eq!(issuer.as_str(), format!("did:keri:{}", f.issuer_aid));
                 assert_eq!(
                     subject.as_str(),
@@ -423,6 +430,95 @@ async fn revoked_credential_rejected_by_kel_position() {
     assert_eq!(
         verdict,
         CredentialVerdict::CredentialRevoked { revoked_at: 3 }
+    );
+}
+
+/// A credential verified against a captured *pre-revoke* slice returns a positionally-correct
+/// `Valid`, hiding a later revocation. The bare offline
+/// verifier names freshness `Unknown` (never a bare `Valid`); a relying party with a
+/// fresher-tip oracle (a witness head) then grades it `Stale`, and `is_trusted` rejects it —
+/// where the old `is_valid()` would have trusted the stale slice.
+#[tokio::test]
+async fn stale_pre_revoke_slice_is_graded_stale_not_trusted() {
+    // The issuer + credential are deterministic (seed 1), so the pre-revoke and post-revoke
+    // fixtures describe the SAME credential at two points in the issuer's history.
+    let stale = build_fixture(&FixtureSpec::basic(CurveType::P256, false));
+    let fresh = build_fixture(&FixtureSpec::basic(CurveType::P256, true));
+    assert_eq!(
+        stale.iss_said, fresh.iss_said,
+        "the two views are the same credential issuance"
+    );
+
+    // The issuer's TRUE current state: the credential is revoked at the fresher tip (seq 3).
+    let current = auths_verifier::verify_credential(
+        &fresh.signed,
+        &fresh.issuer_kel,
+        &fresh.tel,
+        &[],
+        VerifierWitnessPolicy::Warn,
+        now(),
+        &provider(),
+    )
+    .await;
+    assert_eq!(
+        current,
+        CredentialVerdict::CredentialRevoked { revoked_at: 3 },
+        "the credential is revoked at the issuer's current tip"
+    );
+
+    // The attack: present only the captured pre-revoke slice (tip 2). It verifies `Valid` —
+    // positionally correct, but stale. The verifier names freshness `Unknown`, not bare.
+    let stale_verdict = auths_verifier::verify_credential(
+        &stale.signed,
+        &stale.issuer_kel,
+        &stale.tel,
+        &[],
+        VerifierWitnessPolicy::Warn,
+        now(),
+        &provider(),
+    )
+    .await;
+    let as_of = match &stale_verdict {
+        CredentialVerdict::Valid {
+            as_of, freshness, ..
+        } => {
+            assert_eq!(*as_of, 2, "the stale slice's tip");
+            assert_eq!(
+                *freshness,
+                Freshness::Unknown,
+                "the offline verifier names freshness Unknown, never a bare Valid"
+            );
+            *as_of
+        }
+        other => panic!("expected Valid on the stale slice, got {other:?}"),
+    };
+    assert!(
+        stale_verdict.is_valid(),
+        "is_valid() alone trusts the stale slice — the vulnerability the grade closes"
+    );
+
+    // The fix: a relying party with a fresher-tip oracle (the issuer's current tip is 3, from
+    // a witness head) grades the verdict. The slice is behind the fresher tip → Stale.
+    let oracle = FreshnessEvidence::FresherTip {
+        latest_seq: 3,
+        slice_as_of: as_of,
+    };
+    let graded = stale_verdict.with_freshness(&FreshnessPolicy::default(), oracle);
+    assert_eq!(
+        graded.freshness(),
+        Freshness::Stale,
+        "a slice behind the fresher tip is Stale"
+    );
+    // A stale slice is trusted by no policy — neither the 24h default nor a strict one.
+    assert!(
+        !graded.is_trusted(&FreshnessPolicy::default()),
+        "the default policy must not trust a stale slice"
+    );
+    assert!(
+        !graded.is_trusted(&FreshnessPolicy::strict(std::time::Duration::from_secs(
+            3600
+        ))),
+        "a strict policy must reject a stale slice"
     );
 }
 


### PR DESCRIPTION
A credential verified against a captured pre-revoke KEL slice returns a
positionally-correct Valid that hides a later revocation. The verifier now names
its freshness instead: the bare offline verdict is Valid{freshness: Unknown}
(never a bare Valid), and a relying party with a fresher-tip oracle (a witness
head) grades it via FreshnessEvidence::FresherTip — a slice behind the tip is
Stale. is_trusted(policy) rejects Stale under every policy and Unknown under a
strict one.

Adds FreshnessEvidence (the one model shared with bundle-age freshness:
Offline / SourceAge / FresherTip) and an exploit test proving the same
credential is Valid on the captured stale slice but CredentialRevoked at the
issuer's current tip.

Auths-Id: did:keri:EB5cPHY0t-ejNC_rUzPS1dclTvd6kG-R9mQzjozCuGgd
Auths-Device: did:keri:EB5cPHY0t-ejNC_rUzPS1dclTvd6kG-R9mQzjozCuGgd
Auths-Anchor-Seq: 1
