### PR TITLE
verifier: grade commit verdicts by bundle age against the verifier policy

### DIFF
--- a/crates/auths-cli/src/commands/verify_commit.rs
+++ b/crates/auths-cli/src/commands/verify_commit.rs
@@ -608,6 +608,7 @@ fn verdict_to_result(commit: String, verdict: CommitVerdict) -> VerifyCommitResu
             signer_did,
             root_did,
             duplicitous_root,
+            ..
         } => {
             result.valid = true;
             result.ssh_valid = Some(true);
@@ -1068,6 +1069,8 @@ mod tests {
                 signer_did: "did:keri:dev".into(),
                 root_did: "did:keri:root".into(),
                 duplicitous_root: true,
+                as_of: 0,
+                freshness: auths_verifier::freshness::Freshness::Unknown,
             },
         );
         assert!(result.valid);

--- a/crates/auths-mcp-core/src/gate.rs
+++ b/crates/auths-mcp-core/src/gate.rs
@@ -464,6 +464,8 @@ mod tests {
                 signer_did: "did:keri:Eagent".into(),
                 root_did: "did:keri:Eroot".into(),
                 duplicitous_root: false,
+                as_of: 0,
+                freshness: auths_verifier::freshness::Freshness::Unknown,
             }),
             Verdict::Allowed
         );

--- a/crates/auths-verifier/src/commit_bundle.rs
+++ b/crates/auths-verifier/src/commit_bundle.rs
@@ -18,6 +18,7 @@ use serde::Serialize;
 
 use crate::commit_kel::{CommitVerdict, commit_signer_trailers, verify_commit_against_kel};
 use crate::core::{IdentityBundle, MAX_JSON_BATCH_SIZE};
+use crate::freshness::{Freshness, FreshnessEvidence, FreshnessPolicy};
 use auths_crypto::CryptoProvider;
 
 /// Why an identity bundle could not become a trust anchor. Fails closed: an
