### PR TITLE
init: lock the unsatisfiable-threshold rejection at identity creation

### DIFF
--- a/crates/auths-cli/src/commands/init/mod.rs
+++ b/crates/auths-cli/src/commands/init/mod.rs
@@ -617,6 +617,22 @@ mod tests {
     }
 
     #[test]
+    fn parse_threshold_cli_rejects_unsatisfiable_thresholds() {
+        // A threshold larger than the device count can never be met — it would brick recovery,
+        // so it is rejected at creation.
+        assert!(parse_threshold_cli("3", 2).is_err());
+        // Zero is unsatisfiable for a non-empty device set.
+        assert!(parse_threshold_cli("0", 2).is_err());
+        // A satisfiable threshold parses: 2-of-2.
+        assert_eq!(
+            parse_threshold_cli("2", 2).unwrap(),
+            auths_keri::Threshold::Simple(2)
+        );
+        // 1-of-N (the any-device default) is satisfiable.
+        assert!(parse_threshold_cli("1", 3).is_ok());
+    }
+
+    #[test]
     fn test_setup_command_defaults() {
         let cmd = InitCommand {
             interactive: false,


### PR DESCRIPTION
A signing/next threshold greater than the device count can never be met and
would brick recovery; parse_threshold_cli already rejects it (and threshold 0)
at creation, matching the KEL-validation guard. Adds a regression test pinning
that behavior: 3-of-2 and 0-of-2 are rejected, 2-of-2 and 1-of-3 parse.

Auths-Id: did:keri:EB5cPHY0t-ejNC_rUzPS1dclTvd6kG-R9mQzjozCuGgd
Auths-Device: did:keri:EB5cPHY0t-ejNC_rUzPS1dclTvd6kG-R9mQzjozCuGgd
Auths-Anchor-Seq: 1
