### PR TITLE
idp: document that the OIDC verifier deliberately does not check nonce

### DIFF
--- a/ee/auths-idp/src/oidc/mod.rs
+++ b/ee/auths-idp/src/oidc/mod.rs
@@ -68,6 +68,13 @@ pub(crate) struct StandardOidcClaims {
 
 /// Validates standard OIDC claims (issuer, audience, expiry).
 ///
+/// Accepted risk — the OIDC `nonce` is deliberately NOT validated here. This verifier checks a
+/// token whose freshness is bounded by `exp` and whose binding to the caller is enforced upstream
+/// by KEL-anchoring (the token never stands alone as a session). `nonce` defends replay into an
+/// INTERACTIVE login callback where the verifier itself minted the nonce — that is not the defense
+/// on this path. Before placing this verifier behind such an interactive callback, add a nonce
+/// check bound to a verifier-minted, single-use value.
+///
 /// Args:
 /// * `claims`: The deserialized OIDC claims.
 /// * `expected_issuer`: The expected issuer URL.


### PR DESCRIPTION
The OIDC token verifier validates issuer, audience, and expiry but not `nonce`.
That is by design on this path: the token's freshness is bounded by `exp` and its
binding to the caller is enforced upstream by KEL-anchoring, so it never stands
alone as a session. `nonce` defends replay into an interactive login callback where
the verifier minted the nonce — not this path. Documents the accepted risk and the
condition (an interactive callback) under which a nonce check must be added.

Auths-Id: did:keri:EB5cPHY0t-ejNC_rUzPS1dclTvd6kG-R9mQzjozCuGgd
Auths-Device: did:keri:EB5cPHY0t-ejNC_rUzPS1dclTvd6kG-R9mQzjozCuGgd
Auths-Anchor-Seq: 1
