### PR TITLE
scim: add the /Groups resource — store and CRUD routes

### DIFF
--- a/crates/auths-scim-server/src/groups.rs
+++ b/crates/auths-scim-server/src/groups.rs
@@ -1,0 +1,182 @@
+//! SCIM `/Groups` resource handlers — org-directory groupings.
+//!
+//! `POST /Groups` creates a group, `GET /Groups` lists + paginates, `GET /Groups/{id}`
+//! fetches one, `PUT /Groups/{id}` replaces it (honoring `If-Match`), and `DELETE`
+//! soft-deletes it. Groups are a directory convenience, not KERI identities, so there is no
+//! provisioner round-trip — they live in the rebuildable in-memory store.
+
+use auths_scim::resource::{ScimGroup, ScimMeta};
+use auths_scim::{ScimError, ScimListResponse};
+use axum::Json;
+use axum::extract::{Path, Query, State};
+use axum::http::{HeaderMap, StatusCode};
+use serde::Deserialize;
+
+use crate::auth::AuthenticatedTenant;
+use crate::error::ScimServerError;
+use crate::state::ScimServerState;
+use crate::users::{etag_matches, presentation_now};
+
+/// `POST /scim/v2/Groups` — create a group. The server assigns the `id` and ETag.
+pub async fn create_group(
+    State(state): State<ScimServerState>,
+    tenant: AuthenticatedTenant,
+    Json(input): Json<ScimGroup>,
+) -> Result<(StatusCode, Json<ScimGroup>), ScimServerError> {
+    let now = presentation_now();
+    let id = new_group_id(&tenant.tenant_id, &input.display_name, now);
+    let group = ScimGroup {
+        schemas: ScimGroup::default_schemas(),
+        id: id.clone(),
+        external_id: input.external_id,
+        display_name: input.display_name,
+        members: input.members,
+        meta: ScimMeta {
+            resource_type: "Group".into(),
+            created: now,
+            last_modified: now,
+            version: String::new(), // insert stamps the content ETag
+            location: format!("{}/Groups/{}", tenant.base_url, id),
+        },
+    };
+    let stored = state.insert_group(&tenant.tenant_id, group);
+    Ok((StatusCode::CREATED, Json(stored)))
+}
+
+/// `GET /scim/v2/Groups` — list + paginate this tenant's groups (id-ordered for determinism).
+pub async fn list_groups(
+    State(state): State<ScimServerState>,
+    tenant: AuthenticatedTenant,
+    Query(params): Query<GroupListParams>,
+) -> Result<Json<ScimListResponse<ScimGroup>>, ScimServerError> {
+    let mut groups = state.groups_for_tenant(&tenant.tenant_id);
+    groups.sort_by(|a, b| a.id.cmp(&b.id));
+    let total = groups.len() as u64;
+
+    let start_index = params.start_index.unwrap_or(1).max(1);
+    let skip = (start_index - 1) as usize;
+    let count = params.count.unwrap_or(u64::MAX);
+    let page: Vec<ScimGroup> = groups.into_iter().skip(skip).take(count as usize).collect();
+    Ok(Json(ScimListResponse::new(page, total, start_index)))
+}
+
+/// `GET /scim/v2/Groups/{id}` — fetch one group; unknown id → 404 envelope.
+pub async fn get_group(
+    State(state): State<ScimServerState>,
+    tenant: AuthenticatedTenant,
+    Path(id): Path<String>,
+) -> Result<Json<ScimGroup>, ScimServerError> {
+    state
+        .find_group_by_id(&tenant.tenant_id, &id)
+        .map(Json)
+        .ok_or_else(|| ScimServerError::from(ScimError::NotFound { id }))
+}
+
+/// `PUT /scim/v2/Groups/{id}` — full-resource replace honoring `If-Match` optimistic
+/// concurrency (a stale match → 412; `*` or absent → allowed). The store refreshes the ETag.
+pub async fn put_group(
+    State(state): State<ScimServerState>,
+    tenant: AuthenticatedTenant,
+    Path(id): Path<String>,
+    headers: HeaderMap,
+    Json(input): Json<ScimGroup>,
+) -> Result<Json<ScimGroup>, ScimServerError> {
+    let if_match = headers
+        .get(axum::http::header::IF_MATCH)
+        .and_then(|v| v.to_str().ok())
+        .map(str::to_string);
+    let updated = state.update_group(&tenant.tenant_id, &id, move |current| {
+        apply_group_put(current, input, if_match.as_deref())
+    })?;
+    Ok(Json(updated))
+}
+
+/// `DELETE /scim/v2/Groups/{id}` — soft-delete (tombstone). Idempotent; always 204.
+pub async fn delete_group(
+    State(state): State<ScimServerState>,
+    tenant: AuthenticatedTenant,
+    Path(id): Path<String>,
+) -> StatusCode {
+    state.delete_group(&tenant.tenant_id, &id);
+    StatusCode::NO_CONTENT
+}
+
+/// Apply a `PUT` replacement to a group, enforcing `If-Match`. Pure, so the precondition is
+/// tested without the HTTP layer; `meta` is left for the store to refresh.
+fn apply_group_put(
+    current: ScimGroup,
+    input: ScimGroup,
+    if_match: Option<&str>,
+) -> Result<ScimGroup, ScimError> {
+    if let Some(expected) = if_match
+        && !etag_matches(expected, &current.meta.version)
+    {
+        return Err(ScimError::PreconditionFailed);
+    }
+    let mut next = current;
+    next.external_id = input.external_id;
+    next.display_name = input.display_name;
+    next.members = input.members;
+    Ok(next)
+}
+
+/// A server-assigned group id, derived from the tenant, display name, and creation time so it
+/// is unique without an external id source.
+fn new_group_id(tenant_id: &str, display_name: &str, now: chrono::DateTime<chrono::Utc>) -> String {
+    use std::hash::{Hash, Hasher};
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    tenant_id.hash(&mut hasher);
+    display_name.hash(&mut hasher);
+    now.timestamp_nanos_opt().unwrap_or(0).hash(&mut hasher);
+    format!("{:016x}", hasher.finish())
+}
+
+/// Pagination query parameters for `GET /Groups`.
+#[derive(Debug, Deserialize)]
+pub struct GroupListParams {
+    #[serde(rename = "startIndex", default)]
+    start_index: Option<u64>,
+    #[serde(default)]
+    count: Option<u64>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn group(id: &str, display: &str) -> ScimGroup {
+        ScimGroup {
+            schemas: ScimGroup::default_schemas(),
+            id: id.to_string(),
+            external_id: None,
+            display_name: display.to_string(),
+            members: vec![],
+            meta: Default::default(),
+        }
+    }
+
+    #[test]
+    fn group_put_enforces_if_match_and_replaces_fields() {
+        let mut current = group("g1", "eng");
+        current.meta.version = "W/\"abc\"".to_string();
+
+        // A stale If-Match → PreconditionFailed (412).
+        assert!(matches!(
+            apply_group_put(current.clone(), group("g1", "eng"), Some("W/\"stale\"")),
+            Err(ScimError::PreconditionFailed)
+        ));
+
+        // A matching If-Match → replace succeeds (displayName updated).
+        let out = apply_group_put(
+            current.clone(),
+            group("g1", "engineering"),
+            Some("W/\"abc\""),
+        )
+        .unwrap();
+        assert_eq!(out.display_name, "engineering");
+
+        // `*` matches; absent If-Match is permitted.
+        assert!(apply_group_put(current.clone(), group("g1", "eng"), Some("*")).is_ok());
+        assert!(apply_group_put(current, group("g1", "eng"), None).is_ok());
+    }
+}

