### PR TITLE
verify: drop the unverified git author from the authorization summary

### DIFF
--- a/crates/auths-verifier/src/authorization_summary.rs
+++ b/crates/auths-verifier/src/authorization_summary.rs
@@ -24,10 +24,10 @@ pub enum AuthorizationSummary {
         /// The action payload's top-level fields, rendered as key/value pairs.
         details: Vec<(String, String)>,
     },
-    /// A git commit: its author and message — both legible from the signed object.
+    /// A git commit's message — the legible content being authorized. The commit's git `author`
+    /// line is deliberately excluded: it is an unverified self-claim, and the authorizing identity
+    /// is always the verdict's cryptographically-verified signer, never the git author.
     Commit {
-        /// The commit `author` line.
-        author: String,
         /// The commit message.
         message: String,
     },
@@ -90,21 +90,18 @@ fn parse_action(bytes: &[u8]) -> Option<AuthorizationSummary> {
     })
 }
 
-/// Parse a git commit object (`tree …`, an `author …` line, a blank line, then the message).
+/// Parse a git commit object (`tree …` header, a blank line, then the message). The `author`
+/// line is intentionally not read — it is an unverified self-claim, not the authorizing identity.
 fn parse_commit(bytes: &[u8]) -> Option<AuthorizationSummary> {
     let text = std::str::from_utf8(bytes).ok()?;
     if !text.starts_with("tree ") {
         return None;
     }
-    let author = text
-        .lines()
-        .find_map(|l| l.strip_prefix("author "))
-        .map(str::to_string)?;
     let message = text
         .split_once("\n\n")
         .map(|(_, m)| m.trim_end().to_string())
         .unwrap_or_default();
-    Some(AuthorizationSummary::Commit { author, message })
+    Some(AuthorizationSummary::Commit { message })
 }
 
 /// Render a JSON value as a compact display string (strings unquoted, others as JSON).
@@ -129,9 +126,9 @@ impl fmt::Display for AuthorizationSummary {
                 }
                 Ok(())
             }
-            AuthorizationSummary::Commit { author, message } => {
+            AuthorizationSummary::Commit { message } => {
                 let subject = message.lines().next().unwrap_or("");
-                write!(f, "commit by {author}: {subject}")
+                write!(f, "commit: {subject}")
             }
             AuthorizationSummary::Opaque { digest_hex } => {
                 write!(f, "opaque payload sha256:{digest_hex}")

--- a/crates/auths-verifier/tests/cases/authorization_summary.rs
+++ b/crates/auths-verifier/tests/cases/authorization_summary.rs
@@ -38,19 +38,26 @@ fn summarizes_a_signed_action_request_from_its_bytes() {
 }
 
 #[test]
-fn summarizes_a_signed_commit_object_from_its_bytes() {
+fn commit_summary_excludes_the_unverified_git_author() {
+    // The git `author` line is an attacker-controllable self-claim, not the authorizing identity
+    // (that is the verdict's cryptographically-verified signer). It must not appear in the consent
+    // summary; only the legible message is carried.
     let bytes = b"tree abc123\n\
-        author Test User <test@example.com> 1700000000 +0000\n\
-        committer Test User <test@example.com> 1700000000 +0000\n\
+        author Attacker Name <attacker@evil.example> 1700000000 +0000\n\
+        committer Attacker Name <attacker@evil.example> 1700000000 +0000\n\
         \n\
         Fix the thing\n";
-    match AuthorizationSummary::from_signed_bytes(bytes) {
-        AuthorizationSummary::Commit { author, message } => {
-            assert!(author.contains("Test User"), "author: {author}");
+    let summary = AuthorizationSummary::from_signed_bytes(bytes);
+    match &summary {
+        AuthorizationSummary::Commit { message } => {
             assert!(message.contains("Fix the thing"), "message: {message}");
         }
         other => panic!("expected a Commit summary, got {other:?}"),
     }
+    assert!(
+        !summary.to_string().contains("Attacker"),
+        "the unverified git author must not appear in the consent summary, got {summary}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## What
`AuthorizationSummary::Commit` carried the git commit `author` line and rendered it as `"commit by {author}: …"`. The git author is an unauthenticated, attacker-controllable self-claim; presenting it as a by-line lets an attacker-set author stand in as the authorizing identity. The authorizing identity is, and must remain, the verdict's cryptographically-verified signer (the `Auths-Id`/`Auths-Device` trailers — which `verify_commit` already names).

`AuthorizationSummary` is currently built but unwired (no consumer), so this is a latent foot-gun rather than an active exploit — fixed structurally: the `Commit` variant no longer carries the git author at all (`Commit { message }`), `parse_commit` no longer reads the `author` line, and the Display renders `"commit: {subject}"`. The foot-gun is now unrepresentable.

## Battery
- e2e/property: `commit_summary_excludes_the_unverified_git_author` — a commit whose git author is an attacker name → the rendered summary contains the message but NOT the attacker author (RED on HEAD where the Display showed "commit by {attacker}…"). 3 authorization_summary tests pass; build --workspace + clippy + fmt + deny + error-docs green.
- Differential-oracle / constant-time: N/A (a display-derivation, no crypto primitive or secret comparison).

## Follow-up (deferred)
Surfacing the legible summary in the verify consent *output* alongside the verified `signer_did` is a UX wiring — `verify_commit` already names the verified signer, so the security invariant (consent names the verified signer, not the git author) holds.

Verifier-touching — on the pre-launch crypto-audit list.