### PR TITLE
chore: add ee/ commercial tier; move auths-idp into it (source-available)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,8 @@
 [workspace]
 resolver = "3"
+# ee/ is the source-available commercial tier — its own workspace, never built or shipped
+# by the open-source (Apache-2.0) workspace.
+exclude = ["ee"]
 members = [
   "crates/auths",
   "crates/auths-core",

--- a/ee/Cargo.toml
+++ b/ee/Cargo.toml
@@ -1,0 +1,19 @@
+# Auths commercial tier — source-available, NOT open source.
+#
+# Crates under ee/ are licensed separately from the Apache-2.0 crates under crates/ and are
+# NOT part of the open-source workspace. This is its own Cargo workspace; the root workspace
+# excludes it via `exclude = ["ee"]`, so `cargo build --workspace` at the repo root never
+# compiles or ships these crates.
+[workspace]
+resolver = "3"
+members = ["auths-idp"]
+
+[workspace.package]
+version = "0.1.3"
+license = "LicenseRef-Proprietary"
+repository = "https://github.com/auths-dev/auths"
+homepage = "https://github.com/auths-dev/auths"
+
+[workspace.dependencies]
+thiserror = "2"
+tokio = { version = "1" }

--- a/ee/LICENSE
+++ b/ee/LICENSE
@@ -1,0 +1,14 @@
+Auths Commercial License (Proprietary, Source-Available)
+========================================================
+
+Copyright (c) Auths.
+
+The software in this directory (the "Commercial Tier") is source-available but NOT open
+source. It is licensed separately from the Apache-2.0 licensed software under `../crates`.
+
+All rights reserved. No license, express or implied, is granted to use, copy, modify, or
+distribute this software except under the terms of a separate written commercial agreement
+with the copyright holder.
+
+This is a placeholder notice. Replace it with the final commercial / source-available license
+terms before any distribution.

--- a/ee/README.md
+++ b/ee/README.md
@@ -1,0 +1,18 @@
+# Auths — Enterprise / Commercial tier (`ee/`)
+
+Crates in this directory are **source-available but not open source**. They are licensed
+separately from the Apache-2.0 crates under [`../crates`](../crates) and are **not** part of the
+open-source product.
+
+- **License:** `LicenseRef-Proprietary` (see [`LICENSE`](./LICENSE)). Not redistributable under
+  Apache-2.0.
+- **Build:** `ee/` is its own Cargo workspace. The root workspace excludes it
+  (`exclude = ["ee"]`), so `cargo build --workspace` at the repo root never compiles or ships
+  these crates. Build them explicitly with `cargo build --manifest-path ee/Cargo.toml`.
+- **Publishing:** every crate here sets `publish = false`.
+
+## Crates
+
+| Crate | Purpose |
+|-------|---------|
+| `auths-idp` | Enterprise IdP verification — OIDC/SAML identity binding (the "log in with your company IdP" verifier). |

--- a/ee/auths-idp/Cargo.toml
+++ b/ee/auths-idp/Cargo.toml
@@ -1,0 +1,45 @@
+[package]
+name = "auths-idp"
+version.workspace = true
+edition = "2024"
+rust-version = "1.93"
+authors = ["Auths Contributors"]
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+publish = false
+description = "Enterprise IdP verification — OIDC and SAML identity binding for Auths"
+
+[features]
+default = ["oidc"]
+oidc = ["dep:reqwest", "dep:jsonwebtoken"]
+saml = ["dep:samael", "dep:base64", "dep:reqwest"]
+test-utils = []
+
+[lib]
+name = "auths_idp"
+path = "src/lib.rs"
+
+[dependencies]
+async-trait = "0.1"
+chrono = { version = "0.4", features = ["serde"] }
+json-canon = "0.1"
+jsonwebtoken = { version = "10.3.0", optional = true }
+reqwest = { version = "0.13.2", default-features = false, features = ["json", "rustls-tls"], optional = true }
+samael = { version = "0.0.19", optional = true }
+base64 = { version = "0.22", optional = true }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+thiserror.workspace = true
+tokio = { workspace = true, features = ["sync", "time"] }
+tracing = "0.1"
+
+[dev-dependencies]
+async-trait = "0.1"
+axum = "0.8"
+base64 = "0.22.1"
+chrono = "0.4"
+jsonwebtoken = "10.3.0"
+rsa = { version = "0.9", features = ["pem"] }
+serde_json = "1"
+tokio = { workspace = true, features = ["full", "test-util"] }

--- a/ee/auths-idp/src/binding.rs
+++ b/ee/auths-idp/src/binding.rs
@@ -1,0 +1,135 @@
+//! IdP binding attestation type and binding workflow.
+//!
+//! Validates an IdP credential and constructs a canonicalized binding
+//! attestation suitable for KEL anchoring via `anchor_data()`.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use crate::error::IdpError;
+use crate::oidc::IdpVerifier;
+use crate::types::IdpProtocol;
+
+/// An attestation that a DID was authenticated by an enterprise IdP.
+///
+/// Stored as a canonicalized JSON blob referenced by SAID in the KEL.
+/// No expiration — the binding records a fact ("this DID was authenticated
+/// by $IdP at time T"). Freshness enforcement belongs to the policy layer.
+///
+/// Args:
+/// * `version`: Schema version (currently 1).
+/// * `idp_issuer`: The IdP's issuer URL or SAML entity ID.
+/// * `idp_protocol`: Whether this binding came from OIDC or SAML.
+/// * `subject`: The stable IdP subject identifier (oid@tid for Entra ID).
+/// * `subject_email`: Email, if available (display/audit only).
+/// * `auth_time`: When the user authenticated at the IdP.
+/// * `auth_context_class`: ACR / AuthnContextClassRef.
+/// * `bound_did`: The `did:keri:...` identity being linked.
+/// * `timestamp`: When this binding attestation was created.
+///
+/// Usage:
+/// ```ignore
+/// let attestation = IdpBindingAttestation {
+///     version: 1,
+///     idp_issuer: "https://company.okta.com".into(),
+///     idp_protocol: IdpProtocol::Oidc,
+///     subject: "user-123".into(),
+///     subject_email: Some("user@company.com".into()),
+///     auth_time: Utc::now(),
+///     auth_context_class: None,
+///     bound_did: "did:keri:Eabc123".into(),
+///     timestamp: Utc::now(),
+/// };
+/// let canonical = attestation.canonicalize()?;
+/// ```
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct IdpBindingAttestation {
+    pub version: u8,
+    pub idp_issuer: String,
+    pub idp_protocol: IdpProtocol,
+    pub subject: String,
+    pub subject_email: Option<String>,
+    pub auth_time: DateTime<Utc>,
+    pub auth_context_class: Option<String>,
+    pub bound_did: String,
+    pub timestamp: DateTime<Utc>,
+}
+
+impl IdpBindingAttestation {
+    /// Produces the canonicalized JSON representation (per RFC 8785 / json-canon).
+    ///
+    /// Usage:
+    /// ```ignore
+    /// let canonical_bytes = attestation.canonicalize()?;
+    /// ```
+    pub fn canonicalize(&self) -> Result<Vec<u8>, IdpError> {
+        let value = serde_json::to_value(self)
+            .map_err(|e| IdpError::ProviderConfig(format!("serialization failed: {e}")))?;
+        json_canon::to_vec(&value)
+            .map_err(|e| IdpError::ProviderConfig(format!("canonicalization failed: {e}")))
+    }
+}
+
+/// Result of a successful IdP binding operation.
+///
+/// Contains the attestation and its canonical form, ready for KEL anchoring.
+///
+/// Args:
+/// * `attestation`: The full binding attestation.
+/// * `canonical_bytes`: The canonicalized JSON bytes (for signing / SAID computation).
+///
+/// Usage:
+/// ```ignore
+/// let result = bind_identity_to_idp(&verifier, credential, did, now).await?;
+/// // Anchor result.canonical_bytes with SealType::IdpBinding
+/// ```
+#[derive(Debug, Clone)]
+pub struct BindingResult {
+    pub attestation: IdpBindingAttestation,
+    pub canonical_bytes: Vec<u8>,
+}
+
+/// Validates an IdP credential and constructs a binding attestation.
+///
+/// This performs the verification and attestation construction. The caller
+/// is responsible for anchoring the result in the KEL via `anchor_data()`
+/// with `SealType::IdpBinding`.
+///
+/// Args:
+/// * `verifier`: The IdP-specific verifier (Okta, Entra, Google, SAML).
+/// * `credential`: Raw credential bytes (JWT for OIDC, XML for SAML).
+/// * `bound_did`: The `did:keri:...` identity to bind.
+/// * `now`: Current time (injected for testability).
+///
+/// Usage:
+/// ```ignore
+/// let result = bind_identity_to_idp(&okta_verifier, jwt_bytes, "did:keri:Eabc", now).await?;
+/// let ixn_said = anchor_data(&identity, SealType::IdpBinding, &result.canonical_bytes)?;
+/// ```
+pub async fn bind_identity_to_idp(
+    verifier: &dyn IdpVerifier,
+    credential: &[u8],
+    bound_did: &str,
+    now: DateTime<Utc>,
+) -> Result<BindingResult, IdpError> {
+    let identity = verifier.verify(credential, now).await?;
+
+    let attestation = IdpBindingAttestation {
+        version: 1,
+        idp_issuer: identity.idp_issuer,
+        idp_protocol: identity.idp_protocol,
+        subject: identity.subject,
+        subject_email: identity.subject_email,
+        auth_time: identity.auth_time,
+        auth_context_class: identity.auth_context_class,
+        bound_did: bound_did.to_string(),
+        timestamp: now,
+    };
+
+    let canonical_bytes = attestation.canonicalize()?;
+
+    Ok(BindingResult {
+        attestation,
+        canonical_bytes,
+    })
+}

--- a/ee/auths-idp/src/error.rs
+++ b/ee/auths-idp/src/error.rs
@@ -1,0 +1,36 @@
+//! IdP verification errors.
+
+use thiserror::Error;
+
+/// Errors produced during IdP verification and JWKS operations.
+///
+/// Args:
+/// * `TokenInvalid`: The IdP token failed signature or claims validation.
+/// * `JwksFetchFailed`: JWKS key fetch failed (network or parse error).
+/// * `ProviderConfig`: The IdP provider is misconfigured.
+/// * `UnsupportedProtocol`: The IdP protocol is not supported.
+///
+/// Usage:
+/// ```ignore
+/// match idp_verifier.verify(token, now).await {
+///     Err(IdpError::TokenInvalid(msg)) => eprintln!("bad token: {msg}"),
+///     Err(IdpError::JwksFetchFailed(msg)) => eprintln!("JWKS error: {msg}"),
+///     _ => {}
+/// }
+/// ```
+#[derive(Debug, Error)]
+pub enum IdpError {
+    #[error("token invalid: {0}")]
+    TokenInvalid(String),
+
+    #[error("JWKS fetch failed: {0}")]
+    JwksFetchFailed(String),
+
+    #[error("provider misconfigured: {0}")]
+    ProviderConfig(String),
+
+    #[error("unsupported protocol: {0}")]
+    UnsupportedProtocol(String),
+}
+
+pub type IdpResult<T> = Result<T, IdpError>;

--- a/ee/auths-idp/src/jwks.rs
+++ b/ee/auths-idp/src/jwks.rs
@@ -1,0 +1,362 @@
+//! Generic OIDC JWKS client with caching, circuit-breaker, and request coalescing.
+//!
+//! Extracted from the GitHub-specific `JwksClient` in `auths-oidc-bridge`,
+//! generalized for any OIDC provider (Okta, Entra ID, Google Workspace, etc.).
+
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::time::{Duration, Instant};
+
+use jsonwebtoken::DecodingKey;
+use jsonwebtoken::jwk::JwkSet;
+use tokio::sync::{Mutex, RwLock};
+
+use crate::error::IdpError;
+
+const DEFAULT_CACHE_TTL: Duration = Duration::from_secs(3600);
+const CIRCUIT_BREAKER_THRESHOLD: u32 = 5;
+const CIRCUIT_BREAKER_COOLDOWN: Duration = Duration::from_secs(60);
+const BACKOFF_INITIAL: Duration = Duration::from_secs(1);
+const BACKOFF_MAX: Duration = Duration::from_secs(30);
+
+struct CachedJwks {
+    keys: JwkSet,
+    fetched_at: Instant,
+}
+
+struct CircuitBreakerState {
+    consecutive_failures: AtomicU32,
+    last_failure_at: RwLock<Option<Instant>>,
+}
+
+/// Generic OIDC JWKS client with resilient fetching.
+///
+/// Provides caching with configurable TTL, thundering-herd protection
+/// via request coalescing, exponential backoff on failures, circuit-breaker
+/// after consecutive failures, and stale-cache fallback on transient errors.
+///
+/// Args:
+/// * `issuer`: The OIDC issuer URL (used to derive the JWKS endpoint).
+/// * `expected_audience`: Audience to validate tokens against (confused-deputy prevention).
+/// * `cache_ttl`: How long to cache JWKS keys before refreshing.
+///
+/// Usage:
+/// ```ignore
+/// let client = OidcJwksClient::new(
+///     "https://company.okta.com",
+///     "my-app-client-id",
+///     Duration::from_secs(3600),
+/// );
+/// let key = client.get_key_for_token(&jwt).await?;
+/// ```
+pub struct OidcJwksClient {
+    http: reqwest::Client,
+    jwks_url: String,
+    expected_audience: String,
+    issuer: String,
+    cache: RwLock<Option<CachedJwks>>,
+    cache_ttl: Duration,
+    fetch_lock: Mutex<()>,
+    circuit_breaker: CircuitBreakerState,
+}
+
+impl OidcJwksClient {
+    /// Creates a new JWKS client.
+    ///
+    /// Args:
+    /// * `issuer`: The OIDC issuer URL.
+    /// * `expected_audience`: The audience to validate tokens against.
+    /// * `cache_ttl`: How long to cache JWKS keys before refreshing.
+    ///
+    /// Usage:
+    /// ```ignore
+    /// let client = OidcJwksClient::new(
+    ///     "https://login.microsoftonline.com/{tenant}/v2.0",
+    ///     "client-id",
+    ///     Duration::from_secs(3600),
+    /// );
+    /// ```
+    pub fn new(issuer: &str, expected_audience: &str, cache_ttl: Duration) -> Self {
+        let jwks_url = format!(
+            "{}/.well-known/openid-configuration/jwks",
+            issuer.trim_end_matches('/')
+        );
+        Self {
+            // INVARIANT: reqwest Client::builder with only timeout cannot fail
+            #[allow(clippy::expect_used)]
+            http: reqwest::Client::builder()
+                .timeout(Duration::from_secs(10))
+                .build()
+                .expect("failed to build HTTP client"),
+            jwks_url,
+            expected_audience: expected_audience.to_string(),
+            issuer: issuer.to_string(),
+            cache: RwLock::new(None),
+            cache_ttl,
+            fetch_lock: Mutex::new(()),
+            circuit_breaker: CircuitBreakerState {
+                consecutive_failures: AtomicU32::new(0),
+                last_failure_at: RwLock::new(None),
+            },
+        }
+    }
+
+    /// Creates a new JWKS client with default 1-hour cache TTL.
+    ///
+    /// Args:
+    /// * `issuer`: The OIDC issuer URL.
+    /// * `expected_audience`: The audience to validate tokens against.
+    ///
+    /// Usage:
+    /// ```ignore
+    /// let client = OidcJwksClient::with_defaults("https://company.okta.com", "client-id");
+    /// ```
+    pub fn with_defaults(issuer: &str, expected_audience: &str) -> Self {
+        Self::new(issuer, expected_audience, DEFAULT_CACHE_TTL)
+    }
+
+    /// Returns the configured expected audience.
+    pub fn expected_audience(&self) -> &str {
+        &self.expected_audience
+    }
+
+    /// Returns the configured issuer URL.
+    pub fn issuer(&self) -> &str {
+        &self.issuer
+    }
+
+    /// Returns the JWKS endpoint URL.
+    pub fn jwks_url(&self) -> &str {
+        &self.jwks_url
+    }
+
+    /// Retrieves the decoding key for a JWT by matching its `kid` header.
+    ///
+    /// Args:
+    /// * `token`: The raw JWT string to find the matching key for.
+    ///
+    /// Usage:
+    /// ```ignore
+    /// let key = client.get_key_for_token(&jwt_string).await?;
+    /// ```
+    pub async fn get_key_for_token(&self, token: &str) -> Result<DecodingKey, IdpError> {
+        let header = jsonwebtoken::decode_header(token)
+            .map_err(|e| IdpError::TokenInvalid(format!("invalid JWT header: {e}")))?;
+
+        let kid = header
+            .kid
+            .ok_or_else(|| IdpError::TokenInvalid("JWT header missing kid".to_string()))?;
+
+        if let Some(key) = self.find_key_in_cache(&kid).await {
+            return Ok(key);
+        }
+
+        self.refresh_and_find_key(&kid).await
+    }
+
+    async fn find_key_in_cache(&self, kid: &str) -> Option<DecodingKey> {
+        let cache = self.cache.read().await;
+        let cached = cache.as_ref()?;
+
+        if cached.fetched_at.elapsed() > self.cache_ttl {
+            return None;
+        }
+
+        find_key_in_jwks(&cached.keys, kid)
+    }
+
+    async fn refresh_and_find_key(&self, kid: &str) -> Result<DecodingKey, IdpError> {
+        let _guard = self.fetch_lock.lock().await;
+
+        if let Some(key) = self.find_key_in_cache(kid).await {
+            return Ok(key);
+        }
+
+        {
+            let cache = self.cache.read().await;
+            if let Some(cached) = cache.as_ref()
+                && let Some(key) = find_key_in_jwks(&cached.keys, kid)
+            {
+                return Ok(key);
+            }
+        }
+
+        match self.fetch_jwks().await {
+            Ok(jwks) => {
+                let key = find_key_in_jwks(&jwks, kid).ok_or_else(|| {
+                    IdpError::TokenInvalid(format!("kid '{kid}' not found in JWKS"))
+                })?;
+
+                let mut cache = self.cache.write().await;
+                *cache = Some(CachedJwks {
+                    keys: jwks,
+                    fetched_at: Instant::now(),
+                });
+
+                self.circuit_breaker
+                    .consecutive_failures
+                    .store(0, Ordering::Relaxed);
+
+                Ok(key)
+            }
+            Err(fetch_err) => {
+                self.record_failure().await;
+
+                let cache = self.cache.read().await;
+                if let Some(cached) = cache.as_ref()
+                    && let Some(key) = find_key_in_jwks(&cached.keys, kid)
+                {
+                    tracing::warn!(
+                        kid = kid,
+                        error = %fetch_err,
+                        "serving stale JWKS cache after fetch failure"
+                    );
+                    return Ok(key);
+                }
+
+                Err(fetch_err)
+            }
+        }
+    }
+
+    async fn fetch_jwks(&self) -> Result<JwkSet, IdpError> {
+        if self.is_circuit_open().await {
+            return Err(IdpError::JwksFetchFailed(
+                "circuit breaker open".to_string(),
+            ));
+        }
+
+        let failures = self
+            .circuit_breaker
+            .consecutive_failures
+            .load(Ordering::Relaxed);
+        if failures > 0 {
+            let backoff = compute_backoff(failures);
+            tokio::time::sleep(backoff).await;
+        }
+
+        let response = self
+            .http
+            .get(&self.jwks_url)
+            .send()
+            .await
+            .map_err(|e| IdpError::JwksFetchFailed(format!("request failed: {e}")))?;
+
+        if !response.status().is_success() {
+            return Err(IdpError::JwksFetchFailed(format!(
+                "HTTP {}",
+                response.status()
+            )));
+        }
+
+        response
+            .json::<JwkSet>()
+            .await
+            .map_err(|e| IdpError::JwksFetchFailed(format!("invalid JWKS JSON: {e}")))
+    }
+
+    async fn is_circuit_open(&self) -> bool {
+        let failures = self
+            .circuit_breaker
+            .consecutive_failures
+            .load(Ordering::Relaxed);
+        if failures < CIRCUIT_BREAKER_THRESHOLD {
+            return false;
+        }
+
+        let last_failure = self.circuit_breaker.last_failure_at.read().await;
+        match *last_failure {
+            Some(t) => t.elapsed() < CIRCUIT_BREAKER_COOLDOWN,
+            None => false,
+        }
+    }
+
+    async fn record_failure(&self) {
+        self.circuit_breaker
+            .consecutive_failures
+            .fetch_add(1, Ordering::Relaxed);
+        let mut last = self.circuit_breaker.last_failure_at.write().await;
+        *last = Some(Instant::now());
+    }
+}
+
+/// Creates an `OidcJwksClient` with a custom JWKS URL for testing.
+///
+/// Args:
+/// * `jwks_url`: Direct URL to the JWKS endpoint (bypasses discovery).
+/// * `issuer`: The issuer URL for token validation.
+/// * `expected_audience`: The audience to validate tokens against.
+///
+/// Usage:
+/// ```ignore
+/// let client = test_jwks_client("http://localhost:9999/jwks", "https://idp.example.com", "test-aud");
+/// ```
+pub fn test_jwks_client(jwks_url: &str, issuer: &str, expected_audience: &str) -> OidcJwksClient {
+    OidcJwksClient {
+        // INVARIANT: reqwest Client::builder with only timeout cannot fail
+        #[allow(clippy::expect_used)]
+        http: reqwest::Client::builder()
+            .timeout(Duration::from_secs(5))
+            .build()
+            .expect("failed to build HTTP client"),
+        jwks_url: jwks_url.to_string(),
+        expected_audience: expected_audience.to_string(),
+        issuer: issuer.to_string(),
+        cache: RwLock::new(None),
+        cache_ttl: DEFAULT_CACHE_TTL,
+        fetch_lock: Mutex::new(()),
+        circuit_breaker: CircuitBreakerState {
+            consecutive_failures: AtomicU32::new(0),
+            last_failure_at: RwLock::new(None),
+        },
+    }
+}
+
+fn find_key_in_jwks(jwks: &JwkSet, kid: &str) -> Option<DecodingKey> {
+    jwks.find(kid)
+        .and_then(|jwk| DecodingKey::from_jwk(jwk).ok())
+}
+
+fn compute_backoff(failures: u32) -> Duration {
+    let base = BACKOFF_INITIAL.as_millis() as u64;
+    let exp = base.saturating_mul(1u64 << failures.min(10));
+    let capped = exp.min(BACKOFF_MAX.as_millis() as u64);
+    let jitter = (failures as u64 * 137) % (capped / 4 + 1);
+    Duration::from_millis(capped.saturating_sub(jitter))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_compute_backoff_increases() {
+        let b1 = compute_backoff(1);
+        let b3 = compute_backoff(3);
+        let b10 = compute_backoff(10);
+
+        assert!(b1 < b3, "backoff should increase: {b1:?} < {b3:?}");
+        assert!(b3 < b10, "backoff should increase: {b3:?} < {b10:?}");
+        assert!(
+            b10 <= BACKOFF_MAX,
+            "backoff should be capped at {BACKOFF_MAX:?}, got {b10:?}"
+        );
+    }
+
+    #[test]
+    fn test_jwks_url_construction() {
+        let client = OidcJwksClient::new("https://company.okta.com", "aud", DEFAULT_CACHE_TTL);
+        assert_eq!(
+            client.jwks_url(),
+            "https://company.okta.com/.well-known/openid-configuration/jwks"
+        );
+    }
+
+    #[test]
+    fn test_jwks_url_strips_trailing_slash() {
+        let client = OidcJwksClient::new("https://company.okta.com/", "aud", DEFAULT_CACHE_TTL);
+        assert_eq!(
+            client.jwks_url(),
+            "https://company.okta.com/.well-known/openid-configuration/jwks"
+        );
+    }
+}

--- a/ee/auths-idp/src/lib.rs
+++ b/ee/auths-idp/src/lib.rs
@@ -1,0 +1,34 @@
+//! Enterprise IdP verification for Auths.
+//!
+//! Provides the `IdpVerifier` trait and supporting types for binding
+//! Auths identities to corporate identity providers (Okta, Entra ID,
+//! Google Workspace, generic SAML 2.0).
+//!
+//! Usage:
+//! ```ignore
+//! use auths_idp::{IdpVerifier, IdpProtocol, VerifiedIdpIdentity, OidcJwksClient};
+//!
+//! let client = OidcJwksClient::with_defaults("https://company.okta.com", "client-id");
+//! let key = client.get_key_for_token(&jwt).await?;
+//! ```
+
+pub mod binding;
+pub mod error;
+#[cfg(feature = "oidc")]
+pub mod jwks;
+pub mod oidc;
+pub mod saml;
+pub mod types;
+
+pub use binding::{BindingResult, IdpBindingAttestation, bind_identity_to_idp};
+pub use error::{IdpError, IdpResult};
+#[cfg(feature = "oidc")]
+pub use jwks::OidcJwksClient;
+pub use oidc::IdpVerifier;
+#[cfg(feature = "oidc")]
+pub use oidc::entra::EntraIdpVerifier;
+#[cfg(feature = "oidc")]
+pub use oidc::google::GoogleIdpVerifier;
+#[cfg(feature = "oidc")]
+pub use oidc::okta::OktaIdpVerifier;
+pub use types::{IdpProtocol, VerifiedIdpIdentity};

--- a/ee/auths-idp/src/oidc/entra.rs
+++ b/ee/auths-idp/src/oidc/entra.rs
@@ -1,0 +1,147 @@
+//! Azure AD / Entra ID OIDC verifier.
+//!
+//! Entra ID uses pairwise `sub` claims — different per application.
+//! This verifier uses `oid` (Object ID) + `tid` (Tenant ID) as the
+//! compound subject identifier: `"{oid}@{tid}"`.
+
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use jsonwebtoken::{Algorithm, Validation, decode};
+
+use crate::error::IdpError;
+use crate::jwks::OidcJwksClient;
+use crate::oidc::{IdpVerifier, validate_standard_claims};
+use crate::types::{IdpProtocol, VerifiedIdpIdentity};
+
+/// Entra ID-specific claims extending standard OIDC.
+#[derive(Debug, Clone, serde::Deserialize)]
+struct EntraClaims {
+    iss: String,
+    sub: String,
+    aud: serde_json::Value,
+    #[serde(default)]
+    email: Option<String>,
+    #[serde(default)]
+    preferred_username: Option<String>,
+    #[serde(default)]
+    auth_time: Option<i64>,
+    #[serde(default)]
+    acr: Option<String>,
+    /// Object ID — stable, globally unique within the tenant.
+    #[serde(default)]
+    oid: Option<String>,
+    /// Tenant ID — identifies the Azure AD tenant.
+    #[serde(default)]
+    tid: Option<String>,
+    pub iat: i64,
+    pub exp: i64,
+}
+
+/// Entra ID (Azure AD) OIDC identity provider verifier.
+///
+/// Args:
+/// * `issuer`: The Entra ID issuer URL (e.g., "https://login.microsoftonline.com/{tenant}/v2.0").
+/// * `audience`: The expected application (client) ID.
+/// * `jwks_client`: The JWKS client for key fetching.
+///
+/// Usage:
+/// ```ignore
+/// let verifier = EntraIdpVerifier::new(
+///     "https://login.microsoftonline.com/{tenant}/v2.0",
+///     "app-client-id",
+///     OidcJwksClient::with_defaults("https://login.microsoftonline.com/{tenant}/v2.0", "app-client-id"),
+/// );
+/// let identity = verifier.verify(jwt_bytes, Utc::now()).await?;
+/// assert!(identity.subject.contains('@'));
+/// ```
+pub struct EntraIdpVerifier {
+    issuer: String,
+    audience: String,
+    jwks_client: OidcJwksClient,
+}
+
+impl EntraIdpVerifier {
+    /// Creates a new Entra ID verifier.
+    ///
+    /// Args:
+    /// * `issuer`: The Entra ID issuer URL.
+    /// * `audience`: The expected application (client) ID.
+    /// * `jwks_client`: JWKS client for key fetching.
+    pub fn new(
+        issuer: impl Into<String>,
+        audience: impl Into<String>,
+        jwks_client: OidcJwksClient,
+    ) -> Self {
+        Self {
+            issuer: issuer.into(),
+            audience: audience.into(),
+            jwks_client,
+        }
+    }
+}
+
+#[async_trait]
+impl IdpVerifier for EntraIdpVerifier {
+    async fn verify(
+        &self,
+        credential: &[u8],
+        now: DateTime<Utc>,
+    ) -> Result<VerifiedIdpIdentity, IdpError> {
+        let token = std::str::from_utf8(credential)
+            .map_err(|_| IdpError::TokenInvalid("credential is not valid UTF-8".to_string()))?;
+
+        let key = self.jwks_client.get_key_for_token(token).await?;
+
+        let mut validation = Validation::new(Algorithm::RS256);
+        validation.validate_exp = false;
+        validation.validate_aud = false;
+        validation.set_required_spec_claims(&["exp", "iss", "sub", "aud"]);
+
+        let token_data = decode::<EntraClaims>(token, &key, &validation)
+            .map_err(|e| IdpError::TokenInvalid(format!("JWT decode failed: {e}")))?;
+
+        let claims = token_data.claims;
+
+        let standard = crate::oidc::StandardOidcClaims {
+            iss: claims.iss.clone(),
+            sub: claims.sub.clone(),
+            aud: claims.aud.clone(),
+            email: claims.email.clone(),
+            auth_time: claims.auth_time,
+            acr: claims.acr.clone(),
+            iat: claims.iat,
+            exp: claims.exp,
+        };
+        validate_standard_claims(&standard, &self.issuer, &self.audience, now)?;
+
+        // Entra ID: use oid@tid as compound subject (pairwise sub is app-specific)
+        let subject = match (&claims.oid, &claims.tid) {
+            (Some(oid), Some(tid)) => format!("{oid}@{tid}"),
+            _ => claims.sub.clone(),
+        };
+
+        let subject_email = claims.email.or(claims.preferred_username);
+
+        let auth_time = claims
+            .auth_time
+            .and_then(|ts| DateTime::from_timestamp(ts, 0))
+            .unwrap_or(now);
+
+        Ok(VerifiedIdpIdentity {
+            idp_issuer: claims.iss,
+            idp_protocol: IdpProtocol::Oidc,
+            subject,
+            subject_email,
+            auth_time,
+            auth_context_class: claims.acr,
+        })
+    }
+
+    fn provider_name(&self) -> &str {
+        "entra-id"
+    }
+
+    fn protocol(&self) -> IdpProtocol {
+        IdpProtocol::Oidc
+    }
+}

--- a/ee/auths-idp/src/oidc/google.rs
+++ b/ee/auths-idp/src/oidc/google.rs
@@ -1,0 +1,163 @@
+//! Google Workspace OIDC verifier.
+//!
+//! Standard OIDC discovery with numeric `sub` (globally unique).
+//! Validates `hd` (hosted domain) claim for org membership verification.
+
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use jsonwebtoken::{Algorithm, Validation, decode};
+
+use crate::error::IdpError;
+use crate::jwks::OidcJwksClient;
+use crate::oidc::{IdpVerifier, validate_standard_claims};
+use crate::types::{IdpProtocol, VerifiedIdpIdentity};
+
+/// Google-specific claims extending standard OIDC.
+#[derive(Debug, Clone, serde::Deserialize)]
+struct GoogleClaims {
+    iss: String,
+    sub: String,
+    aud: serde_json::Value,
+    #[serde(default)]
+    email: Option<String>,
+    #[serde(default)]
+    #[allow(dead_code)]
+    email_verified: Option<bool>,
+    #[serde(default)]
+    auth_time: Option<i64>,
+    #[serde(default)]
+    acr: Option<String>,
+    /// Hosted domain — present for Google Workspace accounts.
+    #[serde(default)]
+    hd: Option<String>,
+    pub iat: i64,
+    pub exp: i64,
+}
+
+/// Google Workspace OIDC identity provider verifier.
+///
+/// Args:
+/// * `issuer`: The Google issuer URL (typically "https://accounts.google.com").
+/// * `audience`: The expected OAuth client ID.
+/// * `jwks_client`: The JWKS client for key fetching.
+/// * `required_domain`: If set, rejects tokens without a matching `hd` claim.
+///
+/// Usage:
+/// ```ignore
+/// let verifier = GoogleIdpVerifier::new(
+///     "https://accounts.google.com",
+///     "client-id.apps.googleusercontent.com",
+///     OidcJwksClient::with_defaults("https://accounts.google.com", "client-id"),
+/// ).with_required_domain("company.com");
+/// let identity = verifier.verify(jwt_bytes, Utc::now()).await?;
+/// ```
+pub struct GoogleIdpVerifier {
+    issuer: String,
+    audience: String,
+    jwks_client: OidcJwksClient,
+    required_domain: Option<String>,
+}
+
+impl GoogleIdpVerifier {
+    /// Creates a new Google Workspace verifier.
+    ///
+    /// Args:
+    /// * `issuer`: The Google issuer URL.
+    /// * `audience`: The expected OAuth client ID.
+    /// * `jwks_client`: JWKS client for key fetching.
+    pub fn new(
+        issuer: impl Into<String>,
+        audience: impl Into<String>,
+        jwks_client: OidcJwksClient,
+    ) -> Self {
+        Self {
+            issuer: issuer.into(),
+            audience: audience.into(),
+            jwks_client,
+            required_domain: None,
+        }
+    }
+
+    /// Restricts verification to a specific Google Workspace domain.
+    ///
+    /// Args:
+    /// * `domain`: The required hosted domain (e.g., "company.com").
+    pub fn with_required_domain(mut self, domain: impl Into<String>) -> Self {
+        self.required_domain = Some(domain.into());
+        self
+    }
+}
+
+#[async_trait]
+impl IdpVerifier for GoogleIdpVerifier {
+    async fn verify(
+        &self,
+        credential: &[u8],
+        now: DateTime<Utc>,
+    ) -> Result<VerifiedIdpIdentity, IdpError> {
+        let token = std::str::from_utf8(credential)
+            .map_err(|_| IdpError::TokenInvalid("credential is not valid UTF-8".to_string()))?;
+
+        let key = self.jwks_client.get_key_for_token(token).await?;
+
+        let mut validation = Validation::new(Algorithm::RS256);
+        validation.validate_exp = false;
+        validation.validate_aud = false;
+        validation.set_required_spec_claims(&["exp", "iss", "sub", "aud"]);
+
+        let token_data = decode::<GoogleClaims>(token, &key, &validation)
+            .map_err(|e| IdpError::TokenInvalid(format!("JWT decode failed: {e}")))?;
+
+        let claims = token_data.claims;
+
+        let standard = crate::oidc::StandardOidcClaims {
+            iss: claims.iss.clone(),
+            sub: claims.sub.clone(),
+            aud: claims.aud.clone(),
+            email: claims.email.clone(),
+            auth_time: claims.auth_time,
+            acr: claims.acr.clone(),
+            iat: claims.iat,
+            exp: claims.exp,
+        };
+        validate_standard_claims(&standard, &self.issuer, &self.audience, now)?;
+
+        if let Some(required_domain) = &self.required_domain {
+            match &claims.hd {
+                Some(hd) if hd == required_domain => {}
+                Some(hd) => {
+                    return Err(IdpError::TokenInvalid(format!(
+                        "hosted domain mismatch: expected '{required_domain}', got '{hd}'"
+                    )));
+                }
+                None => {
+                    return Err(IdpError::TokenInvalid(format!(
+                        "missing 'hd' claim: token is not from a Google Workspace account (expected domain: '{required_domain}')"
+                    )));
+                }
+            }
+        }
+
+        let auth_time = claims
+            .auth_time
+            .and_then(|ts| DateTime::from_timestamp(ts, 0))
+            .unwrap_or(now);
+
+        Ok(VerifiedIdpIdentity {
+            idp_issuer: claims.iss,
+            idp_protocol: IdpProtocol::Oidc,
+            subject: claims.sub,
+            subject_email: claims.email,
+            auth_time,
+            auth_context_class: claims.acr,
+        })
+    }
+
+    fn provider_name(&self) -> &str {
+        "google-workspace"
+    }
+
+    fn protocol(&self) -> IdpProtocol {
+        IdpProtocol::Oidc
+    }
+}

--- a/ee/auths-idp/src/oidc/mod.rs
+++ b/ee/auths-idp/src/oidc/mod.rs
@@ -1,0 +1,107 @@
+//! OIDC IdP verification — shared logic, trait, and provider implementations.
+
+#[cfg(feature = "oidc")]
+pub mod entra;
+#[cfg(feature = "oidc")]
+pub mod google;
+#[cfg(feature = "oidc")]
+pub mod okta;
+
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+
+use crate::error::IdpError;
+use crate::types::{IdpProtocol, VerifiedIdpIdentity};
+
+/// Trait for verifying enterprise IdP credentials.
+///
+/// Implementations handle provider-specific token validation (OIDC JWT
+/// verification, SAML assertion parsing) and return a normalized
+/// `VerifiedIdpIdentity`.
+///
+/// Args:
+/// * `credential`: Raw credential bytes (JWT string for OIDC, XML for SAML).
+/// * `now`: Current timestamp for expiry and freshness checks.
+///
+/// Usage:
+/// ```ignore
+/// let identity = verifier.verify(jwt_bytes, Utc::now()).await?;
+/// println!("Verified: {} from {}", identity.subject, identity.idp_issuer);
+/// ```
+#[async_trait]
+pub trait IdpVerifier: Send + Sync {
+    /// Verifies a credential and returns the verified identity.
+    ///
+    /// Args:
+    /// * `credential`: Raw credential bytes (JWT for OIDC, XML for SAML).
+    /// * `now`: Current time for expiry validation (injected for testability).
+    async fn verify(
+        &self,
+        credential: &[u8],
+        now: DateTime<Utc>,
+    ) -> Result<VerifiedIdpIdentity, IdpError>;
+
+    /// Human-readable provider name (e.g., "okta", "entra-id", "google-workspace").
+    fn provider_name(&self) -> &str;
+
+    /// The protocol this verifier handles.
+    fn protocol(&self) -> IdpProtocol;
+}
+
+/// Standard OIDC claims shared by all providers.
+#[cfg(feature = "oidc")]
+#[derive(Debug, Clone, serde::Deserialize)]
+pub(crate) struct StandardOidcClaims {
+    pub iss: String,
+    pub sub: String,
+    pub aud: serde_json::Value,
+    #[serde(default)]
+    pub email: Option<String>,
+    #[serde(default)]
+    pub auth_time: Option<i64>,
+    #[serde(default)]
+    pub acr: Option<String>,
+    #[allow(dead_code)]
+    pub iat: i64,
+    pub exp: i64,
+}
+
+/// Validates standard OIDC claims (issuer, audience, expiry).
+///
+/// Args:
+/// * `claims`: The deserialized OIDC claims.
+/// * `expected_issuer`: The expected issuer URL.
+/// * `expected_audience`: The expected audience.
+/// * `now`: Current time for expiry validation.
+#[cfg(feature = "oidc")]
+pub(crate) fn validate_standard_claims(
+    claims: &StandardOidcClaims,
+    expected_issuer: &str,
+    expected_audience: &str,
+    now: DateTime<Utc>,
+) -> Result<(), IdpError> {
+    if claims.iss != expected_issuer {
+        return Err(IdpError::TokenInvalid(format!(
+            "issuer mismatch: expected '{}', got '{}'",
+            expected_issuer, claims.iss
+        )));
+    }
+
+    let aud_matches = match &claims.aud {
+        serde_json::Value::String(s) => s == expected_audience,
+        serde_json::Value::Array(arr) => arr.iter().any(|v| v.as_str() == Some(expected_audience)),
+        _ => false,
+    };
+    if !aud_matches {
+        return Err(IdpError::TokenInvalid(format!(
+            "audience mismatch: expected '{expected_audience}'"
+        )));
+    }
+
+    let now_ts = now.timestamp();
+    if claims.exp < now_ts {
+        return Err(IdpError::TokenInvalid("token expired".to_string()));
+    }
+
+    Ok(())
+}

--- a/ee/auths-idp/src/oidc/okta.rs
+++ b/ee/auths-idp/src/oidc/okta.rs
@@ -1,0 +1,101 @@
+//! Okta OIDC IdP verifier.
+//!
+//! Standard OIDC discovery, `sub` claim as stable subject identifier.
+
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use jsonwebtoken::{Algorithm, Validation, decode};
+
+use crate::error::IdpError;
+use crate::jwks::OidcJwksClient;
+use crate::oidc::{IdpVerifier, StandardOidcClaims, validate_standard_claims};
+use crate::types::{IdpProtocol, VerifiedIdpIdentity};
+
+/// Okta OIDC identity provider verifier.
+///
+/// Args:
+/// * `issuer`: The Okta org URL (e.g., "https://company.okta.com").
+/// * `audience`: The expected audience (client ID).
+/// * `jwks_client`: The JWKS client for key fetching.
+///
+/// Usage:
+/// ```ignore
+/// let verifier = OktaIdpVerifier::new(
+///     "https://company.okta.com",
+///     "client-id",
+///     OidcJwksClient::with_defaults("https://company.okta.com", "client-id"),
+/// );
+/// let identity = verifier.verify(jwt_bytes, Utc::now()).await?;
+/// ```
+pub struct OktaIdpVerifier {
+    issuer: String,
+    audience: String,
+    jwks_client: OidcJwksClient,
+}
+
+impl OktaIdpVerifier {
+    /// Creates a new Okta verifier.
+    ///
+    /// Args:
+    /// * `issuer`: The Okta org URL.
+    /// * `audience`: The expected client ID / audience.
+    /// * `jwks_client`: JWKS client for key fetching.
+    pub fn new(
+        issuer: impl Into<String>,
+        audience: impl Into<String>,
+        jwks_client: OidcJwksClient,
+    ) -> Self {
+        Self {
+            issuer: issuer.into(),
+            audience: audience.into(),
+            jwks_client,
+        }
+    }
+}
+
+#[async_trait]
+impl IdpVerifier for OktaIdpVerifier {
+    async fn verify(
+        &self,
+        credential: &[u8],
+        now: DateTime<Utc>,
+    ) -> Result<VerifiedIdpIdentity, IdpError> {
+        let token = std::str::from_utf8(credential)
+            .map_err(|_| IdpError::TokenInvalid("credential is not valid UTF-8".to_string()))?;
+
+        let key = self.jwks_client.get_key_for_token(token).await?;
+
+        let mut validation = Validation::new(Algorithm::RS256);
+        validation.validate_exp = false;
+        validation.validate_aud = false;
+        validation.set_required_spec_claims(&["exp", "iss", "sub", "aud"]);
+
+        let token_data = decode::<StandardOidcClaims>(token, &key, &validation)
+            .map_err(|e| IdpError::TokenInvalid(format!("JWT decode failed: {e}")))?;
+
+        let claims = token_data.claims;
+        validate_standard_claims(&claims, &self.issuer, &self.audience, now)?;
+
+        let auth_time = claims
+            .auth_time
+            .and_then(|ts| DateTime::from_timestamp(ts, 0))
+            .unwrap_or(now);
+
+        Ok(VerifiedIdpIdentity {
+            idp_issuer: claims.iss,
+            idp_protocol: IdpProtocol::Oidc,
+            subject: claims.sub,
+            subject_email: claims.email,
+            auth_time,
+            auth_context_class: claims.acr,
+        })
+    }
+
+    fn provider_name(&self) -> &str {
+        "okta"
+    }
+
+    fn protocol(&self) -> IdpProtocol {
+        IdpProtocol::Oidc
+    }
+}

--- a/ee/auths-idp/src/saml/mod.rs
+++ b/ee/auths-idp/src/saml/mod.rs
@@ -1,0 +1,10 @@
+//! SAML 2.0 Service Provider module for enterprise IdP verification.
+//!
+//! Gated behind the `saml` feature flag. Requires `libxml2-dev` and
+//! `xmlsec1-dev` system packages at build time.
+
+#[cfg(feature = "saml")]
+pub mod provider;
+
+#[cfg(feature = "saml")]
+pub use provider::SamlIdpVerifier;

--- a/ee/auths-idp/src/saml/provider.rs
+++ b/ee/auths-idp/src/saml/provider.rs
@@ -1,0 +1,239 @@
+//! SAML 2.0 IdP verifier using `samael` for XML-DSig validation.
+//!
+//! Implements SP-initiated SSO with HTTP-POST binding.
+//! Validates XML signature BEFORE extracting claims.
+
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use samael::metadata::EntityDescriptor;
+use samael::schema::Response as SamlResponse;
+
+use crate::error::IdpError;
+use crate::oidc::IdpVerifier;
+use crate::types::{IdpProtocol, VerifiedIdpIdentity};
+
+/// SAML 2.0 Service Provider verifier.
+///
+/// Validates SAML assertions using the IdP's signing certificate
+/// from metadata. Enforces algorithm allowlist (SHA-256+) and
+/// prevents replay via consumed assertion ID tracking.
+///
+/// Args:
+/// * `entity_id`: The SP entity ID (audience restriction).
+/// * `idp_metadata`: Parsed IdP metadata with signing certificate.
+///
+/// Usage:
+/// ```ignore
+/// let metadata = SamlIdpVerifier::load_metadata_from_url("https://idp.example.com/metadata").await?;
+/// let verifier = SamlIdpVerifier::new("https://sp.example.com", metadata)?;
+/// let identity = verifier.verify(saml_response_xml, Utc::now()).await?;
+/// ```
+pub struct SamlIdpVerifier {
+    entity_id: String,
+    idp_entity_id: String,
+    idp_signing_cert: Vec<u8>,
+    consumed_ids: std::sync::RwLock<std::collections::HashSet<String>>,
+}
+
+impl SamlIdpVerifier {
+    /// Creates a new SAML verifier from IdP metadata.
+    ///
+    /// Args:
+    /// * `entity_id`: The SP entity ID (must match AudienceRestriction).
+    /// * `idp_metadata`: Parsed IdP metadata (EntityDescriptor).
+    pub fn new(
+        entity_id: impl Into<String>,
+        idp_metadata: &EntityDescriptor,
+    ) -> Result<Self, IdpError> {
+        let idp_entity_id = idp_metadata.entity_id.clone().ok_or_else(|| {
+            IdpError::ProviderConfig("IdP metadata missing entity_id".to_string())
+        })?;
+
+        let cert = extract_signing_cert(idp_metadata)?;
+
+        Ok(Self {
+            entity_id: entity_id.into(),
+            idp_entity_id,
+            idp_signing_cert: cert,
+            consumed_ids: std::sync::RwLock::new(std::collections::HashSet::new()),
+        })
+    }
+
+    /// Loads IdP metadata from a URL.
+    ///
+    /// Args:
+    /// * `url`: The metadata endpoint URL.
+    pub async fn load_metadata_from_url(url: &str) -> Result<EntityDescriptor, IdpError> {
+        let response = reqwest::get(url)
+            .await
+            .map_err(|e| IdpError::ProviderConfig(format!("metadata fetch failed: {e}")))?;
+
+        let body = response
+            .text()
+            .await
+            .map_err(|e| IdpError::ProviderConfig(format!("metadata read failed: {e}")))?;
+
+        Self::load_metadata_from_xml(&body)
+    }
+
+    /// Loads IdP metadata from an XML string.
+    ///
+    /// Args:
+    /// * `xml`: The metadata XML.
+    pub fn load_metadata_from_xml(xml: &str) -> Result<EntityDescriptor, IdpError> {
+        xml.parse::<EntityDescriptor>()
+            .map_err(|e| IdpError::ProviderConfig(format!("metadata parse failed: {e}")))
+    }
+}
+
+#[async_trait]
+impl IdpVerifier for SamlIdpVerifier {
+    async fn verify(
+        &self,
+        credential: &[u8],
+        now: DateTime<Utc>,
+    ) -> Result<VerifiedIdpIdentity, IdpError> {
+        let xml = std::str::from_utf8(credential)
+            .map_err(|_| IdpError::TokenInvalid("SAML response is not valid UTF-8".to_string()))?;
+
+        let response: SamlResponse = xml
+            .parse()
+            .map_err(|e| IdpError::TokenInvalid(format!("SAML response parse failed: {e}")))?;
+
+        samael::crypto::verify_signed_xml(xml.as_bytes(), &self.idp_signing_cert, Some("ID"))
+            .map_err(|e| IdpError::TokenInvalid(format!("XML signature invalid: {e}")))?;
+
+        let assertion = response
+            .assertion
+            .as_ref()
+            .ok_or_else(|| IdpError::TokenInvalid("SAML response missing assertion".to_string()))?;
+
+        if let Some(issuer_value) = &assertion.issuer.value
+            && issuer_value != &self.idp_entity_id
+        {
+            return Err(IdpError::TokenInvalid(format!(
+                "issuer mismatch: expected '{}', got '{issuer_value}'",
+                self.idp_entity_id
+            )));
+        }
+
+        if let Some(conditions) = &assertion.conditions {
+            validate_audience(conditions, &self.entity_id)?;
+            validate_time_conditions(conditions, now)?;
+        }
+
+        // Replay protection
+        {
+            let mut consumed = self
+                .consumed_ids
+                .write()
+                .map_err(|_| IdpError::ProviderConfig("consumed ID lock poisoned".to_string()))?;
+            if !consumed.insert(assertion.id.clone()) {
+                return Err(IdpError::TokenInvalid(format!(
+                    "replay detected: assertion ID '{}' already consumed",
+                    assertion.id
+                )));
+            }
+        }
+
+        let subject = assertion
+            .subject
+            .as_ref()
+            .and_then(|s| s.name_id.as_ref())
+            .map(|n| n.value.clone())
+            .ok_or_else(|| IdpError::TokenInvalid("assertion missing NameID".to_string()))?;
+
+        let (auth_time, auth_context_class) = extract_authn_statement(assertion);
+
+        Ok(VerifiedIdpIdentity {
+            idp_issuer: self.idp_entity_id.clone(),
+            idp_protocol: IdpProtocol::Saml2,
+            subject,
+            subject_email: None,
+            auth_time: auth_time.unwrap_or(now),
+            auth_context_class,
+        })
+    }
+
+    fn provider_name(&self) -> &str {
+        "saml"
+    }
+
+    fn protocol(&self) -> IdpProtocol {
+        IdpProtocol::Saml2
+    }
+}
+
+fn extract_signing_cert(metadata: &EntityDescriptor) -> Result<Vec<u8>, IdpError> {
+    use base64::Engine;
+
+    let cert_b64 = metadata
+        .idp_sso_descriptors
+        .as_ref()
+        .and_then(|descs| descs.first())
+        .map(|desc| &desc.key_descriptors)
+        .and_then(|kds| kds.first())
+        .and_then(|kd| kd.key_info.x509_data.as_ref())
+        .and_then(|x509| x509.certificates.first())
+        .ok_or_else(|| {
+            IdpError::ProviderConfig("no signing certificate in IdP metadata".to_string())
+        })?;
+
+    base64::engine::general_purpose::STANDARD
+        .decode(cert_b64.replace(['\n', '\r', ' '], ""))
+        .map_err(|e| IdpError::ProviderConfig(format!("invalid certificate encoding: {e}")))
+}
+
+fn validate_audience(
+    conditions: &samael::schema::Conditions,
+    expected: &str,
+) -> Result<(), IdpError> {
+    if let Some(restrictions) = &conditions.audience_restrictions {
+        for restriction in restrictions {
+            // audience is Vec<String> — compare directly
+            for audience in &restriction.audience {
+                if audience == expected {
+                    return Ok(());
+                }
+            }
+        }
+        return Err(IdpError::TokenInvalid(format!(
+            "audience restriction mismatch: expected '{expected}'"
+        )));
+    }
+    Ok(())
+}
+
+fn validate_time_conditions(
+    conditions: &samael::schema::Conditions,
+    now: DateTime<Utc>,
+) -> Result<(), IdpError> {
+    if let Some(not_before) = conditions.not_before
+        && now < not_before
+    {
+        return Err(IdpError::TokenInvalid(format!(
+            "assertion not yet valid (not_before: {not_before})"
+        )));
+    }
+    if let Some(not_on_or_after) = conditions.not_on_or_after
+        && now >= not_on_or_after
+    {
+        return Err(IdpError::TokenInvalid("assertion expired".to_string()));
+    }
+    Ok(())
+}
+
+fn extract_authn_statement(
+    assertion: &samael::schema::Assertion,
+) -> (Option<DateTime<Utc>>, Option<String>) {
+    let stmt = assertion
+        .authn_statements
+        .as_ref()
+        .and_then(|stmts| stmts.first());
+    let auth_time = stmt.and_then(|s| s.authn_instant);
+    let acr = stmt
+        .and_then(|s| s.authn_context.as_ref())
+        .and_then(|ctx| ctx.value.as_ref())
+        .and_then(|class_ref| class_ref.value.clone());
+    (auth_time, acr)
+}

--- a/ee/auths-idp/src/types.rs
+++ b/ee/auths-idp/src/types.rs
@@ -1,0 +1,58 @@
+//! Core types for IdP verification.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+/// Protocol used by the identity provider.
+///
+/// Args:
+/// * `Oidc`: OpenID Connect (Okta, Entra ID, Google Workspace).
+/// * `Saml2`: SAML 2.0 (generic enterprise IdPs).
+///
+/// Usage:
+/// ```
+/// use auths_idp::IdpProtocol;
+/// let proto = IdpProtocol::Oidc;
+/// assert_eq!(proto.as_str(), "oidc");
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum IdpProtocol {
+    Oidc,
+    Saml2,
+}
+
+impl IdpProtocol {
+    /// Returns the protocol as a lowercase string.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Oidc => "oidc",
+            Self::Saml2 => "saml2",
+        }
+    }
+}
+
+/// Verified identity extracted from an IdP token or assertion.
+///
+/// Args:
+/// * `idp_issuer`: The IdP's issuer URL or SAML entity ID.
+/// * `idp_protocol`: Whether this came from OIDC or SAML.
+/// * `subject`: The stable subject identifier (oid+tid for Entra ID, sub for others).
+/// * `subject_email`: Email address, if available (for display/audit only).
+/// * `auth_time`: When the user authenticated at the IdP.
+/// * `auth_context_class`: The authentication context class reference (ACR/AuthnContextClassRef).
+///
+/// Usage:
+/// ```ignore
+/// let identity = verifier.verify(token, now).await?;
+/// println!("Authenticated {} via {}", identity.subject, identity.idp_issuer);
+/// ```
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct VerifiedIdpIdentity {
+    pub idp_issuer: String,
+    pub idp_protocol: IdpProtocol,
+    pub subject: String,
+    pub subject_email: Option<String>,
+    pub auth_time: DateTime<Utc>,
+    pub auth_context_class: Option<String>,
+}

