### PR TITLE
verify: an offline identity bundle's freshness is Unknown, never its own timestamp

### DIFF
--- a/crates/auths-cli/src/commands/verify_commit.rs
+++ b/crates/auths-cli/src/commands/verify_commit.rs
@@ -186,7 +186,7 @@ pub async fn handle_verify_commit(
     let mut bundle_kel: Option<BundleKel> = None;
     if let Some(bundle_path) = &cmd.identity_bundle {
         match load_bundle_trust(bundle_path, chrono::Utc::now()) {
-            Ok((root, kel, freshness_age)) => {
+            Ok((root, kel)) => {
                 // Evidence-only (RT-005): the bundle is *evidence for* a root that
                 // must be pinned independently (`.auths/roots` or self-trust). It
                 // never becomes its own trust anchor — otherwise the anchor and the
@@ -210,7 +210,6 @@ pub async fn handle_verify_commit(
                     bundle_kel = Some(BundleKel {
                         did: root,
                         events: kel,
-                        freshness_age,
                     });
                 }
             }
@@ -255,9 +254,6 @@ struct BundleKel {
     /// The bundle's KEL events, oldest first — already signature-authenticated by
     /// [`load_bundle_trust`] (RT-002).
     events: Vec<Event>,
-    /// The bundle's age at load time; the verdict's freshness is graded against it so the
-    /// verifier's policy caps trust, not the bundle's self-declared TTL.
-    freshness_age: std::time::Duration,
 }
 
 /// Load an identity bundle from `path` and return the trusted root `did:keri:` it pins
@@ -269,16 +265,15 @@ struct BundleKel {
 fn load_bundle_trust(
     path: &std::path::Path,
     now: chrono::DateTime<chrono::Utc>,
-) -> std::result::Result<(String, Vec<Event>, std::time::Duration), String> {
+) -> std::result::Result<(String, Vec<Event>), String> {
     let content = fs::read_to_string(path)
         .map_err(|e| format!("could not read identity bundle {path:?}: {e}"))?;
     let bundle: IdentityBundle = serde_json::from_str(&content)
         .map_err(|e| format!("identity bundle {path:?} is not valid JSON: {e}"))?;
     let trust = BundleTrust::parse(&bundle, now)
         .map_err(|e| format!("identity bundle {path:?} is not a usable trust anchor: {e}"))?;
-    let age = (now - bundle.bundle_timestamp).to_std().unwrap_or_default();
     let (root, kel) = trust.into_parts();
-    Ok((root, kel, age))
+    Ok((root, kel))
 }
 
 /// Resolve the commit spec to a list of commit SHAs.
@@ -527,14 +522,14 @@ async fn verify_one_commit(
         now,
     )
     .await;
-    // When the signer was resolved from an identity bundle, grade the verdict's freshness
-    // from the bundle's age against the verifier's policy (ADR 009): the policy caps trust,
-    // not the bundle's own TTL. A direct verify carries no such signal and stays Unknown.
+    // A bundle's timestamp and TTL are producer-set, unsigned fields; an offline verifier holds
+    // no source it can trust to confirm freshness from them. Absent a verifier-supplied fresher
+    // tip, the strongest honest grade is Unknown — the policy decides whether to tolerate it
+    // (ADR 009 D5). A direct verify carries no such signal and likewise stays Unknown.
     let verdict = match bundle_kel {
-        Some(bk) => witnessed.verdict.with_freshness(
-            &FreshnessPolicy::default(),
-            FreshnessEvidence::SourceAge(bk.freshness_age),
-        ),
+        Some(_) => witnessed
+            .verdict
+            .with_freshness(&FreshnessPolicy::default(), FreshnessEvidence::Offline),
         None => witnessed.verdict,
     };
     let mut result = verdict_to_result(sha.clone(), verdict);

--- a/crates/auths-cli/tests/cases/verify_identity_bundle.rs
+++ b/crates/auths-cli/tests/cases/verify_identity_bundle.rs
@@ -87,39 +87,53 @@ fn good_identity_bundle_pins_root_and_verifies() {
 }
 
 #[test]
-fn stale_identity_bundle_is_not_trusted_under_the_verifier_policy() {
+fn bundle_freshness_grade_ignores_the_producer_timestamp() {
+    // The bundle's `bundle_timestamp` / `max_valid_for_secs` are producer-set, unsigned fields.
+    // An offline verifier holds no source it can trust to confirm freshness, so the grade must be
+    // identical no matter what the producer wrote: a forged recent timestamp cannot buy "fresh",
+    // and an aged one cannot be distinguished from it. Otherwise an attacker edits one JSON field
+    // and a stale/revoked bundle reads fresh. The honest offline grade is Unknown; the relying
+    // party's policy decides whether to tolerate it.
     let (env, good) = setup_signed_commit_and_bundle();
 
-    // Age the bundle past the verifier's freshness window, but well within its own
-    // (inflated) TTL — a bundle's self-declared TTL must not buy unbounded trust; the
-    // verifier's policy caps it.
-    let stale = env.home.path().join("stale-bundle.json");
-    let mut bundle: serde_json::Value =
-        serde_json::from_str(&std::fs::read_to_string(&good).unwrap()).unwrap();
-    let aged = chrono::Utc::now() - chrono::Duration::hours(25);
-    bundle["bundle_timestamp"] = serde_json::json!(aged.to_rfc3339());
-    bundle["max_valid_for_secs"] = serde_json::json!(31_536_000u64); // one year
-    std::fs::write(&stale, serde_json::to_string(&bundle).unwrap()).unwrap();
+    let graded = |name: &str, ts: chrono::DateTime<chrono::Utc>, ttl: u64| -> serde_json::Value {
+        let path = env.home.path().join(name);
+        let mut bundle: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&good).unwrap()).unwrap();
+        bundle["bundle_timestamp"] = serde_json::json!(ts.to_rfc3339());
+        bundle["max_valid_for_secs"] = serde_json::json!(ttl);
+        std::fs::write(&path, serde_json::to_string(&bundle).unwrap()).unwrap();
+        let out = env
+            .cmd("auths")
+            .args([
+                "verify",
+                "HEAD",
+                "--identity-bundle",
+                path.to_str().unwrap(),
+                "--json",
+            ])
+            .output()
+            .unwrap();
+        serde_json::from_slice(&out.stdout).expect("verify --json")
+    };
 
-    let out = env
-        .cmd("auths")
-        .args([
-            "verify",
-            "HEAD",
-            "--identity-bundle",
-            stale.to_str().unwrap(),
-            "--json",
-        ])
-        .output()
-        .unwrap();
-    let json: serde_json::Value = serde_json::from_slice(&out.stdout).expect("verify --json");
+    let now = chrono::Utc::now();
+    // The attacker's move: stamp the bundle as just-created so it looks maximally fresh.
+    let forged_fresh = graded("forged-fresh.json", now, 3600);
+    // A genuinely old export, with an inflated TTL so the producer can't be the one capping trust.
+    let aged = graded(
+        "aged.json",
+        now - chrono::Duration::hours(24 * 100),
+        31_536_000,
+    );
+
     assert_eq!(
-        json["freshness"], "stale",
-        "the verifier must grade an over-aged bundle stale"
+        forged_fresh["freshness"], aged["freshness"],
+        "freshness grade must not depend on the producer-set timestamp"
     );
     assert_eq!(
-        json["valid"], false,
-        "a stale bundle must not be trusted under the default policy"
+        forged_fresh["freshness"], "unknown",
+        "an offline bundle's freshness is Unknown — never a producer-claimed Fresh or Stale"
     );
 }
 

--- a/crates/auths-verifier/src/commit_bundle.rs
+++ b/crates/auths-verifier/src/commit_bundle.rs
@@ -387,14 +387,12 @@ async fn verify_commit_with_bundle_inner(
     )
     .await;
 
-    // Grade the verdict from the bundle's age against the verifier's freshness policy: the
-    // verifier caps trust, never the bundle's self-declared TTL (ADR 009). A bundle older
-    // than the policy window is Stale and a strict/default relying party rejects it.
-    let age = (now - bundle.bundle_timestamp).to_std().unwrap_or_default();
-    Ok(verdict.with_freshness(
-        &FreshnessPolicy::default(),
-        FreshnessEvidence::SourceAge(age),
-    ))
+    // An offline bundle carries no source the verifier can trust to confirm freshness: its
+    // timestamp and TTL are producer-set, unsigned fields, so an edited or inflated value must not
+    // buy trust. Absent a verifier-supplied fresher tip (a witness head / checkpoint / log tip),
+    // the strongest honest grade is Unknown — the relying party's policy decides whether to
+    // tolerate it (ADR 009 D5).
+    Ok(verdict.with_freshness(&FreshnessPolicy::default(), FreshnessEvidence::Offline))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## What
Both stateless identity-bundle verify paths graded a commit verdict's freshness from the bundle's own `bundle_timestamp` — a producer-set, unsigned field. Editing it (or inflating `max_valid_for_secs`) made a stale/revoked-but-otherwise-valid bundle read `Fresh`. An offline verifier with no trusted fresher source (witness head / checkpoint / log tip) can only honestly assert `Unknown`; the relying party's `FreshnessPolicy` decides tolerance (default tolerates Unknown, strict denies). Both paths now grade `Offline → Unknown`. The witnessed path's grading against a real trusted-source age is unchanged.

## Battery
- **e2e on the wired path**: `bundle_freshness_grade_ignores_the_producer_timestamp` (CLI `auths verify --identity-bundle`) — RED on HEAD (forged-fresh → "fresh" vs aged → "stale"), GREEN after (invariant "unknown"). 18 CLI bundle/commit tests + 68 verifier freshness/bundle tests pass.
- **Invariance property**: the grade is independent of `bundle_timestamp`.
- **Differential-oracle**: N/A — the freshness *policy* is application-specific; no external reference impl (keripy / RFC vectors) exists to differential against.
- **Constant-time**: N/A — no secret/MAC/token comparison; freshness is a public policy classification.

## Residual (follow-up)
The parse-time `max_valid_for_secs` TTL gate (`BundleTrust::parse` → `check_freshness`) remains a forgeable producer field. Post-fix it can no longer forge `Fresh` (the grade is `Offline`); it's the lesser "bundle-set TTL" vector, tracked for removal.

Verifier-surface change — belongs on the pre-launch crypto-audit list.