@@ -172,6 +173,13 @@ enum CommitBundleEnvelope {
         signer_did: Option<String>,
         #[serde(skip_serializing_if = "Option::is_none")]
         root_did: Option<String>,
+        /// The freshness grade of a positive verdict; the relying party's policy, not the
+        /// bundle's TTL, decides whether it clears (ADR 009).
+        #[serde(skip_serializing_if = "Option::is_none")]
+        freshness: Option<Freshness>,
+        /// The signer-KEL tip the verdict was decided against.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        as_of: Option<u128>,
     },
     Error {
         error: String,
@@ -197,6 +205,7 @@ fn verdict_detail(verdict: &CommitVerdict) -> String {
             signer_did,
             root_did,
             duplicitous_root,
+            ..
         } => {
             let fork = if *duplicitous_root {
                 " (warning: root KEL shows a fork)"
@@ -246,20 +255,31 @@ fn verdict_detail(verdict: &CommitVerdict) -> String {
 }
 
 fn verdict_envelope(verdict: CommitVerdict) -> CommitBundleEnvelope {
-    let (signer_did, root_did) = match &verdict {
+    let (signer_did, root_did, as_of, freshness) = match &verdict {
         CommitVerdict::Valid {
             signer_did,
             root_did,
+            as_of,
+            freshness,
             ..
-        } => (Some(signer_did.clone()), Some(root_did.clone())),
-        _ => (None, None),
+        } => (
+            Some(signer_did.clone()),
+            Some(root_did.clone()),
+            Some(*as_of),
+            Some(*freshness),
+        ),
+        _ => (None, None, None, None),
     };
     CommitBundleEnvelope::Verdict {
-        valid: verdict.is_valid(),
+        // The relying party's policy caps trust, not the bundle's self-declared TTL: a bundle
+        // older than the default window is not trusted even though it verified (ADR 009).
+        valid: verdict.is_trusted(&FreshnessPolicy::default()),
         verdict: verdict_code(&verdict),
         detail: verdict_detail(&verdict),
         signer_did,
         root_did,
+        freshness,
+        as_of,
     }
 }
 
@@ -358,14 +378,23 @@ async fn verify_commit_with_bundle_inner(
         }
     }
 
-    Ok(verify_commit_against_kel(
+    let verdict = verify_commit_against_kel(
         commit_text.as_bytes(),
         trust.kel(),
         trust.kel(),
         &pinned_roots,
         provider,
     )
-    .await)
+    .await;
+
+    // Grade the verdict from the bundle's age against the verifier's freshness policy: the
+    // verifier caps trust, never the bundle's self-declared TTL (ADR 009). A bundle older
+    // than the policy window is Stale and a strict/default relying party rejects it.
+    let age = (now - bundle.bundle_timestamp).to_std().unwrap_or_default();
+    Ok(verdict.with_freshness(
+        &FreshnessPolicy::default(),
+        FreshnessEvidence::SourceAge(age),
+    ))
 }
 
 #[cfg(test)]
@@ -566,5 +595,72 @@ mod tests {
                 .contains("not carried by the bundle"),
             "unexpected error: {out}"
         );
+    }
+
+    fn valid_verdict() -> CommitVerdict {
+        CommitVerdict::Valid {
+            signer_did: "did:keri:Edev".to_string(),
+            root_did: ROOT.to_string(),
+            duplicitous_root: false,
+            as_of: 7,
+            freshness: Freshness::Unknown,
+        }
+    }
+
+    #[test]
+    fn bundle_age_grades_the_commit_verdict_against_the_verifier_policy() {
+        let policy = FreshnessPolicy::default(); // 24h
+        // A bundle older than the policy window grades Stale and is trusted by no policy —
+        // the verifier caps trust regardless of the bundle's self-declared TTL.
+        let stale = valid_verdict().with_freshness(
+            &policy,
+            FreshnessEvidence::SourceAge(std::time::Duration::from_secs(25 * 3600)),
+        );
+        assert_eq!(stale.freshness(), Freshness::Stale);
+        assert!(!stale.is_trusted(&policy));
+        // A bundle within the window grades Fresh and is trusted.
+        let fresh = valid_verdict().with_freshness(
+            &policy,
+            FreshnessEvidence::SourceAge(std::time::Duration::from_secs(3600)),
+        );
+        assert_eq!(fresh.freshness(), Freshness::Fresh);
+        assert!(fresh.is_trusted(&policy));
+        // No oracle (a direct verify) → Unknown: the default tolerates it, strict denies it.
+        let unknown = valid_verdict().with_freshness(&policy, FreshnessEvidence::Offline);
+        assert_eq!(unknown.freshness(), Freshness::Unknown);
+        assert!(unknown.is_trusted(&policy));
+        assert!(
+            !unknown.is_trusted(&FreshnessPolicy::strict(std::time::Duration::from_secs(
+                3600
+            )))
+        );
+    }
+
+    #[test]
+    fn verdict_envelope_caps_trust_at_the_policy_and_surfaces_freshness() {
+        // A stale-graded verdict: the envelope reports it not-valid (the verifier policy caps
+        // trust) and surfaces the freshness grade and as-of for the consumer.
+        let stale = valid_verdict().with_freshness(
+            &FreshnessPolicy::default(),
+            FreshnessEvidence::SourceAge(std::time::Duration::from_secs(25 * 3600)),
+        );
+        let json = envelope_to_string(&verdict_envelope(stale));
+        let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(
+            v["valid"], false,
+            "a stale bundle is not trusted under the default policy"
+        );
+        assert_eq!(v["freshness"], "stale");
+        assert_eq!(v["as_of"], 7);
+
+        // A fresh-graded verdict: trusted and surfaced.
+        let fresh = valid_verdict().with_freshness(
+            &FreshnessPolicy::default(),
+            FreshnessEvidence::SourceAge(std::time::Duration::from_secs(3600)),
+        );
+        let v: serde_json::Value =
+            serde_json::from_str(&envelope_to_string(&verdict_envelope(fresh))).unwrap();
+        assert_eq!(v["valid"], true);
+        assert_eq!(v["freshness"], "fresh");
     }
 }

--- a/crates/auths-verifier/src/commit_kel.rs
+++ b/crates/auths-verifier/src/commit_kel.rs
@@ -18,6 +18,7 @@ use crate::commit::{extract_ssh_signature, verify_commit_signature};
 use crate::commit_error::CommitVerificationError;
 use crate::core::DevicePublicKey;
 use crate::duplicity::{KelEventRef, detect_duplicity};