--- a/ee/auths-idp/tests/cases/binding.rs
+++ b/ee/auths-idp/tests/cases/binding.rs
@@ -1,0 +1,138 @@
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+
+use auths_idp::binding::{IdpBindingAttestation, bind_identity_to_idp};
+use auths_idp::oidc::IdpVerifier;
+use auths_idp::{IdpError, IdpProtocol, VerifiedIdpIdentity};
+
+struct MockIdpVerifier {
+    identity: VerifiedIdpIdentity,
+}
+
+#[async_trait]
+impl IdpVerifier for MockIdpVerifier {
+    async fn verify(
+        &self,
+        _credential: &[u8],
+        _now: DateTime<Utc>,
+    ) -> Result<VerifiedIdpIdentity, IdpError> {
+        Ok(self.identity.clone())
+    }
+
+    fn provider_name(&self) -> &str {
+        "mock"
+    }
+
+    fn protocol(&self) -> IdpProtocol {
+        self.identity.idp_protocol
+    }
+}
+
+struct FailingIdpVerifier;
+
+#[async_trait]
+impl IdpVerifier for FailingIdpVerifier {
+    async fn verify(
+        &self,
+        _credential: &[u8],
+        _now: DateTime<Utc>,
+    ) -> Result<VerifiedIdpIdentity, IdpError> {
+        Err(IdpError::TokenInvalid("token expired".to_string()))
+    }
+
+    fn provider_name(&self) -> &str {
+        "failing-mock"
+    }
+
+    fn protocol(&self) -> IdpProtocol {
+        IdpProtocol::Oidc
+    }
+}
+
+#[tokio::test]
+async fn test_binding_end_to_end_with_mock_verifier() {
+    let now = Utc::now();
+    let auth_time = now - chrono::Duration::seconds(60);
+
+    let verifier = MockIdpVerifier {
+        identity: VerifiedIdpIdentity {
+            idp_issuer: "https://company.okta.com".to_string(),
+            idp_protocol: IdpProtocol::Oidc,
+            subject: "okta-user-123".to_string(),
+            subject_email: Some("user@company.com".to_string()),
+            auth_time,
+            auth_context_class: Some("urn:oasis:names:tc:SAML:2.0:ac:classes:Password".to_string()),
+        },
+    };
+
+    let result = bind_identity_to_idp(&verifier, b"mock-credential", "did:keri:Eabc123def456", now)
+        .await
+        .unwrap();
+
+    assert_eq!(result.attestation.version, 1);
+    assert_eq!(result.attestation.idp_issuer, "https://company.okta.com");
+    assert_eq!(result.attestation.idp_protocol, IdpProtocol::Oidc);
+    assert_eq!(result.attestation.subject, "okta-user-123");
+    assert_eq!(
+        result.attestation.subject_email.as_deref(),
+        Some("user@company.com")
+    );
+    assert_eq!(result.attestation.bound_did, "did:keri:Eabc123def456");
+    assert_eq!(result.attestation.timestamp, now);
+
+    assert!(!result.canonical_bytes.is_empty());
+}
+
+#[tokio::test]
+async fn test_binding_serialization_roundtrip() {
+    let now = Utc::now();
+
+    let attestation = IdpBindingAttestation {
+        version: 1,
+        idp_issuer: "https://login.microsoftonline.com/tenant/v2.0".to_string(),
+        idp_protocol: IdpProtocol::Oidc,
+        subject: "oid-123@tid-456".to_string(),
+        subject_email: Some("user@company.onmicrosoft.com".to_string()),
+        auth_time: now,
+        auth_context_class: None,
+        bound_did: "did:keri:Exyz789".to_string(),
+        timestamp: now,
+    };
+
+    let json = serde_json::to_string(&attestation).unwrap();
+    let deserialized: IdpBindingAttestation = serde_json::from_str(&json).unwrap();
+
+    assert_eq!(attestation, deserialized);
+}
+
+#[tokio::test]
+async fn test_binding_canonicalization_is_deterministic() {
+    let now = Utc::now();
+
+    let attestation = IdpBindingAttestation {
+        version: 1,
+        idp_issuer: "https://accounts.google.com".to_string(),
+        idp_protocol: IdpProtocol::Oidc,
+        subject: "123456789".to_string(),
+        subject_email: Some("user@company.com".to_string()),
+        auth_time: now,
+        auth_context_class: Some("urn:mace:incommon:iap:silver".to_string()),
+        bound_did: "did:keri:Etest".to_string(),
+        timestamp: now,
+    };
+
+    let canonical1 = attestation.canonicalize().unwrap();
+    let canonical2 = attestation.canonicalize().unwrap();
+    assert_eq!(canonical1, canonical2);
+}
+
+#[tokio::test]
+async fn test_binding_with_expired_credential_is_rejected() {
+    let now = Utc::now();
+    let verifier = FailingIdpVerifier;
+
+    let result = bind_identity_to_idp(&verifier, b"expired-credential", "did:keri:Eabc", now).await;
+
+    assert!(result.is_err());
+    assert!(result.unwrap_err().to_string().contains("expired"));
+}