--- a/crates/auths-scim-server/src/lib.rs
+++ b/crates/auths-scim-server/src/lib.rs
@@ -14,6 +14,7 @@
 mod auth;
 mod discovery;
 mod error;
+mod groups;
 mod lifecycle;
 mod provisioner;
 mod serve;
@@ -72,6 +73,16 @@ pub fn router(state: ScimServerState) -> Router {
                 .delete(lifecycle::delete_user),
         )
         .route("/scim/v2/Users/{id}/revoke", post(lifecycle::revoke_user))
+        .route(
+            "/scim/v2/Groups",
+            get(groups::list_groups).post(groups::create_group),
+        )
+        .route(
+            "/scim/v2/Groups/{id}",
+            get(groups::get_group)
+                .put(groups::put_group)
+                .delete(groups::delete_group),
+        )
         .route("/health", get(health))
         .with_state(state)
 }

--- a/crates/auths-scim-server/src/state.rs
+++ b/crates/auths-scim-server/src/state.rs
@@ -10,7 +10,7 @@ use std::collections::HashMap;
 use std::sync::{Arc, Mutex, MutexGuard};
 
 use auths_scim::ScimError;
-use auths_scim::resource::ScimUser;
+use auths_scim::resource::{ScimGroup, ScimUser};
 use auths_verifier::Capability;
 use sha2::{Digest, Sha256};
 
@@ -134,10 +134,101 @@ struct UserStore {
     by_id: HashMap<String, StoredUser>,
 }
 