+use crate::freshness::{Freshness, FreshnessEvidence, FreshnessPolicy};
 use crate::ssh_sig::parse_sshsig_pem;
 
 /// The outcome of KEL-native commit verification. Distinguishable so the CLI/UX can
@@ -33,6 +34,12 @@ pub enum CommitVerdict {
         root_did: String,
         /// True if the root KEL shows a fork (non-fatal warning — trust-on-first-sight).
         duplicitous_root: bool,
+        /// The signer-KEL tip sequence this verdict was decided against.
+        as_of: u128,
+        /// How fresh this verdict is under the verifier's freshness policy (ADR 009). The
+        /// positional verifier sets `Unknown`; a caller with a freshness signal upgrades it
+        /// via [`CommitVerdict::with_freshness`].
+        freshness: Freshness,
     },
     /// The commit carries no SSH signature.
     Unsigned,
@@ -153,6 +160,52 @@ impl CommitVerdict {
     /// non-fatal duplicity warning).
     pub fn is_valid(&self) -> bool {
         matches!(self, CommitVerdict::Valid { .. })
+    }
+
+    /// This verdict's freshness (ADR 009). Only meaningful for `Valid`; a non-`Valid`
+    /// verdict reports [`Freshness::Stale`] since it is never trusted regardless.
+    pub fn freshness(&self) -> Freshness {
+        match self {
+            CommitVerdict::Valid { freshness, .. } => *freshness,
+            _ => Freshness::Stale,
+        }
+    }
+
+    /// Re-classify a `Valid` verdict's freshness against a policy and the evidence of a
+    /// fresher source (a bundle age, or a fresher signer-KEL tip). The positional verifier
+    /// emits `Unknown`; the relying party upgrades it here once it has a freshness oracle.
+    /// A no-op on non-`Valid` verdicts.
+    ///
+    /// Args:
+    /// * `policy`: the relying party's freshness policy.
+    /// * `evidence`: what the relying party knows about a source fresher than the slice.
+    pub fn with_freshness(self, policy: &FreshnessPolicy, evidence: FreshnessEvidence) -> Self {
+        match self {
+            CommitVerdict::Valid {
+                signer_did,
+                root_did,
+                duplicitous_root,
+                as_of,
+                ..
+            } => CommitVerdict::Valid {
+                signer_did,
+                root_did,
+                duplicitous_root,
+                as_of,
+                freshness: policy.classify(evidence),
+            },
+            other => other,
+        }
+    }
+
+    /// Whether this verdict is trusted under a freshness policy: it is `Valid` AND its
+    /// freshness clears the policy. A bare `Valid` is never trusted without freshness — the
+    /// relying party's policy (not the signer) decides the tolerance (ADR 009).
+    ///
+    /// Args:
+    /// * `policy`: the relying party's freshness policy.
+    pub fn is_trusted(&self, policy: &FreshnessPolicy) -> bool {
+        self.is_valid() && policy.trusts(self.freshness())
     }
 
     /// A stable, machine-readable code for this verdict, suitable for the `status`
@@ -752,6 +805,8 @@ async fn authorize_commit(
             signer_did: device_did,
             root_did,
             duplicitous_root,
+            as_of: device_state.sequence,
+            freshness: Freshness::Unknown,
         },
         Err(CommitVerificationError::UnsignedCommit) => CommitVerdict::Unsigned,
         Err(CommitVerificationError::GpgNotSupported) => CommitVerdict::GpgUnsupported,


### PR DESCRIPTION
CommitVerdict::Valid now carries {as_of, freshness} and has freshness() /
with_freshness(policy, evidence) / is_trusted(policy), mirroring the credential
verdict. The stateless bundle path grades the verdict from the bundle's age
(now - bundle_timestamp) against the verifier's default 24h policy — so the
verifier caps trust, not the bundle's self-declared TTL. The JSON verdict
envelope reports a bundle older than the window as not-valid (is_trusted) and
surfaces the freshness grade + as_of, so the WASM/CI verifier rejects an
over-aged bundle even when the bundle's own TTL would admit it. Unit tests
cover the grading and the envelope policy cap.

Auths-Id: did:keri:EB5cPHY0t-ejNC_rUzPS1dclTvd6kG-R9mQzjozCuGgd
Auths-Device: did:keri:EB5cPHY0t-ejNC_rUzPS1dclTvd6kG-R9mQzjozCuGgd
Auths-Anchor-Seq: 1