--- a/ee/auths-idp/tests/cases/jwks.rs
+++ b/ee/auths-idp/tests/cases/jwks.rs
@@ -1,0 +1,264 @@
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::time::Duration;
+
+use axum::{Json, Router, routing::get};
+use jsonwebtoken::{Algorithm, DecodingKey, EncodingKey, Header};
+use rsa::pkcs1::DecodeRsaPrivateKey;
+use rsa::pkcs1::EncodeRsaPrivateKey;
+use serde_json::json;
+
+use auths_idp::IdpError;
+use auths_idp::jwks::test_jwks_client;
+
+// Pre-generated 2048-bit RSA key — avoids ~2-3s key generation in debug mode.
+const TEST_RSA_PEM: &str = "-----BEGIN RSA PRIVATE KEY-----
+MIIEogIBAAKCAQEAqQEkBlNgzl73KvtCjLdafiGQk+xEq1w0ZiPA6IpLn88FwRaL
+f50EPefAKxs90zXK66mfnJ7k1fAQ30ynWCSfEKT3u56HQHw2q5wOA2rhVpIA7zHC
+8ifsEe3MWnokMeXJyHY/y/7lYTnImvJSk4yxJGIrFFyNJ8blXt07clrIoMWlBAXl
+LCiInp/YcDaFydZee9Oe6X3Wme0BkendMqmH6LuFZrA3D9kWU6zPVVyLOR4Miv8+
+PgG1KHyd6+aH9KA1kQdGAkMygzsmUy8UfQ3kqPgB02GAQWGMkyrbe/WLpVot9oNc
+oxPEsZlh8osnV5Er7DIpPsO5RVUVOIf1my6bKwIDAQABAoIBAAVRzrSk7uD1YUSe
+Pa/Yh5snwE6/pZZajnWr6MMJCKys41VQDy+tnWK7cYjfJc4znRcCMvlxkOoLpo74
+xohXjWrZ3nMD4Dr540NPOVZciLTlCe19fKbgSyXHUo2DLFzRCvhp1xk7L995u6Q7
+k2N8jrOCpDDTDEhfvNGEbNNtIxqDAPp82T2mKOpaYF5tcmg8j5r/Nh/oFAmGjplz
+TVvGqaWaEYpE7Whtlje6boY1S3z1R465oTMVOCvNvZ9lMMkZHnYg9bd9u5qgsYTF
+FIcAU2ZfI8Y+Cpu8wvFPpdIbrF9LiFLRxKrziXtfXn5hnwZBT7oLcLNcw0s/LBjk
+JQUoYeECgYEA3Q8q3PTWS8V5EMbyKTxyrOvqEPBVBmvTmogksLaGNhJTtjaA7/jo
+2Wl4xSc+raVo9vAUIp8GzxV8Jp/bNAH28pf5w/sJiBcVwHA8HMl8NovljyFgCftv
+VK+557FeRyPJY/iw2V4FCOGo/nUAVVIMms0irFA+bhLp2KDenWFBuiECgYEAw7en
+YK4JTLCzHF0nYjz50EUfa4qPY8kXAiSb5HnRm89zJZ/GvenpOpRzlu9Sv+f1or+7
+hkJzuJaZ8mjBZzsA2VUANPetcLZHwX+YBs+dDDL4k1Pwb/NqE+PdRrijaUkMoJSt
+M4c4K8iNhG3JsHewyl7ZNGX+ReFNY5f7rRLto8sCgYB9QTDaTeh2uoekl/VypAue
+K3ZO7r5eiw41C1suvd1CGhRQtIVOc80ME5UYsOn03jqhYNsn2s+y2suj3wQHbe2M
++8vL3hxCfkIW7gFBlnDJP29tME4Ime01IPTHcVqoGIDuImWiZIGZzLNCquzrazg1
+JnK1DCqzmAfkdRJuPkNNwQKBgEJWDDg7pNFGjt7NQB0O98k8tIKZyzISJWdHi0Ms
+evwpmyikeBNEphWB3Y/J/C0pbNtFy0SdX2WwPeuoz+yyVf5Tziclz7aFQdr26Utd
+sShCWnhtGfCH+2tUb1qaGGEGLm57Fh2B9mr4pea943+ZgeWFsm8NJtr+m2FnURl/
+ceZzAoGAIw4IdELKWBJ2ajlYAXFmCrVIMhZ1EnrisMcOJkzrdiFB6LBj9OPmsl6H
+M00yuDgbdvVwsB2cULp4D+OMjInNCICnmLP/+ysmRSfA15F0iezZrZj9kwNgYyR+
+Kr3UJxzAu0HfzOvdrfzgmfUdHq82sS89GrExX0PzMuo6hh/Mcao=
+-----END RSA PRIVATE KEY-----";
+
+const TEST_ISSUER: &str = "https://test-idp.example.com";
+
+fn generate_test_rsa_keys() -> (rsa::RsaPrivateKey, rsa::RsaPublicKey) {
+    let private_key =
+        rsa::RsaPrivateKey::from_pkcs1_pem(TEST_RSA_PEM).expect("failed to parse test RSA key");
+    let public_key = private_key.to_public_key();
+    (private_key, public_key)
+}
+
+fn build_jwk_from_public_key(public_key: &rsa::RsaPublicKey, kid: &str) -> serde_json::Value {
+    use base64::Engine;
+    use rsa::traits::PublicKeyParts;
+    let n = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(public_key.n().to_bytes_be());
+    let e = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(public_key.e().to_bytes_be());
+
+    json!({
+        "kty": "RSA",
+        "use": "sig",
+        "alg": "RS256",
+        "kid": kid,
+        "n": n,
+        "e": e,
+    })
+}
+
+fn sign_test_token(
+    private_key: &rsa::RsaPrivateKey,
+    kid: &str,
+    claims: &serde_json::Value,
+) -> String {
+    let pem = private_key
+        .to_pkcs1_pem(rsa::pkcs1::LineEnding::LF)
+        .expect("failed to encode PEM");
+    let encoding_key =
+        EncodingKey::from_rsa_pem(pem.as_bytes()).expect("failed to create encoding key");
+
+    let mut header = Header::new(Algorithm::RS256);
+    header.kid = Some(kid.to_string());
+
+    jsonwebtoken::encode(&header, claims, &encoding_key).expect("failed to encode JWT")
+}
+
+fn valid_oidc_claims(aud: &str) -> serde_json::Value {
+    let now = chrono::Utc::now().timestamp();
+    json!({
+        "iss": TEST_ISSUER,
+        "sub": "user-123",
+        "aud": aud,
+        "email": "user@company.com",
+        "iat": now,
+        "nbf": now,
+        "exp": now + 300,
+    })
+}
+
+async fn start_mock_jwks_server(
+    jwks_json: serde_json::Value,
+) -> (std::net::SocketAddr, tokio::task::JoinHandle<()>) {
+    let app = Router::new().route(
+        "/.well-known/openid-configuration/jwks",
+        get(move || {
+            let jwks = jwks_json.clone();
+            async move { Json(jwks) }
+        }),
+    );
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("failed to bind");
+    let addr = listener.local_addr().expect("failed to get addr");
+    let handle = tokio::spawn(async move {
+        axum::serve(listener, app).await.ok();
+    });
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    (addr, handle)
+}
+
+#[tokio::test]
+async fn test_jwks_client_fetches_and_caches_keys() {
+    let (private_key, public_key) = generate_test_rsa_keys();
+    let kid = "cache-test-kid";
+    let expected_audience = "test-app";
+
+    let jwk = build_jwk_from_public_key(&public_key, kid);
+    let jwks_json = json!({ "keys": [jwk] });
+
+    let (addr, _handle) = start_mock_jwks_server(jwks_json).await;
+    let client = test_jwks_client(
+        &format!("http://{addr}/.well-known/openid-configuration/jwks"),
+        TEST_ISSUER,
+        expected_audience,
+    );
+
+    let claims = valid_oidc_claims(expected_audience);
+    let token = sign_test_token(&private_key, kid, &claims);
+
+    let key1: Result<DecodingKey, IdpError> = client.get_key_for_token(&token).await;
+    assert!(key1.is_ok(), "first fetch should succeed: {:?}", key1.err());
+
+    let key2: Result<DecodingKey, IdpError> = client.get_key_for_token(&token).await;
+    assert!(
+        key2.is_ok(),
+        "cached fetch should succeed: {:?}",
+        key2.err()
+    );
+}
+
+#[tokio::test]
+async fn test_unknown_kid_returns_error() {
+    let (private_key, public_key) = generate_test_rsa_keys();
+    let known_kid = "known-kid";
+    let unknown_kid = "unknown-kid";
+    let expected_audience = "test-app";
+
+    let jwk = build_jwk_from_public_key(&public_key, known_kid);
+    let jwks_json = json!({ "keys": [jwk] });
+
+    let (addr, _handle) = start_mock_jwks_server(jwks_json).await;
+    let client = test_jwks_client(
+        &format!("http://{addr}/.well-known/openid-configuration/jwks"),
+        TEST_ISSUER,
+        expected_audience,
+    );
+
+    let claims = valid_oidc_claims(expected_audience);
+    let token = sign_test_token(&private_key, unknown_kid, &claims);
+
+    match client.get_key_for_token(&token).await {
+        Ok(_) => panic!("should fail for unknown kid"),
+        Err(err) => {
+            let msg = err.to_string();
+            assert!(
+                msg.contains("not found in JWKS"),
+                "expected kid-not-found error, got: {msg}"
+            );
+        }
+    }
+}
+
+#[tokio::test]
+async fn test_malformed_token_rejected() {
+    let jwks_json = json!({ "keys": [] });
+    let (addr, _handle) = start_mock_jwks_server(jwks_json).await;
+    let client = test_jwks_client(
+        &format!("http://{addr}/.well-known/openid-configuration/jwks"),
+        TEST_ISSUER,
+        "test-app",
+    );
+
+    match client.get_key_for_token("not.a.jwt").await {
+        Ok(_) => panic!("should fail for malformed token"),
+        Err(err) => {
+            let msg = err.to_string();
+            assert!(
+                msg.contains("invalid JWT header"),
+                "expected header error, got: {msg}"
+            );
+        }
+    }
+}
+
+#[tokio::test]
+async fn test_concurrent_requests_coalesce_fetches() {
+    let (private_key, public_key) = generate_test_rsa_keys();
+    let kid = "concurrent-kid";
+    let expected_audience = "test-app";
+
+    let fetch_count = Arc::new(AtomicU32::new(0));
+    let fetch_count_clone = fetch_count.clone();
+
+    let jwk = build_jwk_from_public_key(&public_key, kid);
+    let jwks_response = json!({ "keys": [jwk] });
+
+    let app = Router::new().route(
+        "/.well-known/openid-configuration/jwks",
+        get(move || {
+            let count = fetch_count_clone.clone();
+            let resp = jwks_response.clone();
+            async move {
+                count.fetch_add(1, Ordering::Relaxed);
+                tokio::time::sleep(Duration::from_millis(100)).await;
+                Json(resp)
+            }
+        }),
+    );
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.ok();
+    });
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    let client = Arc::new(test_jwks_client(
+        &format!("http://{addr}/.well-known/openid-configuration/jwks"),
+        TEST_ISSUER,
+        expected_audience,
+    ));
+
+    let claims = valid_oidc_claims(expected_audience);
+    let token = sign_test_token(&private_key, kid, &claims);
+
+    let mut handles = Vec::new();
+    for _ in 0..5 {
+        let client = client.clone();
+        let token = token.clone();
+        handles.push(tokio::spawn(async move {
+            client.get_key_for_token(&token).await
+        }));
+    }
+
+    for handle in handles {
+        let result: Result<DecodingKey, IdpError> = handle.await.unwrap();
+        assert!(result.is_ok(), "verification failed: {:?}", result.err());
+    }
+
+    let total_fetches = fetch_count.load(Ordering::Relaxed);
+    assert!(
+        total_fetches <= 2,
+        "expected at most 2 fetches (coalesced), got {total_fetches}"
+    );
+}

