### PR TITLE
sdk: wire the revocation-freshness staleness gate into presentation auth

### DIFF
--- a/crates/auths-sdk/src/context.rs
+++ b/crates/auths-sdk/src/context.rs
@@ -95,9 +95,29 @@ pub struct AuthsContext {
     pub witness_config: Option<auths_id::witness_config::WitnessConfig>,
     /// Path to the registry repository (needed for witness receipt storage).
     pub repo_path: Option<std::path::PathBuf>,
+    /// Optional revocation-freshness source. When set, a credential presentation is refused if the
+    /// locally-held copy of the issuer's logs is too stale to trust its revocation status (a `rev`
+    /// may have landed unseen). Default `None` — no staleness gate. Set via
+    /// [`AuthsContext::with_revocation_freshness`].
+    pub revocation_freshness:
+        Option<Arc<dyn crate::domains::credentials::RevocationFreshnessSource>>,
 }
 
 impl AuthsContext {
+    /// Set the revocation-freshness source (a fluent post-build override). When set, a credential
+    /// presentation is refused if the issuer's locally-held logs are too stale to trust their
+    /// revocation status.
+    ///
+    /// Args:
+    /// * `source`: the per-delegator staleness oracle (e.g. a `PolicyBoundRefresh`).
+    pub fn with_revocation_freshness(
+        mut self,
+        source: Arc<dyn crate::domains::credentials::RevocationFreshnessSource>,
+    ) -> Self {
+        self.revocation_freshness = Some(source);
+        self
+    }
+
     /// Build witness params from the context's configuration.
     ///
     /// Returns `WitnessParams::Enabled` when both `witness_config` and `repo_path`
@@ -499,6 +519,7 @@ impl
                 .unwrap_or_else(|| Arc::new(NoopAgentProvider)),
             witness_config: self.witness_config,
             repo_path: self.repo_path,
+            revocation_freshness: None,
         }
     }
 }

--- a/crates/auths-sdk/src/domains/credentials/authenticate.rs
+++ b/crates/auths-sdk/src/domains/credentials/authenticate.rs
@@ -22,6 +22,7 @@ use auths_id::keri::types::Prefix;
 use auths_id::policy::context_from_credential;
 
 use crate::context::AuthsContext;
+use crate::domains::credentials::FreshnessDecision;
 use crate::domains::credentials::error::CredentialError;
 use crate::domains::credentials::present_inputs::load_presentation_inputs;
 use crate::domains::org::error::OrgError;
@@ -56,6 +57,10 @@ pub enum PresentationAuthError {
     /// as a denial; the principal is not authorized when policy cannot be confirmed).
     #[error("org policy could not be evaluated: {0}")]
     Policy(OrgError),
+    /// The locally-held copy of the issuer's logs is too stale to trust its revocation status —
+    /// fail closed, since a `rev` may have landed unseen.
+    #[error("revocation freshness: issuer log copy too stale to honor ({0:?})")]
+    RevocationStale(FreshnessDecision),
 }
 
 impl PresentationAuthError {
@@ -66,7 +71,9 @@ impl PresentationAuthError {
             PresentationAuthError::Wire(_) | PresentationAuthError::NonceLength => 400,
             PresentationAuthError::Denied(denied) => denied.http_status(),
             PresentationAuthError::PolicyDenied { .. } | PresentationAuthError::Policy(_) => 403,
-            PresentationAuthError::Challenge(_) | PresentationAuthError::Resolve(_) => 401,
+            PresentationAuthError::Challenge(_)
+            | PresentationAuthError::Resolve(_)
+            | PresentationAuthError::RevocationStale(_) => 401,
         }
     }
 }
@@ -133,6 +140,25 @@ pub async fn authenticate_presentation(
         &RingCryptoProvider,
     )
     .await;
