### PR TITLE
mcp: distinguish a valid-but-stale grant from an unauthentic proof

### DIFF
--- a/crates/auths-mcp-core/src/audit.rs
+++ b/crates/auths-mcp-core/src/audit.rs
@@ -336,8 +336,9 @@ pub async fn audit_spend_log(
                 };
             }
             crate::gate::Verdict::Revoked => return AuditVerdict::Revoked { at: i },
-            // Allowed / OutsideAgentScope / AgentExpired are AUTHENTIC proofs — a legit refusal is
-            // not a tamper; only forgery and revocation are audit failures of the proof itself.
+            // Allowed / OutsideAgentScope / AgentExpired / Stale are AUTHENTIC proofs — a legit
+            // refusal (including a stale-freshness one) is not a tamper; only forgery and
+            // revocation are audit failures of the proof itself.
             _ => {}
         }
         // Continuity: each record's SIGNED `Auths-Prev` links to the prior record's commit (the

--- a/crates/auths-mcp-core/src/gate.rs
+++ b/crates/auths-mcp-core/src/gate.rs
@@ -92,6 +92,11 @@ pub enum Verdict {
     /// gateway treats this as a hard fail-closed: the call is not forwarded. A
     /// forged or malformed proof lands here.
     ProofUnauthentic { reason: String },
+    /// The proof is authentic, but its freshness failed the policy — a valid grant
+    /// whose source is too stale to trust under the current `FreshnessPolicy`. Distinct
+    /// from [`ProofUnauthentic`]: the call is still fail-closed (not forwarded), but the
+    /// remedy is to re-fetch the latest tip and retry, not to reject a forgery.
+    Stale,
 }
 
 impl Verdict {
@@ -106,6 +111,7 @@ impl Verdict {
             Verdict::AgentExpired => "agent-expired",
             Verdict::Revoked => "revoked",
             Verdict::ProofUnauthentic { .. } => "proof-unauthentic",
+            Verdict::Stale => "stale",
         }
     }
 
@@ -120,9 +126,7 @@ impl Verdict {
             {
                 Verdict::Allowed
             }
-            CommitVerdict::Valid { .. } => Verdict::ProofUnauthentic {
-                reason: "stale".to_string(),
-            },
+            CommitVerdict::Valid { .. } => Verdict::Stale,
             CommitVerdict::OutsideAgentScope { capability, .. } => Verdict::OutsideAgentScope {
                 capability: Capability(capability.clone()),
             },
@@ -494,5 +498,21 @@ mod tests {
             Verdict::from_commit_verdict(&CommitVerdict::SshSignatureInvalid),
             Verdict::ProofUnauthentic { .. }
         ));
+    }
+
+    #[test]
+    fn valid_but_stale_is_stale_not_unauthentic() {
+        // A valid proof whose freshness fails policy is Stale, not ProofUnauthentic: the proof IS
+        // authentic, so the remedy is to re-fetch the latest tip, not to reject a forgery. Both
+        // are fail-closed (not forwarded), but the gateway must keep them distinct.
+        let verdict = Verdict::from_commit_verdict(&CommitVerdict::Valid {
+            signer_did: "did:keri:Eagent".into(),
+            root_did: "did:keri:Eroot".into(),
+            duplicitous_root: false,
+            as_of: 0,
+            freshness: auths_verifier::freshness::Freshness::Stale,
+        });
+        assert_eq!(verdict, Verdict::Stale);
+        assert_eq!(verdict.code(), "stale");
     }
 }


### PR DESCRIPTION
The gate mapped a CommitVerdict::Valid that failed the freshness policy to
`ProofUnauthentic { reason: "stale" }`, overloading the verdict for a forged or
malformed proof. But a stale grant's proof IS authentic — only its freshness failed
policy — so collapsing the two loses the signal a caller needs: re-fetch the latest
tip and retry, versus reject a forgery. Adds a distinct `Verdict::Stale` (code
"stale"), still fail-closed (not forwarded). The audit chain treats it as an
authentic, non-tamper refusal alongside Allowed/OutsideAgentScope/AgentExpired.

Auths-Id: did:keri:EB5cPHY0t-ejNC_rUzPS1dclTvd6kG-R9mQzjozCuGgd
Auths-Device: did:keri:EB5cPHY0t-ejNC_rUzPS1dclTvd6kG-R9mQzjozCuGgd
Auths-Anchor-Seq: 1
