### PR TITLE
verify: the credential presentation path consumes freshness (is_trusted, not is_valid)

### DIFF
--- a/crates/auths-sdk/src/domains/credentials/authenticate.rs
+++ b/crates/auths-sdk/src/domains/credentials/authenticate.rs
@@ -123,6 +123,13 @@ pub async fn authenticate_presentation(
         config_audience.as_str(),
         Some(expected.as_bytes()),
         now,
+        // The presentation path now consumes freshness: the verdict is graded and the gate is
+        // `is_trusted`. The independent fresher-issuer-tip source that makes a behind-slice fail
+        // closed is resolved by the revocation-freshness refresh layer; until that is threaded
+        // here, no fresher tip is supplied, so an offline-resolved slice grades Unknown and the
+        // default policy tolerates it.
+        &auths_verifier::freshness::FreshnessPolicy::default(),
+        None,
         &RingCryptoProvider,
     )
     .await;

--- a/crates/auths-sdk/tests/cases/credential_present.rs
+++ b/crates/auths-sdk/tests/cases/credential_present.rs
@@ -183,6 +183,8 @@ async fn verify(
         AUDIENCE,
         expected_challenge,
         chrono::Utc::now(),
+        &auths_verifier::freshness::FreshnessPolicy::default(),
+        None,
         &RingCryptoProvider,
     )
     .await

--- a/crates/auths-verifier/src/contract.rs
+++ b/crates/auths-verifier/src/contract.rs
@@ -497,6 +497,8 @@ fn run_presentation(request_json: &str) -> Result<WirePresentationVerdict, Reque
         &request.audience,
         expected_challenge.as_deref(),
         request.now,
+        &crate::freshness::FreshnessPolicy::default(),
+        None,
     )
     .into())
 }

--- a/crates/auths-verifier/src/presentation.rs
+++ b/crates/auths-verifier/src/presentation.rs
@@ -39,6 +39,7 @@ use chrono::{DateTime, Utc};
 use subtle::ConstantTimeEq;
 
 use crate::credential::{CredentialVerdict, SignedAcdc, verify_credential_sync};
+use crate::freshness::{FreshnessEvidence, FreshnessPolicy};
 use crate::software_verify::verify_with_key_sync;
 use crate::{CanonicalDid, Capability, IdentityDID};
 
