### PR TITLE
verifier: legible authorization summary from the signed bytes

### DIFF
--- a/crates/auths-cli/src/commands/artifact/sign.rs
+++ b/crates/auths-cli/src/commands/artifact/sign.rs
@@ -97,6 +97,28 @@ pub fn handle_sign(
     );
     println!("  RID:    {}", result.rid);
     println!("  Digest: sha256:{}", result.digest);
+    print_authorization_scope(&final_json);
 
     Ok(())
+}
+
+/// Print the scope this signature grants — who is vouching, for what, and until when — so the
+/// signer sees what they authorize rather than just a digest. The artifact's content is bound by
+/// the digest above, not shown here.
+///
+/// Args:
+/// * `attestation_json`: the canonical attestation JSON that was signed.
+fn print_authorization_scope(attestation_json: &str) {
+    let Ok(value) = serde_json::from_str::<serde_json::Value>(attestation_json) else {
+        return;
+    };
+    for (label, field) in [
+        ("Signer ", "issuer"),
+        ("Subject", "subject"),
+        ("Expires", "expires_at"),
+    ] {
+        if let Some(text) = value.get(field).and_then(|v| v.as_str()) {
+            println!("  {label}: {text}");
+        }
+    }
 }

--- a/crates/auths-verifier/src/authorization_summary.rs
+++ b/crates/auths-verifier/src/authorization_summary.rs
@@ -1,0 +1,141 @@
+//! A legible "what you are authorizing" summary derived from the exact bytes being signed.
+//!
+//! A signer should be able to see what a signature authorizes, not just a digest. For the paths
+//! whose signed bytes are legible — a signed action request, a git commit — this derives a
+//! human-readable summary deterministically from those exact bytes, so the summary cannot drift
+//! from what is signed. For bytes whose content is not legible from the signature (an artifact
+//! attestation binds a digest, not the file content), the summary names the digest rather than
+//! silently showing nothing.
+
+use serde_json::Value;
+use sha2::{Digest, Sha256};
+use std::fmt;
+
+/// What a signer is authorizing, derived from the exact bytes being signed.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AuthorizationSummary {
+    /// A signed action request: the action, the signing identity, and the legible payload
+    /// fields (e.g. an agent capability call's capability, budget, and target).
+    Action {
+        /// The action being authorized.
+        action_type: String,
+        /// The identity signing the action.
+        identity: String,
+        /// The action payload's top-level fields, rendered as key/value pairs.
+        details: Vec<(String, String)>,
+    },
+    /// A git commit: its author and message — both legible from the signed object.
+    Commit {
+        /// The commit `author` line.
+        author: String,
+        /// The commit message.
+        message: String,
+    },
+    /// Signed bytes whose content is not legible from the signature (e.g. an artifact
+    /// attestation binds a digest, not content). The digest is named so consent is never
+    /// silently blank; content consent must be established out of band.
+    Opaque {
+        /// Lowercase hex SHA-256 of the signed bytes.
+        digest_hex: String,
+    },
+}
+
+impl AuthorizationSummary {
+    /// Derive a legible summary from the exact bytes a signature will cover.
+    ///
+    /// Recognizes a signed action request (canonical JSON with `type`/`identity`/`payload`) and
+    /// a git commit object; anything else is summarized by its SHA-256 digest rather than
+    /// silently shown as nothing.
+    ///
+    /// Args:
+    /// * `signed_bytes`: the bytes the signature covers.
+    ///
+    /// Usage:
+    /// ```ignore
+    /// let summary = AuthorizationSummary::from_signed_bytes(&payload);
+    /// println!("Authorizing: {summary}");
+    /// ```
+    pub fn from_signed_bytes(signed_bytes: &[u8]) -> Self {
+        if let Some(action) = parse_action(signed_bytes) {
+            return action;
+        }
+        if let Some(commit) = parse_commit(signed_bytes) {
+            return commit;
+        }
+        AuthorizationSummary::Opaque {
+            digest_hex: hex::encode(Sha256::digest(signed_bytes)),
+        }
+    }
+}
+
+/// Parse signed action-request bytes (canonical JSON carrying `type`, `identity`, `payload`).
+fn parse_action(bytes: &[u8]) -> Option<AuthorizationSummary> {
+    let value: Value = serde_json::from_slice(bytes).ok()?;
+    let obj = value.as_object()?;
+    let action_type = obj.get("type")?.as_str()?.to_string();
+    let identity = obj.get("identity")?.as_str()?.to_string();
+    let payload = obj.get("payload")?;
+    let details = payload
+        .as_object()
+        .map(|m| {
+            m.iter()
+                .map(|(k, v)| (k.clone(), render_scalar(v)))
+                .collect()
+        })
+        .unwrap_or_default();
+    Some(AuthorizationSummary::Action {
+        action_type,
+        identity,
+        details,
+    })
+}
+
+/// Parse a git commit object (`tree …`, an `author …` line, a blank line, then the message).
+fn parse_commit(bytes: &[u8]) -> Option<AuthorizationSummary> {
+    let text = std::str::from_utf8(bytes).ok()?;
+    if !text.starts_with("tree ") {
+        return None;
+    }
+    let author = text
+        .lines()
+        .find_map(|l| l.strip_prefix("author "))
+        .map(str::to_string)?;
+    let message = text
+        .split_once("\n\n")
+        .map(|(_, m)| m.trim_end().to_string())
+        .unwrap_or_default();
+    Some(AuthorizationSummary::Commit { author, message })
+}
+
+/// Render a JSON value as a compact display string (strings unquoted, others as JSON).
+fn render_scalar(v: &Value) -> String {
+    match v {
+        Value::String(s) => s.clone(),
+        other => other.to_string(),
+    }
+}
+
+impl fmt::Display for AuthorizationSummary {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            AuthorizationSummary::Action {
+                action_type,
+                identity,
+                details,
+            } => {
+                write!(f, "action {action_type} by {identity}")?;
+                for (k, v) in details {
+                    write!(f, "; {k}={v}")?;
+                }
+                Ok(())
+            }
+            AuthorizationSummary::Commit { author, message } => {
+                let subject = message.lines().next().unwrap_or("");
+                write!(f, "commit by {author}: {subject}")
+            }
+            AuthorizationSummary::Opaque { digest_hex } => {
+                write!(f, "opaque payload sha256:{digest_hex}")
+            }
+        }
+    }
+}

