### PR TITLE
scim: stamp the content ETag when a user is created

### DIFF
--- a/crates/auths-scim-server/src/lib.rs
+++ b/crates/auths-scim-server/src/lib.rs
@@ -291,6 +291,24 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn created_user_carries_a_content_etag_like_a_group() {
+        // A freshly created user must carry a content ETag (`meta.version`) just as a group does,
+        // so `If-Match` optimistic concurrency works on it from the moment it exists.
+        let resp = router(test_state())
+            .oneshot(post_users(user_body("alice", "ext-alice")))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::CREATED);
+        let body = json_value(resp).await;
+        let version = body["meta"]["version"].as_str().unwrap_or("");
+        assert!(
+            !version.is_empty(),
+            "a created user must carry a content ETag, got meta = {}",
+            body["meta"]
+        );
+    }
+
+    #[tokio::test]
     async fn router_nests_into_a_parent_router() {
         let parent = Router::new().merge(router(test_state()));
         let resp = parent

--- a/crates/auths-scim-server/src/state.rs
+++ b/crates/auths-scim-server/src/state.rs
@@ -134,6 +134,35 @@ struct UserStore {
     by_id: HashMap<String, StoredUser>,
 }
 
+impl UserStore {
+    /// Insert a user, stamping a fresh content ETag (so a created user carries the same kind of
+    /// `meta.version` a created group does), and return the stored value. Mirrors
+    /// [`GroupStore::insert`]; the optional `external_id` indexes the idempotency key.
+    fn insert(
+        &mut self,
+        tenant_id: &str,
+        external_id: Option<String>,
+        mut user: ScimUser,
+    ) -> ScimUser {
+        recompute_etag(&mut user);
+        let id = user.id.clone();
+        if let Some(ext) = external_id {
+            self.by_external
+                .insert((tenant_id.to_string(), ext), id.clone());
+        }
+        let stored = user.clone();
+        self.by_id.insert(
+            id,
+            StoredUser {
+                tenant_id: tenant_id.to_string(),
+                user,
+                deleted: false,
+            },
+        );
+        stored
+    }
+}
+
 /// A stored SCIM Group plus its owning tenant. `deleted` is the soft-delete tombstone,
 /// matching the user store's semantics (hidden from reads, recoverable).
 struct StoredGroup {
@@ -355,23 +384,15 @@ impl ScimServerState {
             .collect()
     }
 
-    /// Insert a freshly provisioned resource and index it on `(tenant, externalId)`.
-    pub(crate) fn insert_user(&self, tenant_id: &str, external_id: Option<String>, user: ScimUser) {
-        let mut store = self.inner.store();
-        let id = user.id.clone();
-        if let Some(ext) = external_id {
-            store
-                .by_external
-                .insert((tenant_id.to_string(), ext), id.clone());
-        }
-        store.by_id.insert(
-            id,
-            StoredUser {
-                tenant_id: tenant_id.to_string(),
-                user,
-                deleted: false,
-            },
-        );
+    /// Insert a freshly provisioned resource and index it on `(tenant, externalId)`, stamping its
+    /// content ETag and returning the stored value.
+    pub(crate) fn insert_user(
+        &self,
+        tenant_id: &str,
+        external_id: Option<String>,
+        user: ScimUser,
+    ) -> ScimUser {
+        self.inner.store().insert(tenant_id, external_id, user)
     }
 
     /// Atomically read-modify-write a live resource under a single lock.
@@ -530,6 +551,26 @@ mod tests {
         a.user_name = "alice-renamed".to_string();
         recompute_etag(&mut a);
         assert_ne!(a.meta.version, v1, "a content change must change the ETag");
+    }
+
+    #[test]
+    fn user_store_insert_stamps_the_content_etag_like_groups() {
+        // A created user must carry the same content-derived ETag a created group does — the value
+        // `recompute_etag` produces for its content — not a separate id-based placeholder.
+        let mut store = UserStore::default();
+        let stored = store.insert("t1", Some("ext-alice".to_string()), user("alice"));
+
+        let mut expected = user("alice");
+        recompute_etag(&mut expected);
+        assert_eq!(
+            stored.meta.version, expected.meta.version,
+            "insert must stamp the content ETag"
+        );
+        assert!(
+            stored.meta.version.starts_with("W/\""),
+            "weak content ETag, got {}",
+            stored.meta.version
+        );
     }
 
     fn group(id: &str, display: &str) -> ScimGroup {

--- a/crates/auths-scim-server/src/users.rs
+++ b/crates/auths-scim-server/src/users.rs
@@ -52,8 +52,8 @@ pub async fn create_user(
         created_at: now,
     };
     let user = provision_result_to_scim_user(&result, &request, now, &tenant.base_url);
-    state.insert_user(&tenant.tenant_id, request.external_id.clone(), user.clone());
-    Ok((StatusCode::CREATED, Json(user)))
+    let stored = state.insert_user(&tenant.tenant_id, request.external_id.clone(), user);
+    Ok((StatusCode::CREATED, Json(stored)))
 }
 
 /// `GET /scim/v2/Users` — list, filter (RFC 7644), and paginate this tenant's


### PR DESCRIPTION
A created group carried a content-derived ETag (GroupStore::insert calls
recompute_etag), and user updates recompute it too, but a freshly created user kept
an id-based placeholder from the mapping layer — a second ETag scheme for the same
resource. Give UserStore an `insert` that stamps the content ETag and returns the
stored value, mirroring GroupStore::insert; `insert_user` delegates to it and
`create_user` responds with the stored value. A created user now carries the same
content ETag it would after an update.

Adds a unit test (the stored ETag equals the content recompute) and an HTTP test
(a created user carries a content ETag). The generic ResourceStore<T> extraction
that would remove the two-store duplication remains deferred until a third SCIM
resource exists.

Auths-Id: did:keri:EB5cPHY0t-ejNC_rUzPS1dclTvd6kG-R9mQzjozCuGgd
Auths-Device: did:keri:EB5cPHY0t-ejNC_rUzPS1dclTvd6kG-R9mQzjozCuGgd
Auths-Anchor-Seq: 1
