### PR TITLE
fix(multi-sig): sign_partial blind-signing oracle — verify bundle bytes against the event

### DIFF
--- a/crates/auths-sdk/src/workflows/multi_sig.rs
+++ b/crates/auths-sdk/src/workflows/multi_sig.rs
@@ -68,6 +68,11 @@ pub enum MultiSigError {
     /// Underlying KEL validator rejected the combined event.
     #[error("Validation error: {0}")]
     Validation(String),
+
+    /// The bundle's stored canonical bytes do not match its event — a tampered bundle that would
+    /// turn a signer into a blind-signing oracle. Refuse rather than sign attacker-chosen bytes.
+    #[error("bundle canonical bytes do not match its event (tampered bundle)")]
+    BundleMismatch,
 }
 
 /// Serialized bundle written by [`begin_multi_sig_event`] and read by
@@ -110,6 +115,30 @@ pub fn begin_multi_sig_event(
     Ok(bundle)
 }
 
+/// Recompute the canonical signing bytes from a bundle's event — the source of truth — and reject a
+/// bundle whose stored `canonical_bytes` disagree with it.
+///
+/// A signer must never sign coordinator-provided bytes blindly: a tampered bundle (a benign `event`
+/// shown to the operator, but `canonical_bytes` belonging to a malicious event) would otherwise harvest
+/// a valid signature over an event the signer never approved. `combine` already re-derives the canonical
+/// bytes from the event when it verifies; this keeps `sign_partial` consistent so the two never diverge.
+///
+/// Args:
+/// * `bundle`: The unsigned-event bundle read from disk.
+///
+/// Usage:
+/// ```ignore
+/// let canonical = bundle_canonical(&bundle)?; // BundleMismatch if the stored bytes were tampered
+/// ```
+fn bundle_canonical(bundle: &UnsignedEventBundle) -> Result<Vec<u8>, MultiSigError> {
+    let canonical = serialize_for_signing(&bundle.event)
+        .map_err(|e| MultiSigError::Serialization(e.to_string()))?;
+    if canonical != bundle.canonical_bytes {
+        return Err(MultiSigError::BundleMismatch);
+    }
+    Ok(canonical)
+}
+
 /// Produce one indexed signature from `key_alias` at `signer_index`.
 ///
 /// Loads the keypair, decrypts it with the passphrase from