@@ -230,6 +231,8 @@ pub async fn verify_presentation(
     expected_audience: &str,
     expected_challenge: Option<&[u8]>,
     now: DateTime<Utc>,
+    policy: &FreshnessPolicy,
+    fresher_tip_seq: Option<u128>,
     _provider: &dyn CryptoProvider,
 ) -> PresentationVerdict {
     verify_presentation_sync(
@@ -244,6 +247,8 @@ pub async fn verify_presentation(
         expected_audience,
         expected_challenge,
         now,
+        policy,
+        fresher_tip_seq,
     )
 }
 
@@ -279,6 +284,8 @@ pub fn verify_presentation_sync(
     expected_audience: &str,
     expected_challenge: Option<&[u8]>,
     now: DateTime<Utc>,
+    policy: &FreshnessPolicy,
+    fresher_tip_seq: Option<u128>,
 ) -> PresentationVerdict {
     let credential_verdict = verify_credential_sync(
         signed,
@@ -288,7 +295,21 @@ pub fn verify_presentation_sync(
         witness_policy,
         now,
     );
-    if !credential_verdict.is_valid() {
+    // Consume freshness: the bare credential verdict is positional (`Unknown`). Grade it against a
+    // known-fresher issuer tip — a slice behind the issuer's true tip is `Stale`, since it cannot
+    // see a later revocation — then gate on the relying party's policy. A bare `Valid` is never
+    // honored without clearing the policy (ADR 009 D7).
+    let evidence = match (&credential_verdict, fresher_tip_seq) {
+        (CredentialVerdict::Valid { as_of, .. }, Some(latest_seq)) => {
+            FreshnessEvidence::FresherTip {
+                latest_seq,
+                slice_as_of: *as_of,
+            }
+        }
+        _ => FreshnessEvidence::Offline,
+    };
+    let credential_verdict = credential_verdict.with_freshness(policy, evidence);
+    if !credential_verdict.is_trusted(policy) {
         return PresentationVerdict::CredentialNotValid(credential_verdict);
     }
 

--- a/crates/auths-verifier/tests/cases/presentation.rs
+++ b/crates/auths-verifier/tests/cases/presentation.rs
@@ -14,6 +14,7 @@ use auths_keri::{
     VersionString, compute_capability_schema_said, compute_next_commitment, encode_tel_nonce,
     finalize_icp_event, finalize_ixn_event, finalize_rot_event,
 };
+use auths_verifier::freshness::FreshnessPolicy;
 use auths_verifier::{
     CredentialVerdict, PresentationBinding, PresentationEnvelope, PresentationVerdict, SignedAcdc,
     VerifierWitnessPolicy, verify_presentation, verify_presentation_json, verify_presentation_sync,
@@ -344,12 +345,44 @@ async fn verify(
         expected_audience,
         expected_challenge,
         now(),
+        &FreshnessPolicy::default(),
+        None,
         &provider(),
     )
     .await
 }
 
 const AUDIENCE: &str = "audience.example";
+
+/// Drive `verify_presentation` with an explicit freshness policy + a known-fresher issuer tip.
+#[allow(clippy::too_many_arguments)]
+async fn verify_with_tip(
+    envelope: &PresentationEnvelope,
+    cred: &Credentialed,
+    subject_kel: &[Event],
+    expected_audience: &str,
+    expected_challenge: Option<&[u8]>,
+    policy: &FreshnessPolicy,
+    fresher_tip_seq: Option<u128>,
+) -> PresentationVerdict {
+    verify_presentation(
+        envelope,
+        &cred.signed,
+        &cred.issuer_kel,
+        &cred.tel,
+        &[],
+        VerifierWitnessPolicy::Warn,
+        subject_kel,
+        &[],
+        expected_audience,
+        expected_challenge,
+        now(),
+        policy,
+        fresher_tip_seq,
+        &provider(),
+    )
+    .await
+}
 
 // ── Tests ───────────────────────────────────────────────────────────────────
 
@@ -419,6 +452,57 @@ async fn valid_challenge_presentation_verifies() {
             other => panic!("expected Valid on {curve:?}, got {other:?}"),
         }
     }
+}
+
+#[tokio::test]
+async fn presentation_behind_a_fresher_issuer_tip_is_rejected() {
+    // A captured slice verifies positionally (Valid as-of its slice), but the verifier knows the
+    // issuer's KEL has advanced past it — a later revocation the slice cannot see. The presentation
+    // path must consume that freshness signal and refuse the stale slice; a slice at or beyond the
+    // known tip is still honored.
+    let subject = Subject::incept(CurveType::Ed25519, 41);
+    let cred = credential_for(&subject.aid, false);
+    let nonce = vec![7u8; 32];
+    let envelope = subject.present(
+        &cred.credential_said,
+        AUDIENCE,
+        PresentationBinding::Challenge {
+            nonce: nonce.clone(),
+        },
+    );
+
+    // A known issuer tip far beyond the slice's as-of → the held slice is stale → not honored.
+    let stale = verify_with_tip(
+        &envelope,
+        &cred,
+        &subject.kel,
+        AUDIENCE,
+        Some(&nonce),
+        &FreshnessPolicy::default(),
+        Some(u128::MAX),
+    )
+    .await;
+    assert!(
+        !matches!(stale, PresentationVerdict::Valid { .. }),
+        "a presentation whose credential slice is behind the issuer's true tip must not be \
+         honored, got {stale:?}"
+    );
+
+    // A tip at or behind the slice → the slice is current → honored.
+    let fresh = verify_with_tip(
+        &envelope,
+        &cred,
+        &subject.kel,
+        AUDIENCE,
+        Some(&nonce),
+        &FreshnessPolicy::default(),
+        Some(0),
+    )
+    .await;
+    assert!(
+        matches!(fresh, PresentationVerdict::Valid { .. }),
+        "a presentation whose credential slice is at the known tip must be honored, got {fresh:?}"
+    );
 }
 
 #[tokio::test]
@@ -642,6 +726,8 @@ async fn sync_and_async_presentation_verdicts_match() {
                 audience,
                 challenge,
                 now(),
+                &FreshnessPolicy::default(),
+                Some(0),
                 &provider(),
             )
             .await;
@@ -658,6 +744,8 @@ async fn sync_and_async_presentation_verdicts_match() {
                 audience,
                 challenge,
                 now(),
+                &FreshnessPolicy::default(),
+                Some(0),
             );
 
             assert_eq!(


### PR DESCRIPTION
## What
The live credential-presentation / agent-passport path gated on bare `CredentialVerdict::is_valid()`, so it never consumed the freshness verdict ADR-009 added. A captured slice that verifies positionally (`Valid { as_of, freshness: Unknown }`) was honored even when the issuer's KEL had advanced past it — the stale-pre-revoke-slice case the freshness model exists to close.

`verify_presentation_sync` now grades the credential verdict against a known-fresher issuer tip (`FresherTip { latest_seq, slice_as_of: as_of }`) and gates on `is_trusted(policy)`: a slice behind the issuer's true tip is `Stale` → refused; one at/beyond it → honored. `verify_presentation`/`verify_presentation_sync` gain a `FreshnessPolicy` + the fresher-tip seq.

## Battery
- **e2e on the wired path**: `presentation_behind_a_fresher_issuer_tip_is_rejected` — proven RED with the gate at `is_valid()` (an ahead-tip slice graded `Stale` is still honored — "got Valid {...}"), GREEN with `is_trusted()`. A tip at/beyond the slice is honored, distinguishing the gate's role.
- 42 verifier + 4 SDK presentation/credential tests pass; build --workspace, fmt, deny, error-docs clean (auths-cli/sdk clippy env-blocked by the macOS Swift SDK skew, Linux-CI-covered).
- Differential-oracle N/A (the ADR-009 freshness policy has no external reference impl); constant-time N/A (no secret/MAC comparison).

## Scope / follow-ups
- The offline JSON entry (`verify_presentation_json`) and the SDK `authenticate_presentation` pass `FreshnessPolicy::default()` + no fresher tip — an offline-resolved slice grades `Unknown`, which the default tolerates (behavior preserved). **The fresher-issuer-tip SOURCE** that makes a behind-slice fail closed on the live path is the `RootRefresh` revocation-freshness gate — the next row, the source half of this wiring.
- Surfacing `freshness` on `PresentationVerdict::Valid` (the positive wire verdict) is a deferred observability follow-up; a rejection already surfaces it via the inner `CredentialVerdict`.

Verifier-surface change — on the pre-launch crypto-audit list.