### PR TITLE
Epic 1: a second person can verify

### DIFF
--- a/crates/auths-cli/src/adapters/git_index.rs
+++ b/crates/auths-cli/src/adapters/git_index.rs
@@ -1,0 +1,57 @@
+use std::path::{Path, PathBuf};
+
+use auths_sdk::ports::git::{IndexError, RepoIndex};
+
+/// System adapter for staging paths into a repository index.
+///
+/// Runs `git add -- <path>` / `git ls-files --error-unmatch -- <path>` via
+/// `std::process::Command`, rooted at the repository working directory.
+///
+/// Usage:
+/// ```ignore
+/// let index = SystemRepoIndex::at(repo_root.clone());
+/// index.stage(&repo_root.join(".auths/roots"))?;
+/// ```
+pub struct SystemRepoIndex {
+    working_dir: PathBuf,
+}
+
+impl SystemRepoIndex {
+    /// Creates an index adapter rooted at the given repository.
+    ///
+    /// Args:
+    /// * `working_dir`: Path to the git repository to operate in.
+    pub fn at(working_dir: PathBuf) -> Self {
+        Self { working_dir }
+    }
+}
+
+impl RepoIndex for SystemRepoIndex {
+    fn stage(&self, path: &Path) -> Result<(), IndexError> {
+        let path_str = path.to_string_lossy().to_string();
+        let output = crate::subprocess::git_command(&["add", "--", &path_str])
+            .current_dir(&self.working_dir)
+            .output()
+            .map_err(|e| IndexError::Stage {
+                path: path_str.clone(),
+                message: e.to_string(),
+            })?;
+
+        if output.status.success() {
+            return Ok(());
+        }
+        Err(IndexError::Stage {
+            path: path_str,
+            message: String::from_utf8_lossy(&output.stderr).trim().to_string(),
+        })
+    }
+
+    fn is_tracked(&self, path: &Path) -> bool {
+        let path_str = path.to_string_lossy().to_string();
+        crate::subprocess::git_command(&["ls-files", "--error-unmatch", "--", &path_str])
+            .current_dir(&self.working_dir)
+            .output()
+            .map(|out| out.status.success())
+            .unwrap_or(false)
+    }
+}

--- a/crates/auths-cli/src/adapters/mod.rs
+++ b/crates/auths-cli/src/adapters/mod.rs
@@ -2,6 +2,7 @@ pub mod agent;
 pub mod config_store;
 pub mod doctor_fixes;
 pub mod git_config;
+pub mod git_index;
 pub mod local_file;
 pub mod ssh_agent;
 pub mod system_diagnostic;

--- a/crates/auths-cli/src/commands/init/mod.rs
+++ b/crates/auths-cli/src/commands/init/mod.rs
@@ -24,6 +24,7 @@ use auths_sdk::keychain::KeyStorage;
 use auths_sdk::ports::git_config::GitConfigProvider;
 use auths_sdk::signing::PrefilledPassphraseProvider;
 use auths_sdk::signing::StorageSigner;
+use auths_sdk::workflows::roots::RootPinOutcome;
 
 use crate::adapters::git_config::SystemGitConfigProvider;
 use crate::config::CliConfig;