@@ -125,6 +154,10 @@ pub fn sign_partial(
     let raw = fs::read(unsigned_bundle_path)?;
     let bundle: UnsignedEventBundle =
         serde_json::from_slice(&raw).map_err(|e| MultiSigError::Serialization(e.to_string()))?;
+
+    // The event is the source of truth; never sign the bundle's stored bytes blindly. A tampered
+    // bundle is refused here, before any key is loaded (blind-signing defense).
+    let canonical = bundle_canonical(&bundle)?;
 
     let keys = match &bundle.event {
         Event::Icp(icp) => &icp.k,
@@ -162,7 +195,7 @@ pub fn sign_partial(
     let keypair = Ed25519KeyPair::from_pkcs8(&decrypted)
         .map_err(|e| MultiSigError::Signing(format!("Ed25519 load: {e}")))?;
     let _pub_bytes = keypair.public_key().as_ref().to_vec();
-    let sig = keypair.sign(&bundle.canonical_bytes);
+    let sig = keypair.sign(&canonical);
 
     Ok(IndexedSignature {
         index: signer_index,
@@ -378,5 +411,46 @@ mod tests {
         assert_eq!(back.index, 1);
         assert_eq!(back.sig.len(), 64);
         assert_eq!(back.sig, sig.sig);
+    }
+
+    #[test]
+    fn bundle_canonical_rejects_a_tampered_bundle() {
+        // A bundle whose stored canonical_bytes belong to a DIFFERENT event must be refused — signing
+        // them would harvest a valid signature over an event the signer never approved. Before this
+        // fix, sign_partial signed `bundle.canonical_bytes` directly, with no such check (RED).
+        let (shown_icp, _) = make_three_key_icp();
+        let (attacker_icp, _) = make_three_key_icp();
+        let shown = Event::Icp(shown_icp);
+        let attacker = Event::Icp(attacker_icp);
+
+        let tampered = UnsignedEventBundle {
+            event: shown.clone(),
+            signer_aliases: vec!["dev-a".to_string()],
+            canonical_bytes: serialize_for_signing(&attacker).unwrap(), // bytes of a different event
+            said: shown.said().as_str().to_string(),
+        };
+
+        let err = bundle_canonical(&tampered).unwrap_err();
+        assert!(
+            matches!(err, MultiSigError::BundleMismatch),
+            "a tampered bundle must be rejected (blind-signing defense), got {err:?}"
+        );
+    }
+
+    #[test]
+    fn bundle_canonical_accepts_a_consistent_bundle() {
+        // The legitimate bundle (canonical_bytes == serialize_for_signing(event)) is accepted, and the
+        // returned bytes are exactly the event's own canonicalization — what a signer must sign.
+        let (icp, _) = make_three_key_icp();
+        let event = Event::Icp(icp);
+        let consistent = UnsignedEventBundle {
+            event: event.clone(),
+            signer_aliases: vec![],
+            canonical_bytes: serialize_for_signing(&event).unwrap(),
+            said: event.said().as_str().to_string(),
+        };
+
+        let canonical = bundle_canonical(&consistent).expect("consistent bundle accepted");
+        assert_eq!(canonical, serialize_for_signing(&event).unwrap());
     }
 }


### PR DESCRIPTION
## Multi-sig: `sign_partial` was a blind-signing oracle

Found by adversarial review of the matrix's untested-sensitive backlog (`multi_sig::sign_partial` had zero test coverage).

### The bug
`sign_partial` signed the bundle's stored `canonical_bytes` (read from disk) **directly**, without verifying they equal `serialize_for_signing(bundle.event)`:

```rust
let sig = keypair.sign(&bundle.canonical_bytes);   // signs whatever the bundle says
```

Meanwhile `combine` / `validate_signed_event` re-derive the canonical bytes **from the event**. So the bytes a signer signs and the bytes a verifier checks could diverge. A tampered bundle — `event` = a benign event shown to the operator, `canonical_bytes` = the canonicalization of a **malicious** event (e.g. a rotation adding the attacker's key) — yields a valid signature the attacker assembles into the malicious event. The signer approves X, signs Y. For a multi-sig whose whole point is independent per-signer approval, that breaks the guarantee.

### The fix (fail-closed)
`bundle_canonical(bundle)` recomputes the canonical bytes from the event (the source of truth) and returns a typed `MultiSigError::BundleMismatch` if the stored bytes disagree — **before any key is loaded**. `sign_partial` signs the recomputed bytes. Legitimate bundles (where `begin_multi_sig_event` wrote consistent bytes) are unaffected; tampered ones are refused loudly. This also brings `sign_partial` into line with `combine`, which already trusts only the event.

### Adversarially verified — two findings refuted
The same review raised two threshold bypasses on `combine` and **refuted both** (kept honest):
- **Duplicate-index quorum** — refuted: `Threshold::is_satisfied` dedupes indices via a `HashSet`, so `[idx 0, idx 0]` counts as one signer.
- **Loose caller `expected_kt`** — refuted: `validate_signed_event` enforces the event's *own* `kt` over *verified* indices, so a caller's looser expectation can't widen the real threshold.

### Tests
- `bundle_canonical_rejects_a_tampered_bundle` — the defense (would not have rejected before this change).
- `bundle_canonical_accepts_a_consistent_bundle` — legitimate path unaffected.
- 5/5 `multi_sig` tests pass (3 pre-existing `combine` tests still green).

Note: the gate is wired into `sign_partial` (`let canonical = bundle_canonical(&bundle)?;`) before any key access; the unit tests exercise the check directly.

Part of matrix ROADMAP_2 R2 (adversarial coverage of untested operations).