+
+    // Revocation freshness: when the relying party has configured a staleness source, refuse to
+    // honor a presentation whose issuer's locally-held logs are too stale to trust their revocation
+    // status (a `rev` may have landed unseen). Fail closed; skipped when no source is configured.
+    if let (Some(source), PresentationVerdict::Valid { issuer, .. }) =
+        (&ctx.revocation_freshness, &verdict)
+    {
+        let delegator = Prefix::new_unchecked(
+            issuer
+                .as_str()
+                .strip_prefix("did:keri:")
+                .unwrap_or(issuer.as_str())
+                .to_string(),
+        );
+        let decision = source.freshness(&delegator, now);
+        if !decision.is_honored() {
+            return Err(PresentationAuthError::RevocationStale(decision));
+        }
+    }
 
     enforce_issuer_policy(ctx, &verdict, now)?;
 

--- a/crates/auths-sdk/src/domains/credentials/freshness.rs
+++ b/crates/auths-sdk/src/domains/credentials/freshness.rs
@@ -243,6 +243,36 @@ impl<S: DelegatorLogSource> RootRefresh<S> {
     }
 }
 
+/// A per-delegator revocation-freshness source the presentation gate consults before honoring a
+/// credential: it answers how stale the locally-held copy of the delegator's logs is. Object-safe,
+/// so an [`AuthsContext`](crate::context::AuthsContext) can hold an optional `Arc<dyn …>` without a
+/// generic; production pairs a [`RootRefresh`] with a [`RevocationFreshnessPolicy`] via
+/// [`PolicyBoundRefresh`], a test injects a fake.
+pub trait RevocationFreshnessSource: Send + Sync {
+    /// The freshness of the locally-held copy of `delegator`'s logs as of `now`.
+    ///
+    /// Args:
+    /// * `delegator`: the delegator (root) AID whose logs gate the delegated subject.
+    /// * `now`: the current time, injected at the boundary.
+    fn freshness(&self, delegator: &Prefix, now: DateTime<Utc>) -> FreshnessDecision;
+}
+
+/// Pairs a [`RootRefresh`] with the [`RevocationFreshnessPolicy`] it enforces, so it can back an
+/// [`AuthsContext`]'s revocation-freshness gate. The live poll against a remote registry is the
+/// deployment's to schedule (`refresh_if_due`); this only reads the watermark that poll maintains.
+pub struct PolicyBoundRefresh<S: DelegatorLogSource> {
+    /// The refresh driver tracking each delegator's freshness watermark.
+    pub refresh: RootRefresh<S>,
+    /// The fail-closed / fail-open policy applied to a stale copy.
+    pub policy: RevocationFreshnessPolicy,
+}
+
+impl<S: DelegatorLogSource> RevocationFreshnessSource for PolicyBoundRefresh<S> {
+    fn freshness(&self, delegator: &Prefix, now: DateTime<Utc>) -> FreshnessDecision {
+        self.refresh.freshness(delegator, &self.policy, now)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/auths-sdk/src/domains/credentials/mod.rs
+++ b/crates/auths-sdk/src/domains/credentials/mod.rs
@@ -32,8 +32,8 @@ pub mod verify;
 pub use authenticate::{PresentationAuthError, authenticate_presentation};
 pub use error::CredentialError;
 pub use freshness::{
-    DelegatorLogSource, FreshnessDecision, RefreshError, RefreshOutcome, RevocationFreshnessPolicy,
-    RootRefresh, enforce_freshness,
+    DelegatorLogSource, FreshnessDecision, PolicyBoundRefresh, RefreshError, RefreshOutcome,
+    RevocationFreshnessPolicy, RevocationFreshnessSource, RootRefresh, enforce_freshness,
 };
 pub use issue::{CredentialIssuance, CredentialSummary, issue, list, revoke};
 pub use present::{ChallengeSession, PresentationChallenge, present_credential};

--- a/crates/auths-sdk/tests/cases/authenticate.rs
+++ b/crates/auths-sdk/tests/cases/authenticate.rs
@@ -19,8 +19,8 @@ use auths_id::keri::types::Prefix;
 use auths_rp::{Audience, ChallengeStore, InMemoryChallengeStore, WirePresentation};
 use auths_sdk::context::AuthsContext;
 use auths_sdk::domains::credentials::{
-    PresentationAuthError, PresentationChallenge, authenticate_presentation, issue,
-    present_credential, revoke,
+    FreshnessDecision, PresentationAuthError, PresentationChallenge, RevocationFreshnessSource,
+    authenticate_presentation, issue, present_credential, revoke,
 };
 use auths_sdk::domains::device::add_device;
 use auths_sdk::domains::identity::service::initialize;
@@ -160,6 +160,65 @@ fn issuer_prefix(h: &Harness) -> Prefix {
         .expect("issuer identity")
         .controller_did;
     parse_did_keri(did.as_str()).expect("issuer prefix")
+}
+
+/// A revocation-freshness source returning a fixed decision, to drive the gate without a live poll.
+struct FakeFreshness(FreshnessDecision);
+
+impl RevocationFreshnessSource for FakeFreshness {
+    fn freshness(
+        &self,
+        _delegator: &Prefix,
+        _now: chrono::DateTime<chrono::Utc>,
+    ) -> FreshnessDecision {
+        self.0
+    }
+}
+
+#[tokio::test]
+async fn revocation_freshness_gate_refuses_a_stale_copy_and_honors_a_fresh_one() {
+    // A configured staleness source whose copy is too stale → the presentation is refused
+    // (fail-closed: a `rev` may have landed unseen), even though it otherwise verifies.
+    {
+        let h = setup();
+        let (subject_alias, _subject, cred) = issue_to_subject(&h, "agent", CurveType::P256);
+        let audience = Audience::parse(AUDIENCE).unwrap();
+        let store = InMemoryChallengeStore::new(16);
+        let now = chrono::Utc::now();
+        let wire = present_with_store(&h, &subject_alias, &cred, &audience, &store, now);
+        let ctx = h.ctx.with_revocation_freshness(Arc::new(FakeFreshness(
+            FreshnessDecision::StaleRejected {
+                age: chrono::Duration::minutes(5),
+            },
+        )));
+        let err = authenticate_presentation(&ctx, &h.issuer_alias, &store, &audience, wire, now)
+            .await
+            .expect_err("a stale issuer-log copy must refuse the presentation");
+        assert!(
+            matches!(err, PresentationAuthError::RevocationStale(_)),
+            "expected RevocationStale, got {err:?}"
+        );
+        assert_eq!(err.http_status(), 401);
+    }
+    // A fresh copy → the presentation is honored.
+    {
+        let h = setup();
+        let (subject_alias, _subject, cred) = issue_to_subject(&h, "agent", CurveType::P256);
+        let audience = Audience::parse(AUDIENCE).unwrap();
+        let store = InMemoryChallengeStore::new(16);
+        let now = chrono::Utc::now();
+        let wire = present_with_store(&h, &subject_alias, &cred, &audience, &store, now);
+        let ctx =
+            h.ctx
+                .with_revocation_freshness(Arc::new(FakeFreshness(FreshnessDecision::Fresh {
+                    age: chrono::Duration::seconds(1),
+                })));
+        let principal =
+            authenticate_presentation(&ctx, &h.issuer_alias, &store, &audience, wire, now)
+                .await
+                .expect("a fresh issuer-log copy must honor the presentation");
+        assert!(!principal.capabilities().is_empty());
+    }
 }
 
 #[tokio::test]


### PR DESCRIPTION
The first-party revocation-freshness gate (enforce_freshness / RootRefresh, an
OCSP-stapling-style staleness check on the local registry copy) had no caller.
authenticate_presentation now consults an optional, context-injected
RevocationFreshnessSource: when configured, a credential presentation is refused
(fail-closed, 401 RevocationStale) if the locally-held copy of the issuer's logs is
too stale to trust its revocation status — a rev may have landed unseen. A None
source preserves current behavior, so there is no caller ripple.

Adds the object-safe RevocationFreshnessSource trait, a PolicyBoundRefresh adapter
(pairs a RootRefresh with its policy), and AuthsContext::with_revocation_freshness.
The production DelegatorLogSource (a live registry-remote poll) + the refresh
scheduler remain the deployment's to wire.

Auths-Id: did:keri:EB5cPHY0t-ejNC_rUzPS1dclTvd6kG-R9mQzjozCuGgd
Auths-Device: did:keri:EB5cPHY0t-ejNC_rUzPS1dclTvd6kG-R9mQzjozCuGgd
Auths-Anchor-Seq: 1