@@ -423,22 +424,32 @@ fn run_developer_setup(
 
     // Pin the local identity as a trusted root for KEL-native verification (Epic B):
     // the committed `<repo>/.auths/roots` is the root of trust — no allowed_signers file.
-    // The hook seeds the same pin into every repo on first signed commit; this covers
-    // the repo the user is standing in right now.
+    // Staging is the load-bearing half: a pin that is written but never staged never
+    // reaches a cloner, so every third-party verification path dead-ends on it. We do
+    // not author a commit on the user's behalf — the pin rides their next one.
     if let Ok(output) = crate::subprocess::git_command(&["rev-parse", "--show-toplevel"]).output()
         && output.status.success()
     {
         let root = PathBuf::from(String::from_utf8_lossy(&output.stdout).trim());
         let root_did = result.identity_did.to_string();
-        match auths_sdk::workflows::roots::add_pinned_root(
+        let index = crate::adapters::git_index::SystemRepoIndex::at(root.clone());
+        match auths_sdk::workflows::roots::pin_root_in_repo(
             &crate::adapters::config_store::FileConfigStore,
-            &root.join(".auths"),
+            &index,
+            &root,
             &root_did,
         ) {
-            Ok(()) => out.println(&format!(
-                "  Pinned trusted root: {}",
+            Ok(RootPinOutcome::AlreadyTracked) => out.println(&format!(
+                "  Trusted root already pinned: {}",
                 crate::ux::product_id(&root_did)
             )),
+            Ok(_) => {
+                out.println(&format!(
+                    "  Pinned trusted root: {}",
+                    crate::ux::product_id(&root_did)
+                ));
+                out.println("  Staged .auths/roots — your next commit lets clones verify you");
+            }
             Err(e) => out.println(&format!("  Note: could not pin trusted root ({e})")),
         }
     }

--- a/crates/auths-cli/src/commands/unified_verify.rs
+++ b/crates/auths-cli/src/commands/unified_verify.rs
@@ -130,10 +130,10 @@ pub struct UnifiedVerifyCommand {
     #[arg(long, value_name = "PATH")]
     pub signature: Option<PathBuf>,
 
-    /// Fetch a signer's KEL from this git remote when it is absent locally
-    /// (opt-in). The local registry stays the trusted floor — a remote can only
-    /// advance the key-state, never roll it back. Without it, resolution is
-    /// local-only (no network).
+    /// Override the git remote a signer's KEL is fetched from when it is absent
+    /// locally. Defaults to the repo's own `origin`. The local registry stays the
+    /// trusted floor — a remote can only advance the key-state, never roll it
+    /// back, and nothing is fetched when the KEL is already local.
     #[arg(long)]
     pub remote: Option<String>,
 

--- a/crates/auths-cli/src/commands/verify_commit.rs
+++ b/crates/auths-cli/src/commands/verify_commit.rs
@@ -41,10 +41,11 @@ pub struct VerifyCommitCommand {
     #[arg(long, num_args = 1..)]
     pub witness_keys: Vec<String>,
 
-    /// Fetch a signer's KEL from this git remote when it is absent locally
-    /// (opt-in). The local registry stays the trusted floor — a remote can only
-    /// advance the key-state, never roll it back. Without this flag, resolution
-    /// is local-only (no network).
+    /// Override the git remote a signer's KEL is fetched from when it is absent
+    /// locally. Defaults to the repo's own `origin`, which is where the managed
+    /// pre-push hook mirrors it. The local registry stays the trusted floor — a
+    /// remote can only advance the key-state, never roll it back, and nothing is
+    /// fetched when the KEL is already local.
     #[arg(long)]
     pub remote: Option<String>,
 
@@ -405,8 +406,19 @@ async fn resolve_signer_kel(
         auths_sdk::keri::verify_prefix_binding(&prefix, &events).map_err(|e| e.to_string())?;
         Ok(events)
     } else {
-        let chain = match &cmd.remote {
-            Some(url) => auths_sdk::keri::KelResolverChain::with_remote(registry, url.clone()),
+        // Default the transport to the repo's own `origin`. The managed pre-push
+        // hook mirrors refs/auths/registry there, but `git clone` fetches only
+        // refs/heads/* and refs/tags/* — so in a fresh clone the KEL sits on the
+        // remote and not in the working copy. Resolution stays local-first: the
+        // chain only reaches for the remote when the KEL is absent locally, so
+        // this costs nothing in the common case and fires exactly where
+        // verification would otherwise fail.
+        let remote = cmd
+            .remote
+            .clone()
+            .or_else(crate::commands::verify_helpers::repo_origin_url);
+        let chain = match remote {
+            Some(url) => auths_sdk::keri::KelResolverChain::with_remote(registry, url),
             None => auths_sdk::keri::KelResolverChain::local(registry),
         };
         chain.resolve_kel(did).map_err(|e| e.to_string())

--- a/crates/auths-cli/src/commands/verify_helpers.rs
+++ b/crates/auths-cli/src/commands/verify_helpers.rs
@@ -24,6 +24,33 @@ pub fn load_project_pinned_roots() -> Vec<String> {
     .unwrap_or_default()
 }
 
+/// The current repository's `origin` URL, when there is one.
+///
+/// Used as the default KEL transport: a repo carries its signer's KEL on the same
+/// remote it carries its code (the managed `pre-push` hook mirrors
+/// `refs/auths/registry` there), but a plain `git clone` fetches only
+/// `refs/heads/*` and `refs/tags/*` — so the ref is on the remote and not in the
+/// clone. Without this, `auths verify` in a fresh clone fails with "KEL not found"
+/// while the KEL sits one fetch away on the remote it was cloned from.
+///
+/// Resolution stays local-first: the chain only reaches for the remote when the
+/// KEL is absent locally, and the local registry remains the trusted floor.
+///
+/// Usage:
+/// ```ignore
+/// let fallback = repo_origin_url();
+/// ```
+pub fn repo_origin_url() -> Option<String> {
+    let output = crate::subprocess::git_command(&["remote", "get-url", "origin"])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let url = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    (!url.is_empty()).then_some(url)
+}
+
 /// The human-readable label for a surfaced freshness verdict (ADR 009).
 ///
 /// Shared by every verify command so an offline verdict renders "freshness unknown"

--- a/crates/auths-cli/tests/cases/mod.rs
+++ b/crates/auths-cli/tests/cases/mod.rs
@@ -18,6 +18,7 @@ mod revocation;
 mod sign_commit_binding;
 mod sign_verify;
 mod sign_verify_roundtrip;
+mod third_party_verify;
 mod trust_pin_control;
 mod trust_repo;
 mod verify;

--- a/crates/auths-cli/tests/cases/third_party_verify.rs
+++ b/crates/auths-cli/tests/cases/third_party_verify.rs
@@ -1,0 +1,187 @@
+//! CLI e2e for the property the whole product rests on: **someone who is not the
+//! signer can verify.**
+//!
+//! Every other verification test in this suite runs as the signer, with a populated
+//! `~/.auths`. That is exactly why a total failure of this property shipped
+//! undetected: `auths init` wrote `<repo>/.auths/roots` but never staged it, so the
+//! trust pin never reached a cloner; and nothing mirrored `refs/auths/registry` to
+//! the remote, so the KEL never travelled either. A fresh clone failed with "KEL not
+//! found" while the engine itself was correct the whole time.
+//!
+//! These tests play the *second person*: a machine with no auths identity, a plain
+//! `git clone`, and no flags. They must keep failing closed when trust is absent.
+//!
+//! Runs hermetically — `TestEnv`'s keychain is file-backed with `AUTHS_PASSPHRASE`,
+//! so signing is non-interactive (no macOS keychain / SIP gate).
+
+use std::path::{Path, PathBuf};
+
+use super::helpers::TestEnv;
+
+/// An identity that has signed HEAD and pushed it to a bare origin.
+///
+/// Returns the signer's env and the origin path. The push goes through a plain
+/// `git push`: the managed pre-push hook is what mirrors `refs/auths/registry`, and
+/// this test would be worthless if it pushed the registry by hand.
+fn signer_with_pushed_commit() -> (TestEnv, PathBuf) {
+    let alice = TestEnv::new();
+    alice.init_identity();
+
+    let origin = alice.home.path().join("origin.git");
+    let init_bare = std::process::Command::new("git")
+        .args(["init", "-q", "--bare"])
+        .arg(&origin)
+        .output()
+        .unwrap();
+    assert!(init_bare.status.success(), "git init --bare failed");
+
+    std::fs::write(alice.repo_path.join("main.rs"), "fn main() {}").unwrap();
+    let add = alice.git_cmd().args(["add", "main.rs"]).output().unwrap();
+    assert!(add.status.success(), "git add failed");
+
+    // A plain signed commit — no `auths sign`. The pin must ride along on its own.
+    let commit = alice
+        .git_cmd()
+        .args(["commit", "-m", "feat: add main"])
+        .output()
+        .unwrap();
+    assert!(
+        commit.status.success(),
+        "git commit failed: {}",
+        String::from_utf8_lossy(&commit.stderr)
+    );
+
+    let branch = alice
+        .git_cmd()
+        .args(["rev-parse", "--abbrev-ref", "HEAD"])
+        .output()
+        .unwrap();
+    let branch = String::from_utf8_lossy(&branch.stdout).trim().to_string();
+
+    let push = alice
+        .git_cmd()
+        .arg("push")
+        .arg(&origin)
+        .arg(&branch)
+        .output()
+        .unwrap();
+    assert!(
+        push.status.success(),
+        "git push failed: {}",
+        String::from_utf8_lossy(&push.stderr)
+    );
+
+    // Point the bare repo's HEAD at the branch we pushed, as any real origin does.
+    // Without this the clone checks out a branch that does not exist and lands empty.
+    let head = std::process::Command::new("git")
+        .arg("--git-dir")
+        .arg(&origin)
+        .args(["symbolic-ref", "HEAD"])
+        .arg(format!("refs/heads/{branch}"))
+        .output()
+        .unwrap();
+    assert!(head.status.success(), "could not set origin HEAD");
+
+    (alice, origin)
+}
+
+/// A machine with **no auths identity**, holding a plain clone of `origin`.
+fn observer_cloning(origin: &Path) -> TestEnv {
+    // `TestEnv::new()` never creates an identity — only `init_identity()` does.
+    let mut bob = TestEnv::new();
+    let clone = bob.home.path().join("clone");
+    let out = std::process::Command::new("git")
+        .arg("clone")
+        .arg("-q")
+        .arg(origin)
+        .arg(&clone)
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "git clone failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    bob.repo_path = clone;
+    bob
+}
+
+/// The headline property. No identity, no flags, no setup.
+#[test]
+fn a_second_person_verifies_a_plain_clone_with_no_identity_and_no_flags() {
+    let (_alice, origin) = signer_with_pushed_commit();
+    let bob = observer_cloning(&origin);
+
+    let out = bob.cmd("auths").args(["verify", "HEAD"]).output().unwrap();
+
+    assert!(
+        out.status.success(),
+        "a second person must be able to verify a clone with no flags.\n\
+         stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&out.stdout).contains("verified"),
+        "expected a verified verdict, got: {}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+}
+
+/// The pin must be *in the clone* — that is what makes it a trust declaration the
+/// repo carries rather than a file on the signer's laptop.
+#[test]
+fn the_trust_pin_travels_with_the_repository() {
+    let (_alice, origin) = signer_with_pushed_commit();
+    let bob = observer_cloning(&origin);
+
+    let pin = bob.repo_path.join(".auths").join("roots");
+    assert!(
+        pin.is_file(),
+        ".auths/roots must be committed, or a cloner has nothing to anchor trust to"
+    );
+    let content = std::fs::read_to_string(&pin).unwrap();
+    assert!(
+        content.contains("did:keri:"),
+        "pin must name a did:keri root, got: {content:?}"
+    );
+}
+
+/// The KEL must reach the remote the code went to, via the managed pre-push hook —
+/// not via a manual `auths registry push`.
+#[test]
+fn a_plain_push_mirrors_the_registry_to_the_remote() {
+    let (alice, origin) = signer_with_pushed_commit();
+
+    let refs = alice
+        .git_cmd()
+        .arg("ls-remote")
+        .arg(&origin)
+        .output()
+        .unwrap();
+    let refs = String::from_utf8_lossy(&refs.stdout);
+    assert!(
+        refs.contains("refs/auths/registry"),
+        "a plain `git push` must mirror the signer's KEL to the remote, got:\n{refs}"
+    );
+}
+
+/// Fail closed: strip the pin and the same clone must refuse. An `Auths-Id` trailer
+/// is attacker-controllable — it may *select* among pinned roots, never *establish*
+/// one — so an unpinned root is untrusted no matter how good the signature is.
+#[test]
+fn an_unpinned_root_still_fails_closed() {
+    let (_alice, origin) = signer_with_pushed_commit();
+    let bob = observer_cloning(&origin);
+
+    std::fs::remove_file(bob.repo_path.join(".auths").join("roots")).unwrap();
+
+    let out = bob.cmd("auths").args(["verify", "HEAD"]).output().unwrap();
+
+    assert!(
+        !out.status.success(),
+        "an unpinned root must not verify — this is the TOFU-on-the-root guard.\n\
+         stdout: {}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+}

--- a/crates/auths-sdk/src/ports/git.rs
+++ b/crates/auths-sdk/src/ports/git.rs
@@ -115,3 +115,34 @@ pub trait GitLogProvider: Send + Sync {
         limit: Option<usize>,
     ) -> Result<Vec<CommitRecord>, GitProviderError>;
 }
+
+/// Errors from staging a path into a repository index.
+#[derive(Debug, thiserror::Error)]
+pub enum IndexError {
+    /// The `git add` invocation failed with the given message.
+    #[error("could not stage {path}: {message}")]
+    Stage {
+        /// The path that failed to stage.
+        path: String,
+        /// The underlying git error output.
+        message: String,
+    },
+}
+
+/// Port for staging paths into a repository's index.
+///
+/// Distinct from [`GitLogProvider`] (read-only history) because staging mutates
+/// the working repository. Kept behind a port so trust-pin distribution stays a
+/// testable SDK workflow rather than CLI subprocess glue.
+///
+/// Usage:
+/// ```ignore
+/// index.stage(&repo_root.join(".auths/roots"))?;
+/// ```
+pub trait RepoIndex: Send + Sync {
+    /// Stage `path` into the index, as `git add -- <path>` would.
+    fn stage(&self, path: &std::path::Path) -> Result<(), IndexError>;
+
+    /// Whether `path` is already tracked by the repository.
+    fn is_tracked(&self, path: &std::path::Path) -> bool;
+}

--- a/crates/auths-sdk/src/workflows/commit_hooks.rs
+++ b/crates/auths-sdk/src/workflows/commit_hooks.rs
@@ -86,6 +86,41 @@ fi
 exit 0
 "#;
 
+/// The managed `pre-push` hook. Mirrors `refs/auths/registry` to the remote the
+/// code is going to, so a clone of that remote can resolve the signer's KEL.
+///
+/// Three properties are deliberate:
+///
+/// * **Non-fatal.** A registry mirror must never block a code push. Every failure
+///   path exits 0 — no write access to the remote is the common, expected case.
+/// * **Opt-out via `auths.autopush=false`.** The registry is public by
+///   construction (a KEL is public keys and events), but pushing to a remote you
+///   do not own should stay refusable.
+/// * **Chains to the repo's own `pre-push`.** `core.hooksPath` *replaces*
+///   `.git/hooks`, so a managed hook that did not chain would silently disable
+///   every repo-local pre-push (husky, pre-commit, prek) on the machine.
+pub const PRE_PUSH_HOOK: &str = r#"#!/bin/sh
+# auths pre-push hook v1 — managed by `auths init`, checked by `auths doctor`.
+# Mirrors refs/auths/registry to the remote being pushed to, so a clone of that
+# remote carries the KEL `auths verify` needs. Fast-forward-only and non-fatal:
+# a registry mirror must never block a code push. Disable with:
+#   git config auths.autopush false
+
+REMOTE_URL="$2"
+
+if [ -n "$REMOTE_URL" ] &&
+    [ "$(git config --get auths.autopush 2>/dev/null)" != "false" ] &&
+    command -v auths >/dev/null 2>&1; then
+    auths registry push "$REMOTE_URL" >/dev/null 2>&1 || true
+fi
+
+REPO_HOOK="$(git rev-parse --git-dir 2>/dev/null)/hooks/pre-push"
+if [ -x "$REPO_HOOK" ]; then
+    exec "$REPO_HOOK" "$@"
+fi
+exit 0
+"#;
+
 /// Failure installing the commit hook or writing its data files.
 #[derive(Debug, thiserror::Error)]
 pub enum CommitHookError {
@@ -121,6 +156,22 @@ fn write_file(path: &Path, content: &str) -> Result<(), CommitHookError> {
     })
 }
 
+/// Write a hook script and mark it executable (no-op on non-unix).
+fn write_executable(path: &Path, content: &str) -> Result<(), CommitHookError> {
+    write_file(path, content)?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o755)).map_err(
+            |source| CommitHookError::Write {
+                path: path.to_path_buf(),
+                source,
+            },
+        )?;
+    }
+    Ok(())
+}
+
 /// Path of the managed hook file under `auths_home`.
 ///
 /// Args:
@@ -134,7 +185,24 @@ pub fn hook_path(auths_home: &Path) -> PathBuf {
     auths_home.join(HOOKS_DIR).join("prepare-commit-msg")
 }
 
-/// Whether the managed hook file exists with the current script content.
+/// Path of the managed `pre-push` hook file under `auths_home`.
+///
+/// Args:
+/// * `auths_home`: The auths data directory (`~/.auths` or a CI registry path).
+///
+/// Usage:
+/// ```ignore
+/// let hook = pre_push_hook_path(&auths_home);
+/// ```
+pub fn pre_push_hook_path(auths_home: &Path) -> PathBuf {
+    auths_home.join(HOOKS_DIR).join("pre-push")
+}
+
+/// Whether both managed hook files exist with the current script content.
+///
+/// Covers `prepare-commit-msg` *and* `pre-push`: a stale or missing pre-push
+/// means the signer's KEL never reaches the remote, which `auths doctor` should
+/// surface as an actionable "re-run auths init" rather than a silent gap.
 ///
 /// Args:
 /// * `auths_home`: The auths data directory.
@@ -144,9 +212,13 @@ pub fn hook_path(auths_home: &Path) -> PathBuf {
 /// if !hook_is_current(&auths_home) { /* doctor: re-run auths init */ }
 /// ```
 pub fn hook_is_current(auths_home: &Path) -> bool {
-    std::fs::read_to_string(hook_path(auths_home))
-        .map(|content| content == PREPARE_COMMIT_MSG_HOOK)
-        .unwrap_or(false)
+    let matches = |path: PathBuf, expected: &str| {
+        std::fs::read_to_string(path)
+            .map(|content| content == expected)
+            .unwrap_or(false)
+    };
+    matches(hook_path(auths_home), PREPARE_COMMIT_MSG_HOOK)
+        && matches(pre_push_hook_path(auths_home), PRE_PUSH_HOOK)
 }
 
 /// Install the `prepare-commit-msg` hook under `<auths_home>/githooks` and write
@@ -170,18 +242,8 @@ pub fn install_commit_hooks(
     root_did: &str,
     device_did: &str,
 ) -> Result<PathBuf, CommitHookError> {
-    let hook = hook_path(auths_home);
-    write_file(&hook, PREPARE_COMMIT_MSG_HOOK)?;
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        std::fs::set_permissions(&hook, std::fs::Permissions::from_mode(0o755)).map_err(
-            |source| CommitHookError::Write {
-                path: hook.clone(),
-                source,
-            },
-        )?;
-    }
+    write_executable(&hook_path(auths_home), PREPARE_COMMIT_MSG_HOOK)?;
+    write_executable(&pre_push_hook_path(auths_home), PRE_PUSH_HOOK)?;
     write_file(
         &auths_home.join(TRAILERS_FILE),
         &format!("Auths-Id: {root_did}\nAuths-Device: {device_did}\n"),
@@ -331,10 +393,61 @@ mod tests {
         use std::os::unix::fs::PermissionsExt;
         let tmp = tempfile::TempDir::new().expect("temp dir");
         install_commit_hooks(tmp.path(), "did:keri:Eroot", "did:keri:Edevice").expect("install");
-        let mode = std::fs::metadata(hook_path(tmp.path()))
-            .expect("metadata")
-            .permissions()
-            .mode();
-        assert_eq!(mode & 0o111, 0o111, "hook must be executable");
+        for path in [hook_path(tmp.path()), pre_push_hook_path(tmp.path())] {
+            let mode = std::fs::metadata(&path)
+                .expect("metadata")
+                .permissions()
+                .mode();
+            assert_eq!(mode & 0o111, 0o111, "{} must be executable", path.display());
+        }
+    }
+
+    #[test]
+    fn install_writes_the_pre_push_hook() {
+        let tmp = tempfile::TempDir::new().expect("temp dir");
+        install_commit_hooks(tmp.path(), "did:keri:Eroot", "did:keri:Edevice").expect("install");
+        let hook = std::fs::read_to_string(pre_push_hook_path(tmp.path())).expect("pre-push");
+        assert_eq!(hook, PRE_PUSH_HOOK);
+        assert!(hook_is_current(tmp.path()));
+    }
+
+    #[test]
+    fn stale_pre_push_is_detected_by_hook_is_current() {
+        let tmp = tempfile::TempDir::new().expect("temp dir");
+        install_commit_hooks(tmp.path(), "did:keri:Eroot", "did:keri:Edevice").expect("install");
+        std::fs::write(pre_push_hook_path(tmp.path()), "#!/bin/sh\n# old\n").expect("overwrite");
+        assert!(
+            !hook_is_current(tmp.path()),
+            "a stale pre-push means the KEL never reaches the remote; doctor must see it"
+        );
+    }
+
+    /// `core.hooksPath` *replaces* `.git/hooks`, so a managed hook that does not
+    /// chain silently disables every repo-local hook on the machine (husky,
+    /// pre-commit, prek). Both managed hooks must exec the repo's own.
+    #[test]
+    fn managed_hooks_chain_to_the_repos_own_hook() {
+        for (name, hook) in [
+            ("prepare-commit-msg", PREPARE_COMMIT_MSG_HOOK),
+            ("pre-push", PRE_PUSH_HOOK),
+        ] {
+            assert!(
+                hook.contains(&format!("hooks/{name}")) && hook.contains("exec \"$REPO_HOOK\""),
+                "{name} must chain to the repo's own hook"
+            );
+        }
+    }
+
+    /// A registry mirror must never block a code push.
+    #[test]
+    fn pre_push_is_non_fatal_and_opt_outable() {
+        assert!(
+            PRE_PUSH_HOOK.contains("|| true"),
+            "registry push failure must not fail the code push"
+        );
+        assert!(
+            PRE_PUSH_HOOK.contains("auths.autopush"),
+            "pushing to a remote you do not own must stay refusable"
+        );
     }
 }

--- a/crates/auths-sdk/src/workflows/commit_hooks.rs
+++ b/crates/auths-sdk/src/workflows/commit_hooks.rs
@@ -35,11 +35,23 @@ pub const HOOKS_DIR: &str = "githooks";
 
 /// The managed `prepare-commit-msg` hook. Version-stamped so `auths doctor` can
 /// detect a stale install; bump the version when editing.
+///
+/// The pin block is a **repair path only** — `auths init` owns pinning and staging
+/// via `roots::pin_root_in_repo`. It exists for repos entered after init ran
+/// elsewhere. Two constraints shape it, both learned the hard way:
+///
+/// 1. It keys off **tracked-ness, not existence**. The previous version skipped
+///    when `.auths/roots` merely existed — which `auths init` had just created —
+///    so the pin was never staged and never travelled.
+/// 2. A `git add` here lands in the **next** commit, not this one: git has already
+///    snapshotted the index by the time `prepare-commit-msg` runs. The message says
+///    so rather than claiming otherwise.
 pub const PREPARE_COMMIT_MSG_HOOK: &str = r#"#!/bin/sh
-# auths prepare-commit-msg hook v1 — managed by `auths init`, checked by
+# auths prepare-commit-msg hook v2 — managed by `auths init`, checked by
 # `auths doctor`. Injects the Auths-Id / Auths-Device trailers so `auths verify`
-# can replay the signer's KEL, and seeds the repo's committed .auths/roots trust
-# pin on first use. Chains to the repo's own hook when one exists.
+# can replay the signer's KEL, and repairs a missing/untracked .auths/roots trust
+# pin (the committed trust declaration teammates and CI inherit).
+# Chains to the repo's own hook when one exists.
 
 MSG_FILE="$1"
 AUTHS_HOME="${AUTHS_REPO:-$HOME/.auths}"
@@ -47,11 +59,17 @@ TRAILERS="$AUTHS_HOME/commit-trailers"
 
 if [ -f "$TRAILERS" ]; then
     TOPLEVEL="$(git rev-parse --show-toplevel 2>/dev/null)"
-    if [ -n "$TOPLEVEL" ] && [ -f "$AUTHS_HOME/root-pin" ] && [ ! -e "$TOPLEVEL/.auths/roots" ]; then
-        mkdir -p "$TOPLEVEL/.auths" &&
-            cp "$AUTHS_HOME/root-pin" "$TOPLEVEL/.auths/roots" &&
-            git add -- "$TOPLEVEL/.auths/roots" >/dev/null 2>&1 &&
-            echo "auths: pinned your identity root in .auths/roots (committed with this commit)" >&2
+    if [ -n "$TOPLEVEL" ] && [ -f "$AUTHS_HOME/root-pin" ]; then
+        PIN="$TOPLEVEL/.auths/roots"
+        [ -e "$PIN" ] || {
+            mkdir -p "$TOPLEVEL/.auths" && cp "$AUTHS_HOME/root-pin" "$PIN"
+        }
+        # Stage only when git isn't tracking it yet. This lands in the NEXT commit:
+        # git snapshotted the index before this hook ran.
+        if [ -e "$PIN" ] && ! git ls-files --error-unmatch -- "$PIN" >/dev/null 2>&1; then
+            git add -- "$PIN" >/dev/null 2>&1 &&
+                echo "auths: staged .auths/roots — your trust pin lands in your next commit" >&2
+        fi
     fi
     while IFS= read -r trailer; do
         case "$trailer" in
@@ -275,6 +293,36 @@ mod tests {
         assert!(!hook_is_current(home));
         install_commit_hooks(home, "did:keri:Eroot", "did:keri:Edevice").expect("reinstall");
         assert!(hook_is_current(home));
+    }
+
+    /// The hook must key the pin repair off *tracked-ness*, not existence. The v1
+    /// hook skipped whenever `.auths/roots` existed — which `auths init` had just
+    /// created — so the pin was never staged and third-party verification was
+    /// impossible. Guard the fix so it cannot silently regress.
+    #[test]
+    fn hook_repairs_pin_on_tracked_ness_not_existence() {
+        assert!(
+            PREPARE_COMMIT_MSG_HOOK.contains("ls-files --error-unmatch"),
+            "pin repair must test tracked-ness, not mere existence"
+        );
+        assert!(
+            !PREPARE_COMMIT_MSG_HOOK.contains("[ ! -e \"$TOPLEVEL/.auths/roots\" ]"),
+            "the v1 existence guard defeated the mechanism it guarded"
+        );
+    }
+
+    /// `git add` inside prepare-commit-msg lands in the NEXT commit — git has
+    /// already snapshotted the index. The hook must not claim otherwise.
+    #[test]
+    fn hook_does_not_claim_the_pin_lands_in_this_commit() {
+        assert!(
+            !PREPARE_COMMIT_MSG_HOOK.contains("committed with this commit"),
+            "false: a git add here lands in the next commit, not this one"
+        );
+        assert!(
+            PREPARE_COMMIT_MSG_HOOK.contains("next commit"),
+            "the hook must tell the truth about when the pin lands"
+        );
     }
 
     #[cfg(unix)]

--- a/crates/auths-sdk/src/workflows/roots.rs
+++ b/crates/auths-sdk/src/workflows/roots.rs
@@ -383,7 +383,10 @@ mod tests {
 
     impl crate::ports::git::RepoIndex for FakeIndex {
         fn stage(&self, path: &Path) -> Result<(), crate::ports::git::IndexError> {
-            self.staged.lock().expect("staged lock").push(path.to_path_buf());
+            self.staged
+                .lock()
+                .expect("staged lock")
+                .push(path.to_path_buf());
             Ok(())
         }
 
@@ -398,8 +401,7 @@ mod tests {
         let repo = tmp.path();
         let index = FakeIndex::new();
 
-        let outcome =
-            pin_root_in_repo(&FsStore, &index, repo, "did:keri:Eroot").expect("pin");
+        let outcome = pin_root_in_repo(&FsStore, &index, repo, "did:keri:Eroot").expect("pin");
 
         assert_eq!(outcome, RootPinOutcome::PinnedAndStaged);
         assert!(is_pinned_root(&FsStore, &repo.join(".auths"), "did:keri:Eroot").expect("pinned"));
@@ -424,8 +426,7 @@ mod tests {
         add_pinned_root(&FsStore, &auths_dir, "did:keri:Eroot").expect("pre-write");
         let index = FakeIndex::new(); // tracks nothing
 
-        let outcome =
-            pin_root_in_repo(&FsStore, &index, repo, "did:keri:Eroot").expect("pin");
+        let outcome = pin_root_in_repo(&FsStore, &index, repo, "did:keri:Eroot").expect("pin");
 
         assert_eq!(outcome, RootPinOutcome::Staged);
         assert_eq!(
@@ -443,11 +444,13 @@ mod tests {
         add_pinned_root(&FsStore, &auths_dir, "did:keri:Eroot").expect("pre-write");
         let index = FakeIndex::with_tracked(vec![auths_dir.join("roots")]);
 
-        let outcome =
-            pin_root_in_repo(&FsStore, &index, repo, "did:keri:Eroot").expect("pin");
+        let outcome = pin_root_in_repo(&FsStore, &index, repo, "did:keri:Eroot").expect("pin");
 
         assert_eq!(outcome, RootPinOutcome::AlreadyTracked);
-        assert!(index.staged().is_empty(), "nothing to do; must not touch the index");
+        assert!(
+            index.staged().is_empty(),
+            "nothing to do; must not touch the index"
+        );
     }
 
     #[test]

--- a/crates/auths-sdk/src/workflows/roots.rs
+++ b/crates/auths-sdk/src/workflows/roots.rs
@@ -111,6 +111,81 @@ pub fn add_pinned_root(
     store.write(&roots_path(auths_dir), &format!("{}\n", roots.join("\n")))
 }
 
+/// What [`pin_root_in_repo`] did, so the caller can report it accurately.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RootPinOutcome {
+    /// The root was newly pinned and the pin file staged.
+    PinnedAndStaged,
+    /// The root was already pinned but the pin file was untracked; it is now staged.
+    Staged,
+    /// The root was already pinned and the pin file already tracked. Nothing to do.
+    AlreadyTracked,
+}
+
+/// Failure pinning a trusted root into a repository.
+#[derive(Debug, thiserror::Error)]
+pub enum PinRootError {
+    /// The pin file could not be read or written.
+    #[error(transparent)]
+    Store(#[from] ConfigStoreError),
+    /// The pin file could not be staged into the index.
+    #[error(transparent)]
+    Index(#[from] crate::ports::git::IndexError),
+}
+
+/// Pin `did` as a trusted root in `<repo_root>/.auths/roots` **and stage it**, so
+/// the declaration travels with the repository.
+///
+/// The pin is the only trust anchor the delegation model permits: an `Auths-Id`
+/// trailer may *select* among pinned roots, never *establish* one. A pin that is
+/// written but never staged therefore never reaches a cloner, and every
+/// third-party verification path dead-ends on it.
+///
+/// Staging (rather than committing) is deliberate: `auths init` must not author a
+/// commit on the user's behalf. The pin rides along with their next commit, which
+/// is the one they are about to make anyway.
+///
+/// Idempotent: staging an unchanged tracked file is a no-op.
+///
+/// Args:
+/// * `store`: File-access port for the pin file.
+/// * `index`: Repository index port used to stage the pin file.
+/// * `repo_root`: The repository's top level (the directory containing `.auths/`).
+/// * `did`: The root `did:keri:` to pin.
+///
+/// Usage:
+/// ```ignore
+/// match pin_root_in_repo(&store, &index, &repo_root, &root_did)? {
+///     RootPinOutcome::AlreadyTracked => {}
+///     _ => println!("pinned — clones can now verify your commits"),
+/// }
+/// ```
+pub fn pin_root_in_repo(
+    store: &dyn ConfigStore,
+    index: &dyn crate::ports::git::RepoIndex,
+    repo_root: &Path,
+    did: &str,
+) -> Result<RootPinOutcome, PinRootError> {
+    let auths_dir = repo_root.join(".auths");
+    let pin_file = roots_path(&auths_dir);
+
+    let already_pinned = is_pinned_root(store, &auths_dir, did)?;
+    if already_pinned && index.is_tracked(&pin_file) {
+        return Ok(RootPinOutcome::AlreadyTracked);
+    }
+
+    if !already_pinned {
+        add_pinned_root(store, &auths_dir, did)?;
+    }
+    index.stage(&pin_file)?;
+
+    Ok(if already_pinned {
+        RootPinOutcome::Staged
+    } else {
+        RootPinOutcome::PinnedAndStaged
+    })
+}
+
 /// Failure loading the typed pinned-root set: a line that is not a well-formed
 /// `did:keri:` identity DID is rejected (fail-closed) rather than silently skipped.
 #[derive(Debug, thiserror::Error)]
@@ -278,5 +353,113 @@ mod tests {
         // A second distinct root.
         add_pinned_root(&store, dir, "did:keri:Esecond").expect("add second");
         assert_eq!(load_pinned_roots(&store, dir).expect("load").len(), 2);
+    }
+
+    /// Records what was staged, and lets a test declare what git already tracks.
+    struct FakeIndex {
+        staged: std::sync::Mutex<Vec<PathBuf>>,
+        tracked: Vec<PathBuf>,
+    }
+
+    impl FakeIndex {
+        fn new() -> Self {
+            Self {
+                staged: std::sync::Mutex::new(Vec::new()),
+                tracked: Vec::new(),
+            }
+        }
+
+        fn with_tracked(tracked: Vec<PathBuf>) -> Self {
+            Self {
+                staged: std::sync::Mutex::new(Vec::new()),
+                tracked,
+            }
+        }
+
+        fn staged(&self) -> Vec<PathBuf> {
+            self.staged.lock().expect("staged lock").clone()
+        }
+    }
+
+    impl crate::ports::git::RepoIndex for FakeIndex {
+        fn stage(&self, path: &Path) -> Result<(), crate::ports::git::IndexError> {
+            self.staged.lock().expect("staged lock").push(path.to_path_buf());
+            Ok(())
+        }
+
+        fn is_tracked(&self, path: &Path) -> bool {
+            self.tracked.iter().any(|p| p == path)
+        }
+    }
+
+    #[test]
+    fn pin_root_in_repo_writes_and_stages_the_pin() {
+        let tmp = tempfile::TempDir::new().expect("temp dir");
+        let repo = tmp.path();
+        let index = FakeIndex::new();
+
+        let outcome =
+            pin_root_in_repo(&FsStore, &index, repo, "did:keri:Eroot").expect("pin");
+
+        assert_eq!(outcome, RootPinOutcome::PinnedAndStaged);
+        assert!(is_pinned_root(&FsStore, &repo.join(".auths"), "did:keri:Eroot").expect("pinned"));
+        assert_eq!(
+            index.staged(),
+            vec![repo.join(".auths").join("roots")],
+            "the pin must be staged, or it never reaches a cloner"
+        );
+    }
+
+    /// The regression that made third-party verification impossible: `auths init`
+    /// wrote `.auths/roots` but never staged it, and the file's mere existence then
+    /// made the hook's `[ ! -e ]` guard false forever — so nothing ever staged it
+    /// and the pin never travelled. Pinning must stage an already-written pin.
+    #[test]
+    fn pin_root_in_repo_stages_a_previously_written_but_untracked_pin() {
+        let tmp = tempfile::TempDir::new().expect("temp dir");
+        let repo = tmp.path();
+        let auths_dir = repo.join(".auths");
+
+        // Simulate the old init: pin written, never staged.
+        add_pinned_root(&FsStore, &auths_dir, "did:keri:Eroot").expect("pre-write");
+        let index = FakeIndex::new(); // tracks nothing
+
+        let outcome =
+            pin_root_in_repo(&FsStore, &index, repo, "did:keri:Eroot").expect("pin");
+
+        assert_eq!(outcome, RootPinOutcome::Staged);
+        assert_eq!(
+            index.staged(),
+            vec![auths_dir.join("roots")],
+            "an already-written but untracked pin must still be staged"
+        );
+    }
+
+    #[test]
+    fn pin_root_in_repo_is_a_noop_when_already_pinned_and_tracked() {
+        let tmp = tempfile::TempDir::new().expect("temp dir");
+        let repo = tmp.path();
+        let auths_dir = repo.join(".auths");
+        add_pinned_root(&FsStore, &auths_dir, "did:keri:Eroot").expect("pre-write");
+        let index = FakeIndex::with_tracked(vec![auths_dir.join("roots")]);
+
+        let outcome =
+            pin_root_in_repo(&FsStore, &index, repo, "did:keri:Eroot").expect("pin");
+
+        assert_eq!(outcome, RootPinOutcome::AlreadyTracked);
+        assert!(index.staged().is_empty(), "nothing to do; must not touch the index");
+    }
+
+    #[test]
+    fn pin_root_in_repo_appends_a_second_root_without_dropping_the_first() {
+        let tmp = tempfile::TempDir::new().expect("temp dir");
+        let repo = tmp.path();
+        let index = FakeIndex::new();
+
+        pin_root_in_repo(&FsStore, &index, repo, "did:keri:Efirst").expect("first");
+        pin_root_in_repo(&FsStore, &index, repo, "did:keri:Esecond").expect("second");
+
+        let roots = load_pinned_roots(&FsStore, &repo.join(".auths")).expect("load");
+        assert_eq!(roots, vec!["did:keri:Efirst", "did:keri:Esecond"]);
     }
 }


### PR DESCRIPTION
## The problem

Only the signer could verify anything. Established by running the product, not reading it:

```
$ git clone <repo> && auths verify HEAD
Verification failed: KEL not found for did:keri:EKjF-HM6…          exit 1
$ auths verify HEAD --remote origin
Verification failed: Root … is not a pinned trusted root.          exit 1
$ auths verify HEAD --identity-bundle bundle.json
Error: a bundle is evidence for a pinned root, never the source of the pin.  exit 2
```

That third error is *correct* — a bundle that bootstrapped its own trust would be circular. The design was right. Two small bugs and one missing default meant nothing could reach a second person.

**Placing `.auths/roots` by hand made every path return exit 0.** The engine was never the problem.

## Root cause

`init/mod.rs` wrote `<repo>/.auths/roots` and never staged it. That file's mere existence then made the hook's `[ ! -e ]` guard at `commit_hooks.rs:50` false *forever*, so the hook never staged it either. The two mechanisms were written to cooperate (see the comment at `init/mod.rs:426`) and instead cancelled out. The pin stayed untracked, never reached a cloner, and every third-party path dead-ended on it.

Separately, `auths registry push` had zero callers outside its own command — logged in `docs/plans/blockers/fixes.md` as *"4D: nothing pushes the registry"* — so the KEL never reached the remote either. And a plain `git clone` fetches only `refs/heads/*` and `refs/tags/*`, so even once mirrored, `auths verify` never looked.

## The four commits

| Commit | What |
|---|---|
| `47e4a8dc` | New `RepoIndex` port + `roots::pin_root_in_repo` workflow: pin **and stage**. Hook keys off tracked-ness, not existence, and stops claiming the pin is "committed with this commit" (it lands in N+1 — git snapshots the index before `prepare-commit-msg`). Hook → v2. |
| `8d57d020` | Managed `pre-push` hook mirrors `refs/auths/registry` to the code remote. Non-fatal, opt-out via `auths.autopush=false`, and **chains to the repo's own pre-push** — `core.hooksPath` replaces `.git/hooks`, so a non-chaining hook would silently disable husky/pre-commit/prek machine-wide. |
| `dc12ee66` | `auths verify` defaults its KEL transport to the repo's own `origin`. Free in the common case (`KelResolverChain` is local-first; nothing is fetched when the KEL is local) and fires exactly where verification would otherwise fail. |
| `6a8d8f14` | The tests that would have caught this. |

## Result — the acceptance criterion

On a machine with **no `~/.auths`**, having never met the signer:

```
$ git clone <repo> && cd <repo>
$ auths verify HEAD
Commit 200a9c0… verified: signed by did:keri:EO0bMMH4XfQdwD1WYbssMjDi2016rcVVc98G0dQrVDBM
exit 0
```

No flags. No identity. No setup.

## On the tests

Every existing verification test runs *as the signer* with a populated `~/.auths` — which is exactly why a total failure of the core promise shipped with a green suite. The new tests play the second person, and the fixture uses plain `git commit` / `git push` (never `auths sign` / `auths registry push`), since a fixture reaching for the manual verbs would prove nothing about the default path.

**Mutation-checked:** restoring the old write-but-never-stage behaviour fails 3 of the 4.

## Verification

- `cargo test -p auths-cli --test integration` → **67 passed, 0 failed**
- `cargo test -p auths-sdk --lib` → **176 passed, 0 failed**
- `cargo clippy -p auths-sdk -p auths-cli --all-targets` → clean
- `cargo fmt --all` → applied

## Honesty note

Committing `.auths/roots` makes the pin **travel**; it does not make first-clone trust *sound*. A cloner trusting the repo's own pin is doing TOFU-on-the-root, which `roots.rs:6-8` correctly warns is unbounded. What this buys is **continuity** — the same root signed throughout, rotations chained, later substitution detectable. That is what the flight-recorder use case needs, and it should be documented that way rather than sold as authenticity. Flagged for a second opinion.