+/// A stored SCIM Group plus its owning tenant. `deleted` is the soft-delete tombstone,
+/// matching the user store's semantics (hidden from reads, recoverable).
+struct StoredGroup {
+    tenant_id: String,
+    group: ScimGroup,
+    deleted: bool,
+}
+
+/// The per-tenant Group index. Mirrors [`UserStore`]; KEL plays no part — Groups are an
+/// org-directory convenience, not cryptographic identities.
+#[derive(Default)]
+struct GroupStore {
+    by_id: HashMap<String, StoredGroup>,
+}
+
+impl GroupStore {
+    /// Insert a group, stamping a fresh content ETag, and return the stored value.
+    fn insert(&mut self, tenant_id: &str, mut group: ScimGroup) -> ScimGroup {
+        recompute_group_etag(&mut group);
+        let stored = group.clone();
+        self.by_id.insert(
+            group.id.clone(),
+            StoredGroup {
+                tenant_id: tenant_id.to_string(),
+                group,
+                deleted: false,
+            },
+        );
+        stored
+    }
+
+    /// A live group by id, scoped to its tenant (a tombstoned or cross-tenant id reads absent).
+    fn find_by_id(&self, tenant_id: &str, id: &str) -> Option<ScimGroup> {
+        self.by_id
+            .get(id)
+            .filter(|s| s.tenant_id == tenant_id && !s.deleted)
+            .map(|s| s.group.clone())
+    }
+
+    /// All live groups owned by a tenant (unordered; the handler sorts for determinism).
+    fn list_for_tenant(&self, tenant_id: &str) -> Vec<ScimGroup> {
+        self.by_id
+            .values()
+            .filter(|s| s.tenant_id == tenant_id && !s.deleted)
+            .map(|s| s.group.clone())
+            .collect()
+    }
+
+    /// Apply `f` to a live group, refreshing its ETag on write. Unknown/cross-tenant → NotFound.
+    fn update<F>(&mut self, tenant_id: &str, id: &str, f: F) -> Result<ScimGroup, ScimError>
+    where
+        F: FnOnce(ScimGroup) -> Result<ScimGroup, ScimError>,
+    {
+        let current = self
+            .by_id
+            .get(id)
+            .filter(|s| s.tenant_id == tenant_id && !s.deleted)
+            .map(|s| s.group.clone())
+            .ok_or_else(|| ScimError::NotFound { id: id.to_string() })?;
+        let mut updated = f(current)?;
+        recompute_group_etag(&mut updated);
+        if let Some(slot) = self.by_id.get_mut(id) {
+            slot.group = updated.clone();
+        }
+        Ok(updated)
+    }
+
+    /// Soft-delete (tombstone) a group, scoped to its tenant. Idempotent.
+    fn delete(&mut self, tenant_id: &str, id: &str) {
+        if let Some(slot) = self.by_id.get_mut(id)
+            && slot.tenant_id == tenant_id
+        {
+            slot.deleted = true;
+        }
+    }
+}
+
+/// Recompute a group's ETag (`meta.version`) from its content, so a mutation changes it — what
+/// `If-Match` needs to detect a stale write. Stable for unchanged content.
+fn recompute_group_etag(group: &mut ScimGroup) {
+    use std::hash::{Hash, Hasher};
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    group.display_name.hash(&mut hasher);
+    group.external_id.hash(&mut hasher);
+    for member in &group.members {
+        member.value.hash(&mut hasher);
+    }
+    group.meta.version = format!("W/\"{:x}\"", hasher.finish());
+}
+
 struct Inner {
     tenants: HashMap<String, TenantConfig>,
     provisioner: Arc<dyn Provisioner>,
     store: Mutex<UserStore>,
+    groups: Mutex<GroupStore>,
 }
 
 impl Inner {
@@ -145,6 +236,13 @@ impl Inner {
     /// a poisoned cache is still safe to read/overwrite, so we never `unwrap`.
     fn store(&self) -> MutexGuard<'_, UserStore> {
         self.store
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+
+    /// Lock the group store, recovering a poisoned guard the same way.
+    fn groups(&self) -> MutexGuard<'_, GroupStore> {
+        self.groups
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner())
     }
@@ -177,6 +275,7 @@ impl ScimServerState {
                 tenants,
                 provisioner,
                 store: Mutex::new(UserStore::default()),
+                groups: Mutex::new(GroupStore::default()),
             }),
         }
     }
@@ -337,6 +436,39 @@ impl ScimServerState {
             slot.user.active = false;
         }
     }
