### PR TITLE
loop/foundation 2026 06 22 141238

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -323,8 +323,16 @@ jobs:
         run: cargo test --target wasm32-unknown-unknown --no-default-features --features wasm --test wasm_bindings
 
   fuzz-smoke:
-    name: Fuzz targets build + smoke (auths-verifier)
+    name: Fuzz targets build + smoke
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - dir: crates/auths-verifier/fuzz
+            targets: verify_presentation_json verify_credential_json verify_chain attestation_parse did_parse
+          - dir: crates/auths-keri/fuzz
+            targets: fuzz_cesr_import fuzz_parse_cesr fuzz_validate_kel
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@nightly
@@ -333,20 +341,20 @@ jobs:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-            crates/auths-verifier/fuzz/target
-          key: ${{ runner.os }}-fuzz-${{ hashFiles('**/Cargo.lock') }}
+            ${{ matrix.dir }}/target
+          key: ${{ runner.os }}-fuzz-${{ hashFiles('**/Cargo.lock') }}-${{ matrix.dir }}
           restore-keys: ${{ runner.os }}-fuzz-
       - name: Install cargo-fuzz
         run: cargo install cargo-fuzz --locked
-      # Building is the anti-bit-rot guard (the targets must track the verifier API); a
+      # Building is the anti-bit-rot guard (the targets must track the crate API); a
       # short run on each exercises the invariants — never accept a forgery, never panic.
       - name: Build fuzz targets
-        working-directory: crates/auths-verifier/fuzz
+        working-directory: ${{ matrix.dir }}
         run: cargo +nightly fuzz build
       - name: Smoke-run each target
-        working-directory: crates/auths-verifier/fuzz
+        working-directory: ${{ matrix.dir }}
         run: |
-          for target in verify_presentation_json verify_credential_json verify_chain attestation_parse did_parse; do
+          for target in ${{ matrix.targets }}; do
             echo "::group::$target"
             cargo +nightly fuzz run "$target" -- -runs=20000
             echo "::endgroup::"

