### PR TITLE
Epic 2: ship the MCP gateway

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,8 +71,15 @@ jobs:
           key: ${{ matrix.target }}
           cache-on-failure: true
 
+      # auths-mcp-gateway ships alongside the CLI: `@auths/mcp`'s launcher shells out
+      # to this binary and its build step defers the binary to "a release-CI step",
+      # which is this one. Without it the published launcher has nothing to run.
       - name: Build release binaries
-        run: cargo build --release --locked --package auths-cli --target ${{ matrix.target }}
+        run: >
+          cargo build --release --locked
+          --package auths-cli
+          --package auths-mcp-gateway
+          --target ${{ matrix.target }}
 
       - name: Package (Unix)
         if: matrix.ext == '.tar.gz'
@@ -81,6 +88,8 @@ jobs:
           cp target/${{ matrix.target }}/release/auths staging/ || true
           cp target/${{ matrix.target }}/release/auths-sign staging/ || true
           cp target/${{ matrix.target }}/release/auths-verify staging/ || true
+          # No `|| true`: a silently absent gateway is how it shipped to nobody.
+          cp target/${{ matrix.target }}/release/auths-mcp-gateway staging/
           tar -czf ${{ matrix.asset_name }}${{ matrix.ext }} -C staging .
 
       - name: Package (Windows)
@@ -91,6 +100,8 @@ jobs:
           Copy-Item target/${{ matrix.target }}/release/auths.exe staging/ -ErrorAction SilentlyContinue
           Copy-Item target/${{ matrix.target }}/release/auths-sign.exe staging/ -ErrorAction SilentlyContinue
           Copy-Item target/${{ matrix.target }}/release/auths-verify.exe staging/ -ErrorAction SilentlyContinue
+          # No SilentlyContinue: a silently absent gateway is how it shipped to nobody.
+          Copy-Item target/${{ matrix.target }}/release/auths-mcp-gateway.exe staging/
           Compress-Archive -Path staging/* -DestinationPath ${{ matrix.asset_name }}${{ matrix.ext }}
 
       - name: Generate SHA256 checksum (Unix)

--- a/.github/workflows/test-windows-build.yml
+++ b/.github/workflows/test-windows-build.yml
@@ -22,14 +22,23 @@ jobs:
         with:
           key: x86_64-pc-windows-msvc
 
-      - name: Build CLI
-        run: cargo build --release --package auths-cli --target x86_64-pc-windows-msvc
+      # Mirrors the release workflow's package set exactly. It previously built only
+      # auths-cli, so auths-mcp-gateway had never been compiled for Windows — a gap
+      # that would have surfaced as a broken Windows release rather than a red CI run.
+      - name: Build CLI + MCP gateway
+        run: >
+          cargo build --release
+          --package auths-cli
+          --package auths-mcp-gateway
+          --target x86_64-pc-windows-msvc
 
-      - name: Verify binary
+      - name: Verify binaries
         run: |
           dir target\x86_64-pc-windows-msvc\release\auths.exe
           target\x86_64-pc-windows-msvc\release\auths.exe --version
           target\x86_64-pc-windows-msvc\release\auths.exe --help
+          dir target\x86_64-pc-windows-msvc\release\auths-mcp-gateway.exe
+          target\x86_64-pc-windows-msvc\release\auths-mcp-gateway.exe --help
 
       - name: Package
         run: |
@@ -37,6 +46,7 @@ jobs:
           Copy-Item target/x86_64-pc-windows-msvc/release/auths.exe staging/
           Copy-Item target/x86_64-pc-windows-msvc/release/auths-sign.exe staging/ -ErrorAction SilentlyContinue
           Copy-Item target/x86_64-pc-windows-msvc/release/auths-verify.exe staging/ -ErrorAction SilentlyContinue
+          Copy-Item target/x86_64-pc-windows-msvc/release/auths-mcp-gateway.exe staging/
           Compress-Archive -Path staging/* -DestinationPath auths-windows-x86_64.zip
 
       - uses: actions/upload-artifact@v4


### PR DESCRIPTION
## The one line

`release.yml:75` built `--package auths-cli` only. Eight of the repo's nine binaries reached no user — including `auths-mcp-gateway`, a real rmcp MCP proxy that gates every `tools/call` (scope ⊆ parent · budget · expiry · revocation) and emits a signed receipt either way.

## This is not unfinished work

The sibling **`auths-mcp`** repo already publishes the launcher that runs it — `@auths/mcp`, with `bin/auths-mcp.mjs` written. Its `build.mjs` says verbatim:

> *"the actual enforcement lives in the gateway binary the … prebuilt-binary-per-platform vendor tree"* … *"vendor bundling is a release-CI step"*

**That release-CI step did not exist.** A finished product in a sibling repo has been blocked on one line here. `agent-treasury` and 11 `.recurve/claims/auths-mcp/probes/*` consume it too.

## The Windows gap this found

`test-windows-build.yml` built **only** `auths-cli`, so `auths-mcp-gateway` **had never been compiled for Windows**. Adding it straight to `release.yml` would have surfaced as a broken Windows release rather than a red CI run.

So this PR also makes `test-windows-build.yml` mirror the release package set and smoke-run `auths-mcp-gateway.exe --help`. I dispatched it against this branch rather than assume — result is in the checks.

## Deliberate detail

The gateway is copied **without** `|| true` / `-ErrorAction SilentlyContinue`, unlike its neighbours. A silently absent binary is precisely how this one shipped to nobody; if it isn't there, the release should fail loudly.

## Verification

- `cargo build --release --locked -p auths-cli -p auths-mcp-gateway` → all four binaries, gateway runs
- Windows build dispatched on this branch (`test-windows-build.yml`)

## Correction to the roadmap this came from

My roadmap proposed a Task 2.2 to *build* the npx wrapper. That was wrong — it already exists in `auths-mcp`. I'd audited reachability with this repo as the boundary while the architecture spans ~38 sibling repos linked by relative path. Task 2.2 is dropped; the roadmap doc is corrected in place.