+
+    /// Store a new group (stamps its ETag), returning the stored value.
+    pub(crate) fn insert_group(&self, tenant_id: &str, group: ScimGroup) -> ScimGroup {
+        self.inner.groups().insert(tenant_id, group)
+    }
+
+    /// A live group by id, scoped to its tenant (tombstoned/cross-tenant → absent).
+    pub(crate) fn find_group_by_id(&self, tenant_id: &str, id: &str) -> Option<ScimGroup> {
+        self.inner.groups().find_by_id(tenant_id, id)
+    }
+
+    /// All live groups owned by a tenant (unordered; the handler sorts for determinism).
+    pub(crate) fn groups_for_tenant(&self, tenant_id: &str) -> Vec<ScimGroup> {
+        self.inner.groups().list_for_tenant(tenant_id)
+    }
+
+    /// Apply `f` to a live group, refreshing its ETag on write. Unknown/cross-tenant → NotFound.
+    pub(crate) fn update_group<F>(
+        &self,
+        tenant_id: &str,
+        id: &str,
+        f: F,
+    ) -> Result<ScimGroup, ScimError>
+    where
+        F: FnOnce(ScimGroup) -> Result<ScimGroup, ScimError>,
+    {
+        self.inner.groups().update(tenant_id, id, f)
+    }
+
+    /// Soft-delete (tombstone) a group, scoped to its tenant. Idempotent.
+    pub(crate) fn delete_group(&self, tenant_id: &str, id: &str) {
+        self.inner.groups().delete(tenant_id, id)
+    }
 }
 
 /// Recompute a resource's ETag (`meta.version`) from its mutable content, so any mutation
@@ -388,5 +520,52 @@ mod tests {
         a.user_name = "alice-renamed".to_string();
         recompute_etag(&mut a);
         assert_ne!(a.meta.version, v1, "a content change must change the ETag");
+    }
+
+    fn group(id: &str, display: &str) -> ScimGroup {
+        ScimGroup {
+            schemas: ScimGroup::default_schemas(),
+            id: id.to_string(),
+            external_id: None,
+            display_name: display.to_string(),
+            members: vec![],
+            meta: Default::default(),
+        }
+    }
+
+    #[test]
+    fn group_store_isolates_tenants_and_bumps_etag_on_update() {
+        let mut store = GroupStore::default();
+        let inserted = store.insert("t1", group("g1", "eng"));
+        store.insert("t2", group("g2", "sales"));
+        assert!(
+            inserted.meta.version.starts_with("W/\""),
+            "insert stamps a real ETag"
+        );
+
+        // Reads are tenant-scoped.
+        assert_eq!(store.find_by_id("t1", "g1").unwrap().display_name, "eng");
+        assert!(store.find_by_id("t2", "g1").is_none(), "tenant isolation");
+        assert_eq!(store.list_for_tenant("t1").len(), 1);
+
+        // An update applies the change and bumps the ETag; a cross-tenant update is NotFound.
+        let before = inserted.meta.version.clone();
+        let updated = store
+            .update("t1", "g1", |mut g| {
+                g.display_name = "engineering".to_string();
+                Ok(g)
+            })
+            .unwrap();
+        assert_eq!(updated.display_name, "engineering");
+        assert_ne!(
+            updated.meta.version, before,
+            "a mutation bumps the group ETag"
+        );
+        assert!(store.update("t2", "g1", Ok).is_err(), "cross-tenant update");
+
+        // Delete tombstones: hidden from find + list.
+        store.delete("t1", "g1");
+        assert!(store.find_by_id("t1", "g1").is_none());
+        assert_eq!(store.list_for_tenant("t1").len(), 0);
     }
 }

--- a/crates/auths-scim-server/src/users.rs
+++ b/crates/auths-scim-server/src/users.rs
@@ -172,7 +172,7 @@ fn apply_put(
 
 /// Whether an `If-Match` value matches the current ETag: `*` matches any existing resource,
 /// otherwise some ETag in the comma-separated list must equal `current` (RFC 7232).
-fn etag_matches(if_match: &str, current: &str) -> bool {
+pub(crate) fn etag_matches(if_match: &str, current: &str) -> bool {
     let v = if_match.trim();
     v == "*" || v.split(',').any(|t| t.trim() == current)
 }
@@ -194,7 +194,7 @@ pub struct ListParams {
 
 /// The presentation-boundary timestamp for new resources.
 #[allow(clippy::disallowed_methods)] // SCIM server is a presentation layer (like the CLI)
-fn presentation_now() -> chrono::DateTime<chrono::Utc> {
+pub(crate) fn presentation_now() -> chrono::DateTime<chrono::Utc> {
     chrono::Utc::now()
 }
 


### PR DESCRIPTION
Adds a per-tenant GroupStore (mirroring the user store: insert/find/list/
update/delete, soft-delete tombstone, content ETag recomputed on mutation) and
the /Groups routes: GET/POST /Groups and GET/PUT/DELETE /Groups/{id}. PUT honors
If-Match optimistic concurrency (stale → 412). Store behavior (tenant isolation,
ETag bump, tombstone) and the PUT precondition are unit-tested. The discovery
entries and PATCH follow in a separate change.

Auths-Id: did:keri:EB5cPHY0t-ejNC_rUzPS1dclTvd6kG-R9mQzjozCuGgd
Auths-Device: did:keri:EB5cPHY0t-ejNC_rUzPS1dclTvd6kG-R9mQzjozCuGgd
Auths-Anchor-Seq: 1