--- a/crates/auths-keri/fuzz/Cargo.lock
+++ b/crates/auths-keri/fuzz/Cargo.lock
@@ -69,30 +69,35 @@ dependencies = [
 
 [[package]]
 name = "auths-crypto"
-version = "0.0.1-rc.10"
+version = "0.1.3"
 dependencies = [
  "async-trait",
  "base64",
  "bs58",
- "ring",
+ "cesride",
+ "hex",
+ "serde",
  "ssh-key",
  "thiserror 2.0.18",
- "tokio",
  "zeroize",
 ]
 
 [[package]]
 name = "auths-keri"
-version = "0.0.1-rc.10"
+version = "0.1.3"
 dependencies = [
+ "async-trait",
  "auths-crypto",
- "auths-verifier",
  "base64",
  "blake3",
  "cesride",
+ "chrono",
  "hex",
+ "p256",
+ "ring",
  "serde",
  "serde_json",
+ "subtle",
  "thiserror 2.0.18",
 ]
 
@@ -102,27 +107,7 @@ version = "0.0.0"
 dependencies = [
  "auths-keri",
  "libfuzzer-sys",
-]
-
-[[package]]
-name = "auths-verifier"
-version = "0.0.1-rc.10"
-dependencies = [
- "async-trait",
- "auths-crypto",
- "base64",
- "blake3",
- "bs58",
- "chrono",
- "hex",
- "json-canon",
- "log",
- "ring",
- "serde",
  "serde_json",
- "sha2",
- "subtle",
- "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -148,12 +133,6 @@ name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
-
-[[package]]
-name = "bitflags"
-version = "2.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
 name = "blake2"
@@ -201,12 +180,6 @@ name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
-
-[[package]]
-name = "bytes"
-version = "1.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cc"
@@ -451,16 +424,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
-name = "errno"
-version = "0.3.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
-dependencies = [
- "libc",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "ff"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -621,17 +584,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "json-canon"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "447ae153a2bd47d61acc0d131295408e32ef87ed9785825a6f4ecef85afc0edb"
-dependencies = [
- "ryu-js",
- "serde",
- "serde_json",
-]
-
-[[package]]
 name = "k256"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -686,15 +638,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
-name = "lock_api"
-version = "0.4.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
-dependencies = [
- "scopeguard",
-]
-
-[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -705,17 +648,6 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
-
-[[package]]
-name = "mio"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
-dependencies = [
- "libc",
- "wasi",
- "windows-sys 0.61.2",
-]
 
 [[package]]
 name = "num-bigint"
@@ -829,29 +761,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "parking_lot"
-version = "0.12.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
-dependencies = [
- "lock_api",
- "parking_lot_core",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.9.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall",
- "smallvec",
- "windows-link",
-]
-
-[[package]]
 name = "password-hash"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -870,12 +779,6 @@ checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
 dependencies = [
  "base64ct",
 ]
-
-[[package]]
-name = "pin-project-lite"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pkcs1"
@@ -970,15 +873,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_syscall"
-version = "0.5.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
 name = "regex"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1028,7 +922,7 @@ dependencies = [
  "getrandom 0.2.17",
  "libc",
  "untrusted",
- "windows-sys 0.52.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1066,18 +960,6 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
-
-[[package]]
-name = "ryu-js"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6518fc26bced4d53678a22d6e423e9d8716377def84545fe328236e3af070e7f"
-
-[[package]]
-name = "scopeguard"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "sec1"
@@ -1171,16 +1053,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
-name = "signal-hook-registry"
-version = "1.4.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
-dependencies = [
- "errno",
- "libc",
-]
-
-[[package]]
 name = "signature"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1195,16 +1067,6 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
-
-[[package]]
-name = "socket2"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
-dependencies = [
- "libc",
- "windows-sys 0.61.2",
-]
 
 [[package]]
 name = "spin"
@@ -1335,34 +1197,6 @@ name = "tinyvec_macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
-
-[[package]]
-name = "tokio"
-version = "1.50.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
-dependencies = [
- "bytes",
- "libc",
- "mio",
- "parking_lot",
- "pin-project-lite",
- "signal-hook-registry",
- "socket2",
- "tokio-macros",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "tokio-macros"
-version = "2.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "typenum"
@@ -1517,15 +1351,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-sys"
-version = "0.61.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
-dependencies = [
- "windows-link",
-]
-
-[[package]]
 name = "windows-targets"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1621,6 +1446,7 @@ version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 dependencies = [
+ "serde",
  "zeroize_derive",
 ]
 
@@ -1640,11 +1466,3 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
-
-[[patch.unused]]
-name = "radicle-core"
-version = "0.1.0"
-
-[[patch.unused]]
-name = "radicle-crypto"
-version = "0.14.0"

--- a/crates/auths-keri/fuzz/Cargo.toml
+++ b/crates/auths-keri/fuzz/Cargo.toml
@@ -9,9 +9,7 @@ cargo-fuzz = true
 
 [dependencies]
 libfuzzer-sys = "0.4"
-base64 = "0.22"
-arbitrary = { version = "1", features = ["derive"] }
-serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 
 [dependencies.auths_keri]
 package = "auths-keri"

--- a/crates/auths-keri/fuzz/fuzz_targets/fuzz_parse_cesr.rs
+++ b/crates/auths-keri/fuzz/fuzz_targets/fuzz_parse_cesr.rs
@@ -1,47 +1,38 @@
 #![no_main]
 //! `KeriPublicKey::parse` fuzz harness with a re-encode oracle.
 //!
-//! When a parse succeeds, the harness synthesizes the CESR prefix form
-//! and re-parses it, asserting byte-identical round-trip through the
-//! raw-bytes path. Catches round-trip bugs that a single-parse
-//! harness would miss (length miscounts, base64 edge cases, mixed
-//! prefix ambiguities).
+//! When a parse succeeds, the harness re-encodes the key through the
+//! canonical CESR encoder (`to_qb64`) and re-parses it, asserting a
+//! byte-identical round-trip. Catches round-trip bugs that a single-parse
+//! harness would miss (length miscounts, base64 edge cases, mixed prefix
+//! ambiguities, lead-byte misalignment).
 
 use auths_keri::KeriPublicKey;
-use base64::Engine;
-use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use libfuzzer_sys::fuzz_target;
-
-fn re_encode(pk: &KeriPublicKey) -> String {
-    let bytes = pk.as_bytes();
-    let prefix = pk.cesr_prefix();
-    let encoded = URL_SAFE_NO_PAD.encode(bytes);
-    format!("{prefix}{encoded}")
-}
 
 fuzz_target!(|data: &[u8]| {
     let Ok(s) = std::str::from_utf8(data) else {
         return;
     };
-    match KeriPublicKey::parse(s) {
-        Ok(pk) => {
-            let re_encoded = re_encode(&pk);
-            match KeriPublicKey::parse(&re_encoded) {
-                Ok(pk2) => {
-                    if pk.as_bytes() != pk2.as_bytes() {
-                        panic!("round-trip produced different bytes");
-                    }
-                    if pk.curve() != pk2.curve() {
-                        panic!("round-trip changed curve");
-                    }
-                }
-                Err(e) => {
-                    panic!("re-encoded key failed to parse: {e:?}");
-                }
+    let Ok(pk) = KeriPublicKey::parse(s) else {
+        return;
+    };
+
+    let re_encoded = match pk.to_qb64() {
+        Ok(q) => q,
+        Err(e) => panic!("a parsed key must re-encode to canonical qb64: {e:?}"),
+    };
+    match KeriPublicKey::parse(&re_encoded) {
+        Ok(pk2) => {
+            if pk.as_bytes() != pk2.as_bytes() {
+                panic!("round-trip produced different bytes");
+            }
+            if pk.curve() != pk2.curve() {
+                panic!("round-trip changed curve");
             }
         }
-        Err(_) => {
-            // Expected for most inputs.
+        Err(e) => {
+            panic!("canonical re-encoding failed to parse: {e:?}");
         }
     }
 });

--- a/crates/auths-keri/fuzz/fuzz_targets/fuzz_validate_kel.rs
+++ b/crates/auths-keri/fuzz/fuzz_targets/fuzz_validate_kel.rs
@@ -1,70 +1,37 @@
 #![no_main]
-//! Byte-level KEL replay fuzz target.
+//! Authenticated KEL-replay fuzz target.
 //!
-//! Feeds attacker-controlled bytes through the `import_cesr_to_events`
-//! codec path, then hands the resulting events to `validate_kel` and
-//! asserts structural invariants on any `Ok` branch. A structure-
-//! aware variant that generates `Event` values via `Arbitrary` can be
-//! layered on top of this harness later — the byte-level version
-//! subsumes the interesting cases because the codec itself produces
-//! well-formed-but-hostile event sequences for most inputs.
+//! Decodes attacker-controlled bytes as a JSON array of signed events and
+//! hands them to `validate_signed_kel` — the authenticated replay every
+//! stateless verify entrypoint routes through. The byte-level CESR codec
+//! parser is fuzzed separately by `fuzz_cesr_import`; this target exercises
+//! the validation verdict itself.
 //!
-//! # Invariants asserted on `Ok`
+//! # Invariants asserted
 //!
-//! 1. Event list is non-empty (validate_kel requires at least an Icp).
-//! 2. Sequence numbers are strictly monotonic across consecutive events.
-//! 3. The inception event's `i` (controller AID) is preserved on every
-//!    following event.
+//! 1. Validation never panics on hostile input: every malformed, forged, or
+//!    truncated KEL resolves to a typed error, never a crash.
+//! 2. Any `Ok` verdict describes a single-controller chain — the inception's
+//!    controller AID is preserved on every following event. The validator
+//!    enforces this through chain linkage; re-checking it here turns a silent
+//!    linkage regression into a fuzz crash.
 
-use auths_keri::{CesrV1Codec, Event, import_cesr_to_events, validate_kel};
+use auths_keri::{SignedEvent, validate_signed_kel};
 use libfuzzer_sys::fuzz_target;
 
-fn sn(e: &Event) -> u128 {
-    match e {
-        Event::Icp(ev) => ev.s.value(),
-        Event::Rot(ev) => ev.s.value(),
-        Event::Ixn(ev) => ev.s.value(),
-        Event::Dip(ev) => ev.s.value(),
-        Event::Drt(ev) => ev.s.value(),
-    }
-}
-
-fn controller(e: &Event) -> String {
-    match e {
-        Event::Icp(ev) => ev.i.to_string(),
-        Event::Rot(ev) => ev.i.to_string(),
-        Event::Ixn(ev) => ev.i.to_string(),
-        Event::Dip(ev) => ev.i.to_string(),
-        Event::Drt(ev) => ev.i.to_string(),
-    }
-}
-
 fuzz_target!(|data: &[u8]| {
-    let codec = CesrV1Codec;
-    let Ok(events) = import_cesr_to_events(&codec, data) else {
+    let Ok(events) = serde_json::from_slice::<Vec<SignedEvent>>(data) else {
         return;
     };
-    if events.is_empty() {
-        return;
-    }
-    let Ok(_key_state) = validate_kel(&events) else {
+    let Ok(_key_state) = validate_signed_kel(&events, None) else {
         return;
     };
 
-    // Invariant: strictly monotonic sequence numbers.
-    for window in events.windows(2) {
-        let a = sn(&window[0]);
-        let b = sn(&window[1]);
-        if b <= a {
-            panic!("validate_kel accepted non-monotonic sn: {a} -> {b}");
-        }
-    }
-
-    // Invariant: controller AID is preserved across the sequence.
-    let i0 = controller(&events[0]);
-    for (idx, e) in events.iter().enumerate().skip(1) {
-        if controller(e) != i0 {
-            panic!("event #{idx} has mismatched controller AID");
+    // An accepted KEL is non-empty (EmptyKel is an error) and single-controller.
+    let controller = events[0].prefix().to_string();
+    for (idx, signed) in events.iter().enumerate().skip(1) {
+        if signed.prefix().to_string() != controller {
+            panic!("validate_signed_kel accepted a mismatched controller AID at event #{idx}");
         }
     }
 });

--- a/crates/auths-keri/src/cesr_encode.rs
+++ b/crates/auths-keri/src/cesr_encode.rs
@@ -54,9 +54,15 @@ pub(crate) fn encode_verkey(raw: &[u8], code: &str) -> Result<String, KeriDecode
 /// Args:
 /// * `qb64`: The CESR-qualified verkey string (e.g. `"DAAB…"`, `"1AAJ…"`).
 pub(crate) fn decode_verkey(qb64: &str) -> Result<(Vec<u8>, String), KeriDecodeError> {
-    let verfer = Verfer::new(None, None, None, Some(qb64), None)
-        .map_err(|e| KeriDecodeError::DecodeError(e.to_string()))?;
-    Ok((verfer.raw(), verfer.code()))
+    // cesride derives a primitive's length from its derivation code and indexes
+    // into the qb64 by that length, so a truncated or malformed code slices out
+    // of bounds and panics. Contain the panic at this untrusted-input boundary so
+    // a bad verkey fails closed with a typed error instead of crashing the caller.
+    std::panic::catch_unwind(|| {
+        Verfer::new(None, None, None, Some(qb64), None).map(|v| (v.raw(), v.code()))
+    })
+    .map_err(|_| KeriDecodeError::DecodeError("malformed CESR verkey primitive".into()))?
+    .map_err(|e| KeriDecodeError::DecodeError(e.to_string()))
 }
 
 /// CESR-encode a 32-byte Blake3-256 digest as a qb64 SAID/commitment (`E…`).

--- a/crates/auths-keri/src/keys.rs
+++ b/crates/auths-keri/src/keys.rs
@@ -119,6 +119,27 @@ impl KeriPublicKey {
             return Err(KeriDecodeError::EmptyInput);
         }
 
+        // cesride's qb64 decoder derives a primitive's length from its derivation
+        // code and slices the input by that length, so a non-ASCII, truncated, or
+        // unknown code makes it slice off a char boundary or past the end and panic.
+        // Reject anything that is not an exact, known verkey primitive here so the
+        // parser fails closed on hostile input. The curve is still selected by the
+        // in-band code prefix, never by raw byte length.
+        let expected_len = if encoded.starts_with("1AAI") || encoded.starts_with("1AAJ") {
+            48 // P-256 compressed verkey: 4-char code + 44 base64 chars
+        } else if encoded.starts_with('D') || encoded.starts_with('B') {
+            44 // Ed25519 verkey: 1-char code + 43 base64 chars
+        } else {
+            return Err(KeriDecodeError::UnsupportedKeyType(
+                encoded.chars().take(4).collect(),
+            ));
+        };
+        if !encoded.is_ascii() || encoded.len() != expected_len {
+            return Err(KeriDecodeError::DecodeError(format!(
+                "verkey primitive is not a {expected_len}-char ASCII CESR string"
+            )));
+        }
+
         let (bytes, code) = crate::cesr_encode::decode_verkey(encoded)?;
 
         use cesride::matter::Codex;
@@ -359,6 +380,19 @@ mod tests {
         assert!(!non_transferable.is_transferable());
         assert_eq!(transferable.cesr_prefix(), "1AAJ");
         assert_eq!(non_transferable.cesr_prefix(), "1AAI");
+    }
+
+    #[test]
+    fn parse_rejects_malformed_qb64_without_panicking() {
+        // A derivation code whose declared primitive size exceeds the actual
+        // input length must fail closed with a typed error, never an
+        // out-of-bounds slice panic inside the CESR decoder.
+        for malformed in ["6AAA1IAA", "1AAJ", "D", "1AAI"] {
+            assert!(
+                KeriPublicKey::parse(malformed).is_err(),
+                "malformed CESR verkey {malformed:?} must be rejected, not panic"
+            );
+        }
     }
 
     #[test]

--- a/crates/auths-keri/src/roundtrip.rs
+++ b/crates/auths-keri/src/roundtrip.rs
@@ -97,12 +97,11 @@ fn extract_body_length(bytes: &[u8]) -> Result<usize, KeriTranslationError> {
         ))?;
 
     let hex_start = pos + marker.len();
-    if hex_start + 6 > header.len() {
-        return Err(KeriTranslationError::DecodingFailed(
-            "version string truncated".into(),
-        ));
-    }
-    let hex_str = &header[hex_start..hex_start + 6];
+    let hex_str = header
+        .get(hex_start..hex_start + 6)
+        .ok_or(KeriTranslationError::DecodingFailed(
+            "version string truncated or not char-aligned".into(),
+        ))?;
     usize::from_str_radix(hex_str, 16).map_err(|e| {
         KeriTranslationError::DecodingFailed(format!("invalid hex size in version string: {e}"))
     })

--- a/crates/auths-keri/src/roundtrip.rs
+++ b/crates/auths-keri/src/roundtrip.rs
@@ -97,11 +97,12 @@ fn extract_body_length(bytes: &[u8]) -> Result<usize, KeriTranslationError> {
         ))?;
 
     let hex_start = pos + marker.len();
-    let hex_str = header
-        .get(hex_start..hex_start + 6)
-        .ok_or(KeriTranslationError::DecodingFailed(
-            "version string truncated or not char-aligned".into(),
-        ))?;
+    let hex_str =
+        header
+            .get(hex_start..hex_start + 6)
+            .ok_or(KeriTranslationError::DecodingFailed(
+                "version string truncated or not char-aligned".into(),
+            ))?;
     usize::from_str_radix(hex_str, 16).map_err(|e| {
         KeriTranslationError::DecodingFailed(format!("invalid hex size in version string: {e}"))
     })

--- a/crates/auths-keri/tests/cases/roundtrip.rs
+++ b/crates/auths-keri/tests/cases/roundtrip.rs
@@ -170,3 +170,21 @@ fn export_single_event_roundtrip() {
     assert_eq!(reimported.len(), 1);
     assert_eq!(reimported[0].get("t").and_then(|v| v.as_str()), Some("rot"));
 }
+
+#[test]
+fn import_rejects_multibyte_version_header_without_panicking() {
+    // Five ASCII bytes after the `KERI10JSON` marker put a two-byte UTF-8 char (`Ь`)
+    // astride the six-byte size-field slice: a byte-length check passes, but a direct
+    // `&str` slice would split the char and panic. Import must fail closed instead.
+    let codec = CesrV1Codec::new();
+    let hostile = "{\"v\":\"KERI10JSON00000\u{42c}\"}".as_bytes();
+    let result = import_cesr_to_events(&codec, hostile);
+    assert!(
+        result.is_err(),
+        "a multibyte version header must be rejected, not panic"
+    );
+
+    // A multibyte char inside the six-byte size field is rejected too.
+    let hostile_mid = "{\"v\":\"KERI10JSON00\u{42c}1b_\"}".as_bytes();
+    assert!(import_cesr_to_events(&codec, hostile_mid).is_err());
+}

--- a/crates/auths-sdk/tests/cases/authenticate.rs
+++ b/crates/auths-sdk/tests/cases/authenticate.rs
@@ -165,9 +165,10 @@ async fn authenticated_principal_surfaces_offline_freshness_as_unknown() {
     let now = chrono::Utc::now();
 
     let wire = present_with_store(&h, &subject_alias, &cred, &audience, &store, now);
-    let principal = authenticate_presentation(&h.ctx, &h.issuer_alias, &store, &audience, wire, now)
-        .await
-        .expect("offline-resolved presentation authenticates under the default policy");
+    let principal =
+        authenticate_presentation(&h.ctx, &h.issuer_alias, &store, &audience, wire, now)
+            .await
+            .expect("offline-resolved presentation authenticates under the default policy");
 
     assert_eq!(
         principal.freshness(),

--- a/crates/auths-verifier/tests/cases/cross_surface_parity.rs
+++ b/crates/auths-verifier/tests/cases/cross_surface_parity.rs
@@ -126,7 +126,10 @@ fn ffi_valid_verdicts_name_freshness() {
             PRESENTATION_VALID,
             auths_verify_presentation_json as JsonVerifyFn,
         ),
-        (CREDENTIAL_VALID, auths_verify_credential_json as JsonVerifyFn),
+        (
+            CREDENTIAL_VALID,
+            auths_verify_credential_json as JsonVerifyFn,
+        ),
     ] {
         let verdict: serde_json::Value =
             serde_json::from_str(&ffi_verdict(request, f)).expect("verdict json");

--- a/crates/auths-verifier/tests/cases/freshness_honesty.rs
+++ b/crates/auths-verifier/tests/cases/freshness_honesty.rs
@@ -24,8 +24,10 @@ const PRESENTATION_VALID: &str = include_str!("../fixtures/presentation_valid.js
 /// freshness evidence and a build-digest match is a self-measurement, neither a
 /// time-bounded authority claim. Documented on the types themselves; listed here so the
 /// tripwire's scope is explicit and auditable rather than a silent omission.
-const NON_FRESHNESS_BEARING_POSITIVE_VERDICTS: &[&str] =
-    &["OfflineReceiptVerdict::Verified", "OfflineBuildVerdict::Verified"];
+const NON_FRESHNESS_BEARING_POSITIVE_VERDICTS: &[&str] = &[
+    "OfflineReceiptVerdict::Verified",
+    "OfflineBuildVerdict::Verified",
+];
 
 fn did(s: &str) -> IdentityDID {
     IdentityDID::parse(s).expect("did")
@@ -47,7 +49,11 @@ fn presentation_valid_names_as_of_and_freshness() {
         as_of: 4,
     };
     assert_eq!(verdict.freshness(), Some(Freshness::Unknown));
-    assert_eq!(verdict.as_of(), Some(4), "an honored verdict names the slice position it is as-of");
+    assert_eq!(
+        verdict.as_of(),
+        Some(4),
+        "an honored verdict names the slice position it is as-of"
+    );
 }
 
 #[test]
@@ -84,14 +90,21 @@ fn verification_report_valid_names_as_of_and_freshness() {
     // The pure chain verifier reports no slice position, so `as_of` is honestly `None`; the
     // verdict still *carries* the position channel, and a caller with the slice stamps it.
     assert_eq!(report.as_of(), None);
-    assert_eq!(report.with_as_of(9).as_of(), Some(9), "a report can carry its verified position");
+    assert_eq!(
+        report.with_as_of(9).as_of(),
+        Some(9),
+        "a report can carry its verified position"
+    );
 }
 
 #[test]
 fn presentation_json_valid_verdict_carries_as_of_and_freshness_on_the_wire() {
     let verdict: serde_json::Value =
         serde_json::from_str(&verify_presentation_json(PRESENTATION_VALID)).expect("verdict json");
-    assert_eq!(verdict["kind"], "valid", "fixture must be a valid presentation");
+    assert_eq!(
+        verdict["kind"], "valid",
+        "fixture must be a valid presentation"
+    );
     assert!(
         verdict.get("freshness").and_then(|f| f.as_str()).is_some(),
         "a valid presentation JSON verdict must name its freshness, got {verdict}"
@@ -106,7 +119,10 @@ fn presentation_json_valid_verdict_carries_as_of_and_freshness_on_the_wire() {
 fn credential_json_valid_verdict_carries_as_of_and_freshness_on_the_wire() {
     let verdict: serde_json::Value =
         serde_json::from_str(&verify_credential_json(CREDENTIAL_VALID)).expect("verdict json");
-    assert_eq!(verdict["kind"], "valid", "fixture must be a valid credential");
+    assert_eq!(
+        verdict["kind"], "valid",
+        "fixture must be a valid credential"
+    );
     assert!(
         verdict.get("freshness").and_then(|f| f.as_str()).is_some(),
         "a valid credential JSON verdict must name its freshness in lockstep with the \

--- a/crates/auths-verifier/tests/cases/mod.rs
+++ b/crates/auths-verifier/tests/cases/mod.rs
@@ -7,9 +7,9 @@ mod credential;
 mod cross_surface_parity;
 mod did_parsing;
 mod expiration_skew;
-mod freshness_honesty;
 #[cfg(feature = "ffi")]
 mod ffi_smoke;
+mod freshness_honesty;
 mod issuer_signature_required;
 mod kel_verification;
 mod newtypes;


### PR DESCRIPTION
- **fix(auths-keri): reject multibyte version headers instead of panicking**
- **fix(auths-keri): fail closed on malformed CESR verkeys instead of panicking**
- **test(auths-keri): repair the fuzz targets against the current API**
- **ci: build and smoke-run the auths-keri fuzz targets**
- **style: apply rustfmt across the workspace**