--- a/ee/auths-idp/tests/cases/mod.rs
+++ b/ee/auths-idp/tests/cases/mod.rs
@@ -1,0 +1,3 @@
+mod binding;
+mod jwks;
+mod oidc_providers;

--- a/ee/auths-idp/tests/cases/oidc_providers.rs
+++ b/ee/auths-idp/tests/cases/oidc_providers.rs
@@ -1,0 +1,420 @@
+use std::time::Duration;
+
+use axum::{Json, Router, routing::get};
+use jsonwebtoken::{Algorithm, EncodingKey, Header};
+use rsa::pkcs1::{DecodeRsaPrivateKey, EncodeRsaPrivateKey};
+use serde_json::json;
+
+use auths_idp::jwks::test_jwks_client;
+use auths_idp::oidc::IdpVerifier;
+use auths_idp::oidc::entra::EntraIdpVerifier;
+use auths_idp::oidc::google::GoogleIdpVerifier;
+use auths_idp::oidc::okta::OktaIdpVerifier;
+
+const TEST_RSA_PEM: &str = "-----BEGIN RSA PRIVATE KEY-----
+MIIEogIBAAKCAQEAqQEkBlNgzl73KvtCjLdafiGQk+xEq1w0ZiPA6IpLn88FwRaL
+f50EPefAKxs90zXK66mfnJ7k1fAQ30ynWCSfEKT3u56HQHw2q5wOA2rhVpIA7zHC
+8ifsEe3MWnokMeXJyHY/y/7lYTnImvJSk4yxJGIrFFyNJ8blXt07clrIoMWlBAXl
+LCiInp/YcDaFydZee9Oe6X3Wme0BkendMqmH6LuFZrA3D9kWU6zPVVyLOR4Miv8+
+PgG1KHyd6+aH9KA1kQdGAkMygzsmUy8UfQ3kqPgB02GAQWGMkyrbe/WLpVot9oNc
+oxPEsZlh8osnV5Er7DIpPsO5RVUVOIf1my6bKwIDAQABAoIBAAVRzrSk7uD1YUSe
+Pa/Yh5snwE6/pZZajnWr6MMJCKys41VQDy+tnWK7cYjfJc4znRcCMvlxkOoLpo74
+xohXjWrZ3nMD4Dr540NPOVZciLTlCe19fKbgSyXHUo2DLFzRCvhp1xk7L995u6Q7
+k2N8jrOCpDDTDEhfvNGEbNNtIxqDAPp82T2mKOpaYF5tcmg8j5r/Nh/oFAmGjplz
+TVvGqaWaEYpE7Whtlje6boY1S3z1R465oTMVOCvNvZ9lMMkZHnYg9bd9u5qgsYTF
+FIcAU2ZfI8Y+Cpu8wvFPpdIbrF9LiFLRxKrziXtfXn5hnwZBT7oLcLNcw0s/LBjk
+JQUoYeECgYEA3Q8q3PTWS8V5EMbyKTxyrOvqEPBVBmvTmogksLaGNhJTtjaA7/jo
+2Wl4xSc+raVo9vAUIp8GzxV8Jp/bNAH28pf5w/sJiBcVwHA8HMl8NovljyFgCftv
+VK+557FeRyPJY/iw2V4FCOGo/nUAVVIMms0irFA+bhLp2KDenWFBuiECgYEAw7en
+YK4JTLCzHF0nYjz50EUfa4qPY8kXAiSb5HnRm89zJZ/GvenpOpRzlu9Sv+f1or+7
+hkJzuJaZ8mjBZzsA2VUANPetcLZHwX+YBs+dDDL4k1Pwb/NqE+PdRrijaUkMoJSt
+M4c4K8iNhG3JsHewyl7ZNGX+ReFNY5f7rRLto8sCgYB9QTDaTeh2uoekl/VypAue
+K3ZO7r5eiw41C1suvd1CGhRQtIVOc80ME5UYsOn03jqhYNsn2s+y2suj3wQHbe2M
++8vL3hxCfkIW7gFBlnDJP29tME4Ime01IPTHcVqoGIDuImWiZIGZzLNCquzrazg1
+JnK1DCqzmAfkdRJuPkNNwQKBgEJWDDg7pNFGjt7NQB0O98k8tIKZyzISJWdHi0Ms
+evwpmyikeBNEphWB3Y/J/C0pbNtFy0SdX2WwPeuoz+yyVf5Tziclz7aFQdr26Utd
+sShCWnhtGfCH+2tUb1qaGGEGLm57Fh2B9mr4pea943+ZgeWFsm8NJtr+m2FnURl/
+ceZzAoGAIw4IdELKWBJ2ajlYAXFmCrVIMhZ1EnrisMcOJkzrdiFB6LBj9OPmsl6H
+M00yuDgbdvVwsB2cULp4D+OMjInNCICnmLP/+ysmRSfA15F0iezZrZj9kwNgYyR+
+Kr3UJxzAu0HfzOvdrfzgmfUdHq82sS89GrExX0PzMuo6hh/Mcao=
+-----END RSA PRIVATE KEY-----";
+
+fn generate_test_rsa_keys() -> (rsa::RsaPrivateKey, rsa::RsaPublicKey) {
+    let private_key =
+        rsa::RsaPrivateKey::from_pkcs1_pem(TEST_RSA_PEM).expect("failed to parse test RSA key");
+    let public_key = private_key.to_public_key();
+    (private_key, public_key)
+}
+
+fn build_jwk_from_public_key(public_key: &rsa::RsaPublicKey, kid: &str) -> serde_json::Value {
+    use base64::Engine;
+    use rsa::traits::PublicKeyParts;
+    let n = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(public_key.n().to_bytes_be());
+    let e = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(public_key.e().to_bytes_be());
+
+    json!({
+        "kty": "RSA",
+        "use": "sig",
+        "alg": "RS256",
+        "kid": kid,
+        "n": n,
+        "e": e,
+    })
+}
+
+fn sign_test_token(
+    private_key: &rsa::RsaPrivateKey,
+    kid: &str,
+    claims: &serde_json::Value,
+) -> String {
+    let pem = private_key
+        .to_pkcs1_pem(rsa::pkcs1::LineEnding::LF)
+        .expect("failed to encode PEM");
+    let encoding_key =
+        EncodingKey::from_rsa_pem(pem.as_bytes()).expect("failed to create encoding key");
+
+    let mut header = Header::new(Algorithm::RS256);
+    header.kid = Some(kid.to_string());
+
+    jsonwebtoken::encode(&header, claims, &encoding_key).expect("failed to encode JWT")
+}
+
+async fn start_mock_jwks_server(
+    jwks_json: serde_json::Value,
+) -> (std::net::SocketAddr, tokio::task::JoinHandle<()>) {
+    let app = Router::new().route(
+        "/.well-known/openid-configuration/jwks",
+        get(move || {
+            let jwks = jwks_json.clone();
+            async move { Json(jwks) }
+        }),
+    );
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("failed to bind");
+    let addr = listener.local_addr().expect("failed to get addr");
+    let handle = tokio::spawn(async move {
+        axum::serve(listener, app).await.ok();
+    });
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    (addr, handle)
+}
+
+// ─── Okta tests ───
+
+#[tokio::test]
+async fn test_oidc_okta_valid_token() {
+    let (private_key, public_key) = generate_test_rsa_keys();
+    let kid = "okta-kid";
+    let issuer = "https://company.okta.com";
+    let audience = "okta-client-id";
+
+    let jwk = build_jwk_from_public_key(&public_key, kid);
+    let (addr, _handle) = start_mock_jwks_server(json!({ "keys": [jwk] })).await;
+
+    let jwks_client = test_jwks_client(
+        &format!("http://{addr}/.well-known/openid-configuration/jwks"),
+        issuer,
+        audience,
+    );
+    let verifier = OktaIdpVerifier::new(issuer, audience, jwks_client);
+
+    let now = chrono::Utc::now();
+    let claims = json!({
+        "iss": issuer,
+        "sub": "okta-user-123",
+        "aud": audience,
+        "email": "user@company.com",
+        "auth_time": now.timestamp(),
+        "acr": "urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport",
+        "iat": now.timestamp(),
+        "exp": now.timestamp() + 300,
+    });
+    let token = sign_test_token(&private_key, kid, &claims);
+
+    let identity = verifier.verify(token.as_bytes(), now).await.unwrap();
+    assert_eq!(identity.subject, "okta-user-123");
+    assert_eq!(identity.idp_issuer, issuer);
+    assert_eq!(identity.subject_email.as_deref(), Some("user@company.com"));
+    assert_eq!(identity.idp_protocol, auths_idp::IdpProtocol::Oidc);
+    assert_eq!(verifier.provider_name(), "okta");
+}
+
+#[tokio::test]
+async fn test_oidc_okta_expired_token_rejected() {
+    let (private_key, public_key) = generate_test_rsa_keys();
+    let kid = "okta-kid-exp";
+    let issuer = "https://company.okta.com";
+    let audience = "okta-client-id";
+
+    let jwk = build_jwk_from_public_key(&public_key, kid);
+    let (addr, _handle) = start_mock_jwks_server(json!({ "keys": [jwk] })).await;
+
+    let jwks_client = test_jwks_client(
+        &format!("http://{addr}/.well-known/openid-configuration/jwks"),
+        issuer,
+        audience,
+    );
+    let verifier = OktaIdpVerifier::new(issuer, audience, jwks_client);
+
+    let now = chrono::Utc::now();
+    let claims = json!({
+        "iss": issuer,
+        "sub": "okta-user-123",
+        "aud": audience,
+        "iat": now.timestamp() - 600,
+        "exp": now.timestamp() - 300,
+    });
+    let token = sign_test_token(&private_key, kid, &claims);
+
+    let result = verifier.verify(token.as_bytes(), now).await;
+    assert!(result.is_err());
+    assert!(result.unwrap_err().to_string().contains("expired"));
+}
+
+#[tokio::test]
+async fn test_oidc_okta_wrong_audience_rejected() {
+    let (private_key, public_key) = generate_test_rsa_keys();
+    let kid = "okta-kid-aud";
+    let issuer = "https://company.okta.com";
+    let audience = "okta-client-id";
+
+    let jwk = build_jwk_from_public_key(&public_key, kid);
+    let (addr, _handle) = start_mock_jwks_server(json!({ "keys": [jwk] })).await;
+
+    let jwks_client = test_jwks_client(
+        &format!("http://{addr}/.well-known/openid-configuration/jwks"),
+        issuer,
+        audience,
+    );
+    let verifier = OktaIdpVerifier::new(issuer, audience, jwks_client);
+
+    let now = chrono::Utc::now();
+    let claims = json!({
+        "iss": issuer,
+        "sub": "okta-user-123",
+        "aud": "wrong-audience",
+        "iat": now.timestamp(),
+        "exp": now.timestamp() + 300,
+    });
+    let token = sign_test_token(&private_key, kid, &claims);
+
+    let result = verifier.verify(token.as_bytes(), now).await;
+    assert!(result.is_err());
+    assert!(result.unwrap_err().to_string().contains("audience"));
+}
+
+// ─── Entra ID tests ───
+
+#[tokio::test]
+async fn test_oidc_entra_uses_oid_tid_as_subject() {
+    let (private_key, public_key) = generate_test_rsa_keys();
+    let kid = "entra-kid";
+    let tenant = "tenant-uuid-123";
+    let issuer = format!("https://login.microsoftonline.com/{tenant}/v2.0");
+    let audience = "entra-app-client-id";
+
+    let jwk = build_jwk_from_public_key(&public_key, kid);
+    let (addr, _handle) = start_mock_jwks_server(json!({ "keys": [jwk] })).await;
+
+    let jwks_client = test_jwks_client(
+        &format!("http://{addr}/.well-known/openid-configuration/jwks"),
+        &issuer,
+        audience,
+    );
+    let verifier = EntraIdpVerifier::new(&issuer, audience, jwks_client);
+
+    let now = chrono::Utc::now();
+    let claims = json!({
+        "iss": issuer,
+        "sub": "pairwise-sub-abc",
+        "aud": audience,
+        "email": "user@company.onmicrosoft.com",
+        "preferred_username": "user@company.com",
+        "oid": "object-id-456",
+        "tid": tenant,
+        "auth_time": now.timestamp(),
+        "iat": now.timestamp(),
+        "exp": now.timestamp() + 300,
+    });
+    let token = sign_test_token(&private_key, kid, &claims);
+
+    let identity = verifier.verify(token.as_bytes(), now).await.unwrap();
+    assert_eq!(identity.subject, format!("object-id-456@{tenant}"));
+    assert_eq!(identity.idp_issuer, issuer);
+    assert_eq!(verifier.provider_name(), "entra-id");
+}
+
+#[tokio::test]
+async fn test_oidc_entra_falls_back_to_sub_without_oid() {
+    let (private_key, public_key) = generate_test_rsa_keys();
+    let kid = "entra-kid-nosub";
+    let issuer = "https://login.microsoftonline.com/tenant/v2.0";
+    let audience = "entra-app-client-id";
+
+    let jwk = build_jwk_from_public_key(&public_key, kid);
+    let (addr, _handle) = start_mock_jwks_server(json!({ "keys": [jwk] })).await;
+
+    let jwks_client = test_jwks_client(
+        &format!("http://{addr}/.well-known/openid-configuration/jwks"),
+        issuer,
+        audience,
+    );
+    let verifier = EntraIdpVerifier::new(issuer, audience, jwks_client);
+
+    let now = chrono::Utc::now();
+    let claims = json!({
+        "iss": issuer,
+        "sub": "pairwise-sub-xyz",
+        "aud": audience,
+        "iat": now.timestamp(),
+        "exp": now.timestamp() + 300,
+    });
+    let token = sign_test_token(&private_key, kid, &claims);
+
+    let identity = verifier.verify(token.as_bytes(), now).await.unwrap();
+    assert_eq!(identity.subject, "pairwise-sub-xyz");
+}
+
+// ─── Google Workspace tests ───
+
+#[tokio::test]
+async fn test_oidc_google_valid_token_with_hd() {
+    let (private_key, public_key) = generate_test_rsa_keys();
+    let kid = "google-kid";
+    let issuer = "https://accounts.google.com";
+    let audience = "client-id.apps.googleusercontent.com";
+
+    let jwk = build_jwk_from_public_key(&public_key, kid);
+    let (addr, _handle) = start_mock_jwks_server(json!({ "keys": [jwk] })).await;
+
+    let jwks_client = test_jwks_client(
+        &format!("http://{addr}/.well-known/openid-configuration/jwks"),
+        issuer,
+        audience,
+    );
+    let verifier =
+        GoogleIdpVerifier::new(issuer, audience, jwks_client).with_required_domain("company.com");
+
+    let now = chrono::Utc::now();
+    let claims = json!({
+        "iss": issuer,
+        "sub": "123456789",
+        "aud": audience,
+        "email": "user@company.com",
+        "email_verified": true,
+        "hd": "company.com",
+        "auth_time": now.timestamp(),
+        "iat": now.timestamp(),
+        "exp": now.timestamp() + 300,
+    });
+    let token = sign_test_token(&private_key, kid, &claims);
+
+    let identity = verifier.verify(token.as_bytes(), now).await.unwrap();
+    assert_eq!(identity.subject, "123456789");
+    assert_eq!(identity.idp_issuer, issuer);
+    assert_eq!(identity.subject_email.as_deref(), Some("user@company.com"));
+    assert_eq!(verifier.provider_name(), "google-workspace");
+}
+
+#[tokio::test]
+async fn test_oidc_google_missing_hd_rejected_when_required() {
+    let (private_key, public_key) = generate_test_rsa_keys();
+    let kid = "google-kid-nohd";
+    let issuer = "https://accounts.google.com";
+    let audience = "client-id.apps.googleusercontent.com";
+
+    let jwk = build_jwk_from_public_key(&public_key, kid);
+    let (addr, _handle) = start_mock_jwks_server(json!({ "keys": [jwk] })).await;
+
+    let jwks_client = test_jwks_client(
+        &format!("http://{addr}/.well-known/openid-configuration/jwks"),
+        issuer,
+        audience,
+    );
+    let verifier =
+        GoogleIdpVerifier::new(issuer, audience, jwks_client).with_required_domain("company.com");
+
+    let now = chrono::Utc::now();
+    let claims = json!({
+        "iss": issuer,
+        "sub": "123456789",
+        "aud": audience,
+        "email": "user@gmail.com",
+        "iat": now.timestamp(),
+        "exp": now.timestamp() + 300,
+    });
+    let token = sign_test_token(&private_key, kid, &claims);
+
+    let result = verifier.verify(token.as_bytes(), now).await;
+    assert!(result.is_err());
+    assert!(result.unwrap_err().to_string().contains("hd"));
+}
+
+#[tokio::test]
+async fn test_oidc_google_wrong_domain_rejected() {
+    let (private_key, public_key) = generate_test_rsa_keys();
+    let kid = "google-kid-wronghd";
+    let issuer = "https://accounts.google.com";
+    let audience = "client-id.apps.googleusercontent.com";
+
+    let jwk = build_jwk_from_public_key(&public_key, kid);
+    let (addr, _handle) = start_mock_jwks_server(json!({ "keys": [jwk] })).await;
+
+    let jwks_client = test_jwks_client(
+        &format!("http://{addr}/.well-known/openid-configuration/jwks"),
+        issuer,
+        audience,
+    );
+    let verifier =
+        GoogleIdpVerifier::new(issuer, audience, jwks_client).with_required_domain("company.com");
+
+    let now = chrono::Utc::now();
+    let claims = json!({
+        "iss": issuer,
+        "sub": "123456789",
+        "aud": audience,
+        "email": "user@evil.com",
+        "hd": "evil.com",
+        "iat": now.timestamp(),
+        "exp": now.timestamp() + 300,
+    });
+    let token = sign_test_token(&private_key, kid, &claims);
+
+    let result = verifier.verify(token.as_bytes(), now).await;
+    assert!(result.is_err());
+    assert!(result.unwrap_err().to_string().contains("domain mismatch"));
+}
+
+#[tokio::test]
+async fn test_oidc_google_accepts_without_domain_restriction() {
+    let (private_key, public_key) = generate_test_rsa_keys();
+    let kid = "google-kid-nodomainreq";
+    let issuer = "https://accounts.google.com";
+    let audience = "client-id.apps.googleusercontent.com";
+
+    let jwk = build_jwk_from_public_key(&public_key, kid);
+    let (addr, _handle) = start_mock_jwks_server(json!({ "keys": [jwk] })).await;
+
+    let jwks_client = test_jwks_client(
+        &format!("http://{addr}/.well-known/openid-configuration/jwks"),
+        issuer,
+        audience,
+    );
+    let verifier = GoogleIdpVerifier::new(issuer, audience, jwks_client);
+
+    let now = chrono::Utc::now();
+    let claims = json!({
+        "iss": issuer,
+        "sub": "987654321",
+        "aud": audience,
+        "email": "user@gmail.com",
+        "iat": now.timestamp(),
+        "exp": now.timestamp() + 300,
+    });
+    let token = sign_test_token(&private_key, kid, &claims);
+
+    let identity = verifier.verify(token.as_bytes(), now).await.unwrap();
+    assert_eq!(identity.subject, "987654321");
+}

--- a/ee/auths-idp/tests/integration.rs
+++ b/ee/auths-idp/tests/integration.rs
@@ -1,0 +1,9 @@
+#![allow(
+    clippy::disallowed_methods,
+    clippy::print_stdout,
+    clippy::print_stderr,
+    clippy::unwrap_used,
+    clippy::expect_used
+)]
+
+mod cases;


### PR DESCRIPTION
Establishes ee/ as the source-available commercial tier — its own Cargo
workspace, licensed LicenseRef-Proprietary and excluded from the open-source
(Apache-2.0) root workspace via exclude = ["ee"], so `cargo build --workspace`
never compiles or ships it. Moves the enterprise IdP verifier (auths-idp,
OIDC/SAML identity binding) out of the archived cloud tree into ee/auths-idp
with publish = false. The OSS workspace is unchanged and builds green.

Auths-Id: did:keri:EB5cPHY0t-ejNC_rUzPS1dclTvd6kG-R9mQzjozCuGgd
Auths-Device: did:keri:EB5cPHY0t-ejNC_rUzPS1dclTvd6kG-R9mQzjozCuGgd
Auths-Anchor-Seq: 1
