### PR TITLE
cli: remove `auths id expand`

### DIFF
--- a/crates/auths-cli/src/commands/id/identity.rs
+++ b/crates/auths-cli/src/commands/id/identity.rs
@@ -217,29 +217,6 @@ pub enum IdSubcommand {
         timeout: u64,
     },
 
-    /// Expand a single-device identity into multi-device via one rotation.
-    Expand {
-        /// Add a device slot (repeatable). Curve name: `P256` or `Ed25519`.
-        #[arg(long, action = ArgAction::Append, value_name = "CURVE")]
-        add_device: Vec<String>,
-
-        /// Signing threshold after expansion. Required.
-        #[arg(long)]
-        signing_threshold: String,
-
-        /// Rotation threshold after expansion. Required.
-        #[arg(long)]
-        rotation_threshold: String,
-
-        /// Base alias for the existing single-key identity.
-        #[arg(long, default_value = "main")]
-        alias: String,
-
-        /// Alias for the new multi-key identity set.
-        #[arg(long, default_value = "main")]
-        next_alias: String,
-    },
-
     /// Export an identity bundle for stateless CI/CD verification.
     ///
     /// Creates a portable JSON bundle containing the identity ID, public key,
@@ -648,8 +625,9 @@ pub fn handle_id(
             {
                 return Err(anyhow!(
                     "multi-device rotation (--add-device / --remove-device / --signing-threshold / \
-                     --rotation-threshold) is not yet wired through `auths id rotate`. Use \
-                     `auths id expand` to add devices, or omit these flags for a standard rotation."
+                     --rotation-threshold) is not wired through `auths id rotate`. Add a device \
+                     with `auths device pair` (each device is a delegated identity under your \
+                     root), or omit these flags for a standard rotation."
                 ));
             }
             let identity_key_alias = alias.or(current_key_alias);
@@ -775,94 +753,6 @@ pub fn handle_id(
                 result.new_key_alias,
             );
 
-            Ok(())
-        }
-
-        IdSubcommand::Expand {
-            add_device,
-            signing_threshold,
-            rotation_threshold,
-            alias,
-            next_alias,
-        } => {
-            if add_device.is_empty() {
-                return Err(anyhow!(
-                    "`auths id expand` requires at least one --add-device; use `auths id rotate` for key-set-preserving rotations"
-                ));
-            }
-
-            // Parse curves from --add-device string values.
-            let curves: Result<Vec<auths_crypto::CurveType>, _> = add_device
-                .iter()
-                .map(|s| match s.to_ascii_lowercase().as_str() {
-                    "p256" | "p-256" => Ok(auths_crypto::CurveType::P256),
-                    "ed25519" => Ok(auths_crypto::CurveType::Ed25519),
-                    other => Err(anyhow!(
-                        "unknown curve {:?}: expected P256 or Ed25519",
-                        other
-                    )),
-                })
-                .collect();
-            let curves = curves?;
-
-            // Current + added count determines post-expansion device count.
-            // Without state read here, assume current is single-key (the
-            // common `expand` case). If state is already multi-key, the
-            // threshold validator in the SDK rejects mismatches.
-            let estimated_count = 1 + curves.len();
-            let new_kt =
-                crate::commands::init::parse_threshold_cli(&signing_threshold, estimated_count)?;
-            let new_nt =
-                crate::commands::init::parse_threshold_cli(&rotation_threshold, estimated_count)?;
-
-            let base_alias = KeyAlias::new_unchecked(alias.clone());
-
-            // Atomically migrate the legacy {alias} slot to {alias}--0 before
-            // the rotation starts. Idempotent: safe if already migrated.
-            let key_storage: Arc<dyn auths_sdk::keychain::KeyStorage + Send + Sync> = Arc::from(
-                auths_sdk::keychain::get_platform_keychain_with_config(env_config)
-                    .context("Failed to access keychain")?,
-            );
-            let _migrated =
-                auths_sdk::keychain::migrate_legacy_alias(key_storage.as_ref(), &base_alias)
-                    .context("Failed to migrate legacy key alias before expansion")?;
-
-            // Build the registry backend and run the multi-device rotation.
-            let backend: Arc<dyn auths_sdk::ports::RegistryBackend + Send + Sync> = Arc::new(
-                auths_sdk::storage::GitRegistryBackend::from_config_unchecked(
-                    auths_sdk::storage::RegistryConfig::single_tenant(&repo_path),
-                ),
-            );
-
-            let shape = auths_sdk::identity::RotationShape {
-                add_devices: curves,
-                remove_indices: vec![],
-                new_kt: Some(new_kt),
-                new_nt: Some(new_nt),
-            };
-            let layout = auths_sdk::storage_layout::StorageLayoutConfig::default();
-            let next_alias_obj = KeyAlias::new_unchecked(next_alias.clone());
-            let result = auths_sdk::identity::rotate_registry_identity_multi(
-                backend,
-                &base_alias,
-                &next_alias_obj,
-                passphrase_provider.as_ref(),
-                &layout,
-                key_storage.as_ref(),
-                None,
-                shape,
-            )
-            .context("Failed to expand identity")?;
-
-            println!(
-                "[OK] Identity expanded — rotation at sequence {} with {} new device(s)",
-                result.sequence,
-                add_device.len()
-            );
-            println!(
-                "     Base alias: {} → slots {}..{}",
-                alias, 0, estimated_count
-            );
             Ok(())
         }
 

