### PR TITLE
cli: do not bind the ambient git HEAD when signing a file

### DIFF
--- a/crates/auths-cli/src/commands/git_helpers.rs
+++ b/crates/auths-cli/src/commands/git_helpers.rs
@@ -1,6 +1,6 @@
 use anyhow::{Context, Result, anyhow};
 
-use crate::subprocess::{git_command, git_silent};
+use crate::subprocess::git_command;
 
 /// Resolve a git ref to a full commit SHA.
 ///
@@ -44,16 +44,4 @@ pub fn resolve_commit_sha(commit_ref: &str) -> Result<String> {
     }
 
     Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
-}
-
-/// Silently attempt to resolve HEAD to a full commit SHA.
-///
-/// Returns `None` if not in a git repo, no commits exist, or git is unavailable.
-///
-/// Usage:
-/// ```ignore
-/// let sha = resolve_head_silent(); // Some("abc123...") or None
-/// ```
-pub fn resolve_head_silent() -> Option<String> {
-    git_silent(&["rev-parse", "--verify", "--quiet", "HEAD"])
 }

--- a/crates/auths-cli/src/commands/publish.rs
+++ b/crates/auths-cli/src/commands/publish.rs
@@ -58,7 +58,9 @@ impl ExecutableCommand for PublishCommand {
                         )?,
                         None,
                         None,
-                        crate::commands::git_helpers::resolve_head_silent(),
+                        // Auto-signing a file for publish does not bind the ambient git HEAD: it is
+                        // unrelated to the file. Bind one with `auths artifact sign --commit <sha>`.
+                        None,
                         ctx.repo_path.clone(),
                         ctx.passphrase_provider.clone(),
                         &ctx.env_config,

--- a/crates/auths-cli/src/commands/sign.rs
+++ b/crates/auths-cli/src/commands/sign.rs
@@ -362,7 +362,11 @@ pub fn handle_sign_unified(
                 Some(alias) => alias.to_string(),
                 None => super::key_detect::auto_detect_device_key(repo_opt.as_deref(), env_config)?,
             };
-            let commit_sha = super::git_helpers::resolve_head_silent();
+            // A file attestation does not bind a commit: the ambient git HEAD is unrelated to the
+            // file being signed, and inferring it would let whatever commit happens to be checked
+            // out be claimed as the attestation's provenance. Bind one explicitly with
+            // `auths artifact sign --commit <sha>`.
+            let commit_sha: Option<String> = None;
             handle_artifact_sign(
                 &path,
                 cmd.sig_output,

--- a/crates/auths-cli/tests/cases/mod.rs
+++ b/crates/auths-cli/tests/cases/mod.rs
@@ -8,6 +8,7 @@ mod key_rotation;
 mod key_rotation_cli;
 mod preset;
 mod revocation;
+mod sign_commit_binding;
 mod sign_verify;
 mod sign_verify_roundtrip;
 mod verify;

--- a/crates/auths-cli/tests/cases/sign_commit_binding.rs
+++ b/crates/auths-cli/tests/cases/sign_commit_binding.rs
@@ -1,0 +1,41 @@
+use super::helpers::TestEnv;
+
+/// A file attestation must not bind the ambient git HEAD. Before the fix, `auths sign <file>`
+/// resolved the current repo's HEAD and recorded it as the attestation's `commit_sha`, falsely
+/// associating an unrelated commit with the signed file. The commit a file is bound to must be
+/// explicit (`auths artifact sign --commit <sha>`), never inferred from ambient git state.
+#[test]
+fn auths_sign_file_does_not_bind_ambient_git_head() {
+    let env = TestEnv::new();
+    env.init_identity();
+
+    // Give the working repo a HEAD commit — the value the pre-fix code would have bound.
+    std::fs::write(env.repo_path.join("seed.txt"), b"seed").unwrap();
+    env.git_cmd().args(["add", "."]).output().unwrap();
+    env.git_cmd()
+        .args(["commit", "-m", "seed"])
+        .output()
+        .unwrap();
+
+    std::fs::write(env.repo_path.join("artifact.txt"), b"payload").unwrap();
+
+    let output = env
+        .cmd("auths")
+        .args(["sign", "artifact.txt"])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "auths sign failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let att_path = env.repo_path.join("artifact.txt.auths.json");
+    let json: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&att_path).unwrap()).unwrap();
+    let commit_sha = json.get("commit_sha");
+    assert!(
+        commit_sha.is_none_or(|v| v.is_null()),
+        "a file attestation must not bind the ambient git HEAD, got commit_sha = {commit_sha:?}"
+    );
+}


### PR DESCRIPTION
`auths sign <file>` and the auto-sign step in `auths publish` recorded the current
repository's HEAD as the file attestation's `commit_sha`, falsely associating an
unrelated commit with the signed file — whatever happened to be checked out became
the attestation's claimed provenance. A file attestation does not bind a commit;
`commit_sha` is now `None` on these paths. Binding a commit to an artifact is
explicit via `auths artifact sign --commit <sha>`. Removes the now-unused
`resolve_head_silent` helper.

Adds an end-to-end test: signing a file in a repo with a HEAD commit yields an
attestation whose `commit_sha` is absent (it was the ambient HEAD before the fix).

Auths-Id: did:keri:EB5cPHY0t-ejNC_rUzPS1dclTvd6kG-R9mQzjozCuGgd
Auths-Device: did:keri:EB5cPHY0t-ejNC_rUzPS1dclTvd6kG-R9mQzjozCuGgd
Auths-Anchor-Seq: 1