--- a/crates/auths-verifier/src/lib.rs
+++ b/crates/auths-verifier/src/lib.rs
@@ -48,6 +48,8 @@
 //! - `wasm` — Enable WASM bindings via wasm-bindgen
 
 pub mod action;
+/// Legible "what you are authorizing" summary derived from the bytes being signed.
+pub mod authorization_summary;
 pub mod clock;
 pub mod commit;
 /// Stateless commit verification against an identity bundle (CLI + WASM).
@@ -93,6 +95,9 @@ pub use types::{
 
 // Re-export action envelope
 pub use action::ActionEnvelope;
+
+// Re-export the legible authorization summary (signing-consent surface)
+pub use authorization_summary::AuthorizationSummary;
 
 // Re-export core types
 pub use core::{

--- a/crates/auths-verifier/tests/cases/authorization_summary.rs
+++ b/crates/auths-verifier/tests/cases/authorization_summary.rs
@@ -1,0 +1,68 @@
+//! A signer must be able to see what they are authorizing — a legible summary derived from the
+//! exact bytes being signed, not just a digest.
+
+use auths_verifier::AuthorizationSummary;
+
+#[test]
+fn summarizes_a_signed_action_request_from_its_bytes() {
+    let bytes = serde_json::to_vec(&serde_json::json!({
+        "version": "1.0",
+        "type": "agent_call",
+        "identity": "did:keri:Eagent",
+        "payload": { "capability": "payments.transfer", "budget_cents": 1000, "target": "acct:42" },
+        "timestamp": "2025-01-01T00:00:00Z"
+    }))
+    .unwrap();
+    match AuthorizationSummary::from_signed_bytes(&bytes) {
+        AuthorizationSummary::Action {
+            action_type,
+            identity,
+            details,
+        } => {
+            assert_eq!(action_type, "agent_call");
+            assert_eq!(identity, "did:keri:Eagent");
+            assert!(
+                details
+                    .iter()
+                    .any(|(k, v)| k == "capability" && v == "payments.transfer"),
+                "the legible capability must be surfaced: {details:?}"
+            );
+            assert!(
+                details
+                    .iter()
+                    .any(|(k, v)| k == "budget_cents" && v == "1000")
+            );
+        }
+        other => panic!("expected an Action summary, got {other:?}"),
+    }
+}
+
+#[test]
+fn summarizes_a_signed_commit_object_from_its_bytes() {
+    let bytes = b"tree abc123\n\
+        author Test User <test@example.com> 1700000000 +0000\n\
+        committer Test User <test@example.com> 1700000000 +0000\n\
+        \n\
+        Fix the thing\n";
+    match AuthorizationSummary::from_signed_bytes(bytes) {
+        AuthorizationSummary::Commit { author, message } => {
+            assert!(author.contains("Test User"), "author: {author}");
+            assert!(message.contains("Fix the thing"), "message: {message}");
+        }
+        other => panic!("expected a Commit summary, got {other:?}"),
+    }
+}
+
+#[test]
+fn opaque_bytes_are_named_by_digest_never_silently_blank() {
+    // Bytes whose content is not legible from the signature (an artifact attestation binds a
+    // digest, not content) are summarized by their digest — consent is never silently blank.
+    let bytes = b"\x00\x01\x02 not legible signed bytes";
+    match AuthorizationSummary::from_signed_bytes(bytes) {
+        AuthorizationSummary::Opaque { digest_hex } => {
+            assert_eq!(digest_hex.len(), 64, "lowercase sha256 hex");
+            assert!(digest_hex.chars().all(|c| c.is_ascii_hexdigit()));
+        }
+        other => panic!("expected an Opaque summary, got {other:?}"),
+    }
+}

--- a/crates/auths-verifier/tests/cases/mod.rs
+++ b/crates/auths-verifier/tests/cases/mod.rs
@@ -1,3 +1,4 @@
+mod authorization_summary;
 mod capability_fromstr;
 mod commit_kel;
 mod commit_verify;


### PR DESCRIPTION
A signer should see what a signature authorizes, not just a digest.
AuthorizationSummary::from_signed_bytes derives a human-readable summary
deterministically from the exact bytes being signed: a signed action request
(action + identity + payload fields) and a git commit (author + message) are
legible; anything else is named by its sha256 digest rather than shown as
nothing. The artifact sign command now prints the granted scope (signer,
subject, expiry) alongside the digest.

Auths-Id: did:keri:EB5cPHY0t-ejNC_rUzPS1dclTvd6kG-R9mQzjozCuGgd
Auths-Device: did:keri:EB5cPHY0t-ejNC_rUzPS1dclTvd6kG-R9mQzjozCuGgd
Auths-Anchor-Seq: 1