--- a/crates/auths-cli/src/commands/init/mod.rs
+++ b/crates/auths-cli/src/commands/init/mod.rs
@@ -134,9 +134,9 @@ pub struct InitCommand {
     /// Number of device slots for a multi-key KEL (default 1).
     ///
     /// Values > 1 require `--signing-threshold` and `--rotation-threshold`.
-    /// Multi-device init today runs a single-device inception and points the
-    /// operator at `auths id expand` for the device-expansion rotation; the
-    /// full atomic multi-device inception path is wired through later.
+    /// Multi-device init today runs a single-device inception; add further
+    /// devices with `auths device pair` (each is a delegated identity under
+    /// the root). The full atomic multi-device inception path is wired later.
     #[clap(long, default_value_t = 1)]
     pub device_count: u8,
 
@@ -259,8 +259,8 @@ pub fn handle_init(
         let _nt = parse_threshold_cli(nt_str, device_count)?;
         return Err(anyhow!(
             "multi-device init (--device-count > 1) is not yet wired through the developer setup flow. \
-             Run `auths init` for a single-device identity, then `auths id expand --add-device <CURVE>` \
-             (repeatable) with the desired thresholds to convert into a multi-device KEL."
+             Run `auths init` for a single-device identity, then add devices with `auths device pair` \
+             (each device is a delegated identity under your root)."
         ));
     }
     if cmd.signing_threshold.is_some() && device_count == 1 {

--- a/crates/auths-cli/tests/cases/expand_rotate.rs
+++ b/crates/auths-cli/tests/cases/expand_rotate.rs
@@ -1,0 +1,27 @@
+use super::helpers::TestEnv;
+
+/// `auths id expand` has been removed. It ran a shared-`k` rotation to turn a single-key identity
+/// into a multi-slot key set — a path superseded by delegation-based device pairing
+/// (`auths device pair`), where each device is its own delegated identity under the root. The
+/// command was also brick-prone: on a freshly-migrated single key it read a next-key alias the
+/// migration never produced, failing mid-rotation. Multi-device membership is now pairing only.
+#[test]
+fn id_expand_is_removed() {
+    let env = TestEnv::new();
+
+    let output = env
+        .cmd("auths")
+        .args(["id", "expand", "--add-device", "ed25519"])
+        .output()
+        .unwrap();
+
+    assert!(
+        !output.status.success(),
+        "`auths id expand` should no longer exist"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("unrecognized subcommand") || stderr.contains("unexpected argument"),
+        "expected a clap unrecognized-subcommand error, got: {stderr}"
+    );
+}

--- a/crates/auths-cli/tests/cases/mod.rs
+++ b/crates/auths-cli/tests/cases/mod.rs
@@ -1,5 +1,6 @@
 mod clap_collision;
 mod doctor;
+mod expand_rotate;
 mod golden_path;
 mod helpers;
 mod init;


### PR DESCRIPTION
`id expand` ran a shared-`k` rotation to turn a single-key identity into a
multi-slot key set. Multi-device membership is done through delegation: each device
is paired as its own delegated identity under the root (`auths device pair`), which
is the canonical and only supported path. `id expand`'s shared-`k` mechanism was a
retained legacy path, yet its CLI help sold it as the way to go "multi-device,"
duplicating and confusing the pairing flow.

It was also brick-prone: on a freshly-migrated single key it migrated the next-key
commitment to `{alias}--0--next-{seq}` but then read `{alias}--next-{seq}-{idx}`,
which the migration never wrote, failing with a key-not-found mid-rotation — after
potentially publishing the `rot` to the KEL, leaving the KEL ahead of the keychain.

Removes the command and its wiring; redirects the `id rotate --add-device` and
multi-device `init` messages to `auths device pair`. The general multi-rotation
engine (`rotate_registry_identity_multi`) and the keychain migration primitive are
untouched — they remain correct for already-multi identities. Replaces the brick
reproduction with a test asserting the command no longer exists.

Auths-Id: did:keri:EB5cPHY0t-ejNC_rUzPS1dclTvd6kG-R9mQzjozCuGgd
Auths-Device: did:keri:EB5cPHY0t-ejNC_rUzPS1dclTvd6kG-R9mQzjozCuGgd
Auths-Anchor-Seq: 1
