### PR TITLE
scim: add the Group resource type (ScimGroup, GroupMember)

### DIFF
--- a/crates/auths-scim/src/constants.rs
+++ b/crates/auths-scim/src/constants.rs
@@ -1,6 +1,9 @@
 /// SCIM 2.0 Core User schema URI (RFC 7643 Section 4.1).
 pub const SCHEMA_USER: &str = "urn:ietf:params:scim:schemas:core:2.0:User";
 
+/// SCIM 2.0 Core Group schema URI (RFC 7643 Section 4.2).
+pub const SCHEMA_GROUP: &str = "urn:ietf:params:scim:schemas:core:2.0:Group";
+
 /// SCIM 2.0 ListResponse message schema URI (RFC 7644 Section 3.4.2).
 pub const SCHEMA_LIST_RESPONSE: &str = "urn:ietf:params:scim:api:messages:2.0:ListResponse";
 

--- a/crates/auths-scim/src/lib.rs
+++ b/crates/auths-scim/src/lib.rs
@@ -33,7 +33,7 @@ pub use mapping::{
     scim_user_to_update_fields,
 };
 pub use patch::{PatchOpType, PatchOperation, ScimPatchOp, apply_patch_operations};
-pub use resource::{AuthsAgentExtension, ScimMeta, ScimUser};
+pub use resource::{AuthsAgentExtension, GroupMember, ScimGroup, ScimMeta, ScimUser};
 pub use schema::{
     AuthenticationScheme, FilterSupported, ResourceType, SchemaAttribute, SchemaDefinition,
     SchemaExtension, ServiceProviderConfig, Supported,

--- a/crates/auths-scim/src/resource.rs
+++ b/crates/auths-scim/src/resource.rs
@@ -4,7 +4,7 @@ use auths_verifier::{Capability, IdentityDID};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
-use crate::constants::{SCHEMA_AUTHS_AGENT, SCHEMA_USER};
+use crate::constants::{SCHEMA_AUTHS_AGENT, SCHEMA_GROUP, SCHEMA_USER};
 
 /// SCIM 2.0 User resource adapted for Auths agent identities.
 ///
@@ -87,6 +87,43 @@ pub struct AuthsAgentExtension {
     pub revoked: bool,
 }
 
+/// A SCIM Group resource (RFC 7643 §4.2) — a named collection of members.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct ScimGroup {
+    pub schemas: Vec<String>,
+    #[serde(default)]
+    pub id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub external_id: Option<String>,
+    pub display_name: String,
+    #[serde(default)]
+    pub members: Vec<GroupMember>,
+    #[serde(default)]
+    pub meta: ScimMeta,
+}
+
+impl ScimGroup {
+    /// Default schemas for a new Group resource.
+    pub fn default_schemas() -> Vec<String> {
+        vec![SCHEMA_GROUP.into()]
+    }
+}
+
+/// A member reference within a SCIM Group (RFC 7643 §4.2).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct GroupMember {
+    /// The member resource's `id`.
+    pub value: String,
+    /// A human-readable label for the member (e.g. the user's `userName`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub display: Option<String>,
+    /// The URI reference to the member resource, serialized as `$ref`.
+    #[serde(rename = "$ref", skip_serializing_if = "Option::is_none")]
+    pub ref_uri: Option<String>,
+}
+
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod tests {
@@ -163,5 +200,37 @@ mod tests {
         assert_eq!(schemas.len(), 2);
         assert!(schemas.contains(&SCHEMA_USER.to_string()));
         assert!(schemas.contains(&SCHEMA_AUTHS_AGENT.to_string()));
+    }
+
+    #[test]
+    fn scim_group_serializes_with_display_name_and_members() {
+        let group = ScimGroup {
+            schemas: ScimGroup::default_schemas(),
+            id: "g-1".into(),
+            external_id: Some("okta-grp-9".into()),
+            display_name: "engineering".into(),
+            members: vec![GroupMember {
+                value: "u-1".into(),
+                display: Some("alice".into()),
+                ref_uri: Some("/Users/u-1".into()),
+            }],
+            meta: ScimMeta::default(),
+        };
+        let json = serde_json::to_string(&group).unwrap();
+        assert!(json.contains("\"displayName\":\"engineering\""));
+        assert!(json.contains("\"members\""));
+        assert!(json.contains("\"value\":\"u-1\""));
+        // The member reference uses the SCIM `$ref` key, not the Rust field name.
+        assert!(json.contains("\"$ref\":\"/Users/u-1\""));
+        assert!(json.contains(SCHEMA_GROUP));
+        // Round-trips through serde.
+        let back: ScimGroup = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, group);
+    }
+
+    #[test]
+    fn group_default_schemas() {
+        let schemas = ScimGroup::default_schemas();
+        assert_eq!(schemas, vec![SCHEMA_GROUP.to_string()]);
     }
 }


### PR DESCRIPTION
The SCIM /Groups resource was not modeled. Adds ScimGroup (displayName,
members, meta) + GroupMember (value, display, $ref) per RFC 7643 §4.2, the
SCHEMA_GROUP URI constant, and the public exports. Serialization unit-tested
(camelCase, the $ref member key, round-trip). Foundation for the /Groups store
and routes.

Auths-Id: did:keri:EB5cPHY0t-ejNC_rUzPS1dclTvd6kG-R9mQzjozCuGgd
Auths-Device: did:keri:EB5cPHY0t-ejNC_rUzPS1dclTvd6kG-R9mQzjozCuGgd
Auths-Anchor-Seq: 1
