### PR TITLE
Epic 4: stop claiming things that aren't true

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,12 +92,19 @@ Want the whole loop in one shot? `auths demo` signs and verifies a sample artifa
 
 Auths stores your identity and device attestations in a Git repository (`~/.auths` by default). Each device link is a cryptographically signed attestation stored as a Git ref.
 
-- **Identity**: A `did:keri` derived from your Ed25519 key
+- **Identity**: A `did:keri` derived from your P-256 key (Ed25519 is also supported; P-256 is the default because it is what the iOS Secure Enclave can hold)
 - **Devices**: `did:key` identifiers linked via signed attestations
 - **Keys**: Stored in your OS keychain (macOS Keychain, or encrypted file fallback)
 - **Attestations**: Stored in Git refs under `refs/auths/`
+- **Trust**: Your repo commits `.auths/roots` — the trusted root a clone anchors to — and your KEL travels to that repo's remote alongside your code, so `git clone && auths verify HEAD` works with no setup
 
 No central server. No blockchain. Just Git and cryptography.
+
+### What "verify" actually checks
+
+Auths signs commits with a standard SSH signature (`ecdsa-sha2-nistp256`), so `auths verify` replays the signer's key history — their KEL — and checks the signature against the key that was valid **at signing time**, then confirms that key chains back to a root the repository pins.
+
+Sigstore and GitHub can verify offline too. The difference is narrower than "offline vs online" and worth stating precisely: their offline path checks a signature against a **trust-root snapshot** you refreshed at some point, so a key rotation or revocation you have not downloaded is one you cannot see. A KEL carries its own rotation history, so key state verifies without refreshing a trust root. That matters most for **long-lived device keys**, which is Auths's model.
 
 ---
 

--- a/crates/auths-cli/src/adapters/system_diagnostic.rs
+++ b/crates/auths-cli/src/adapters/system_diagnostic.rs
@@ -27,8 +27,14 @@ impl GitDiagnosticProvider for PosixDiagnosticAdapter {
         })
     }
 
+    /// Read the **effective** value of a git config key, not the global one.
+    ///
+    /// `auths init` scopes signing config to the repo by default — a scripted init
+    /// must not rewrite the user's `~/.gitconfig` — so reading `--global` would
+    /// report a correctly configured repo as broken. The effective value is also
+    /// what git itself will use, which is the thing a diagnostic should check.
     fn get_git_config(&self, key: &str) -> Result<Option<String>, DiagnosticError> {
-        let output = crate::subprocess::git_command(&["config", "--global", "--get", key])
+        let output = crate::subprocess::git_command(&["config", "--get", key])
             .output()
             .map_err(|e| DiagnosticError::ExecutionFailed(e.to_string()))?;
 

--- a/crates/auths-cli/src/commands/account.rs
+++ b/crates/auths-cli/src/commands/account.rs
@@ -17,14 +17,14 @@ pub enum AccountSubcommand {
     /// Show account status and rate limits
     Status {
         /// Registry URL to query
-        #[arg(long, default_value = "https://registry.auths.dev")]
-        registry_url: String,
+        #[arg(long, env = "AUTHS_REGISTRY_URL")]
+        registry_url: Option<String>,
     },
     /// Show API usage history
     Usage {
         /// Registry URL to query
-        #[arg(long, default_value = "https://registry.auths.dev")]
-        registry_url: String,
+        #[arg(long, env = "AUTHS_REGISTRY_URL")]
+        registry_url: Option<String>,
         /// Number of days to show
         #[arg(long, default_value = "7")]
         days: u32,
@@ -112,8 +112,13 @@ fn handle_usage(registry_url: &str, days: u32) -> Result<()> {
 impl ExecutableCommand for AccountCommand {
     fn execute(&self, _ctx: &CliConfig) -> Result<()> {
         match &self.subcommand {
-            AccountSubcommand::Status { registry_url } => handle_status(registry_url),
-            AccountSubcommand::Usage { registry_url, days } => handle_usage(registry_url, *days),
+            AccountSubcommand::Status { registry_url } => handle_status(
+                &crate::commands::verify_helpers::require_registry(registry_url.clone())?,
+            ),
+            AccountSubcommand::Usage { registry_url, days } => handle_usage(
+                &crate::commands::verify_helpers::require_registry(registry_url.clone())?,
+                *days,
+            ),
         }
     }
 }

--- a/crates/auths-cli/src/commands/artifact/mod.rs
+++ b/crates/auths-cli/src/commands/artifact/mod.rs
@@ -12,7 +12,6 @@ use std::sync::Arc;
 use anyhow::{Context, Result, bail};
 use auths_sdk::core_config::EnvironmentConfig;
 use auths_sdk::domains::signing::service::EphemeralSignRequest;
-use auths_sdk::registration::DEFAULT_REGISTRY_URL;
 use auths_sdk::signing::PassphraseProvider;
 use auths_sdk::signing::validate_commit_sha;
 
@@ -158,8 +157,8 @@ pub enum ArtifactSubcommand {
         package: Option<String>,
 
         /// Registry URL to publish to.
-        #[arg(long, env = "AUTHS_REGISTRY_URL", default_value = DEFAULT_REGISTRY_URL)]
-        registry: String,
+        #[arg(long, env = "AUTHS_REGISTRY_URL")]
+        registry: Option<String>,
 
         /// Local alias of the identity key. Omit for device-only CI signing.
         #[arg(long)]
@@ -656,7 +655,11 @@ pub fn handle_artifact(
                     "Provide an artifact file to sign-and-publish, or --signature for an existing signature"
                 ),
             };
-            publish::handle_publish(&sig_path, package.as_deref(), &registry)
+            publish::handle_publish(
+                &sig_path,
+                package.as_deref(),
+                &crate::commands::verify_helpers::require_registry(registry.clone())?,
+            )
         }
         ArtifactSubcommand::Verify {
             file,

--- a/crates/auths-cli/src/commands/doctor.rs
+++ b/crates/auths-cli/src/commands/doctor.rs
@@ -202,16 +202,20 @@ fn check_commit_hook_installed() -> Check {
         }
         Ok(home) => {
             let hook_current = auths_sdk::workflows::commit_hooks::hook_is_current(&home);
-            let hooks_path_set =
-                crate::subprocess::git_command(&["config", "--global", "core.hooksPath"])
-                    .output()
-                    .ok()
-                    .filter(|o| o.status.success())
-                    .map(|o| {
-                        String::from_utf8_lossy(&o.stdout).trim()
-                            == home.join("githooks").to_string_lossy()
-                    })
-                    .unwrap_or(false);
+            // Resolve the *effective* core.hooksPath rather than the global one:
+            // `auths init` scopes signing config to the repo by default (a scripted
+            // init must not rewrite ~/.gitconfig), so a working local setup would
+            // otherwise be reported as broken. This is also the value git itself
+            // will use, which is the thing worth checking.
+            let hooks_path_set = crate::subprocess::git_command(&["config", "core.hooksPath"])
+                .output()
+                .ok()
+                .filter(|o| o.status.success())
+                .map(|o| {
+                    String::from_utf8_lossy(&o.stdout).trim()
+                        == home.join("githooks").to_string_lossy()
+                })
+                .unwrap_or(false);
             match (hook_current, hooks_path_set) {
                 (true, true) => (true, "prepare-commit-msg hook installed".to_string()),
                 (false, _) => (false, "hook file missing or stale".to_string()),

--- a/crates/auths-cli/src/commands/doctor.rs
+++ b/crates/auths-cli/src/commands/doctor.rs
@@ -612,23 +612,34 @@ fn check_attestation_expiry(now: DateTime<Utc>) -> ExpiryStatus {
     ExpiryStatus::Ok
 }
 
+/// Report on the configured registry, if there is one.
+///
+/// There is no default registry, so with none configured this passes with
+/// "not configured" rather than failing: a registry is optional, and auths is
+/// fully functional — identity, signing, verification — without one. Previously
+/// this probed a baked-in default that returned 404, so every `auths doctor` run
+/// reported a failing check for a service the user neither had nor needed.
 fn check_registry_connectivity() -> Check {
-    use auths_sdk::registration::DEFAULT_REGISTRY_URL;
+    let Ok(base) = std::env::var("AUTHS_REGISTRY_URL") else {
+        return Check {
+            name: "Registry connectivity".to_string(),
+            passed: true,
+            detail: "not configured (optional — signing and verification need no registry)"
+                .to_string(),
+            suggestion: None,
+            category: CheckCategory::Advisory,
+        };
+    };
 
-    let url = format!("{DEFAULT_REGISTRY_URL}/health");
+    let url = format!("{base}/health");
     let client = reqwest::blocking::Client::builder()
         .timeout(std::time::Duration::from_secs(5))
         .build();
 
     let (passed, detail) = match client {
         Ok(client) => match client.get(&url).send() {
-            Ok(resp) if resp.status().is_success() => {
-                (true, format!("{DEFAULT_REGISTRY_URL} (reachable)"))
-            }
-            Ok(resp) => (
-                false,
-                format!("{DEFAULT_REGISTRY_URL} (HTTP {})", resp.status()),
-            ),
+            Ok(resp) if resp.status().is_success() => (true, format!("{base} (reachable)")),
+            Ok(resp) => (false, format!("{base} (HTTP {})", resp.status())),
             Err(e) => (false, format!("unreachable: {e}")),
         },
         Err(e) => (false, format!("HTTP client error: {e}")),

--- a/crates/auths-cli/src/commands/id/claim.rs
+++ b/crates/auths-cli/src/commands/id/claim.rs
@@ -17,8 +17,6 @@ use console::style;
 use crate::factories::storage::build_auths_context;
 use crate::ux::format::{JsonResponse, is_json_mode};
 
-use super::register::DEFAULT_REGISTRY_URL;
-
 const DEFAULT_GITHUB_CLIENT_ID: &str = "Ov23lio2CiTHBjM2uIL4";
 
 #[allow(clippy::disallowed_methods)]
@@ -38,20 +36,20 @@ pub enum ClaimPlatform {
     /// Link your GitHub account to your identity via OAuth device flow.
     Github {
         /// Registry URL to publish the claim to.
-        #[arg(long, env = "AUTHS_REGISTRY_URL", default_value = DEFAULT_REGISTRY_URL)]
-        registry: String,
+        #[arg(long, env = "AUTHS_REGISTRY_URL")]
+        registry: Option<String>,
     },
     /// Link your npm account to your identity via access token.
     Npm {
         /// Registry URL to publish the claim to.
-        #[arg(long, env = "AUTHS_REGISTRY_URL", default_value = DEFAULT_REGISTRY_URL)]
-        registry: String,
+        #[arg(long, env = "AUTHS_REGISTRY_URL")]
+        registry: Option<String>,
     },
     /// Link your PyPI account to your identity via API token.
     Pypi {
         /// Registry URL to publish the claim to.
-        #[arg(long, env = "AUTHS_REGISTRY_URL", default_value = DEFAULT_REGISTRY_URL)]
-        registry: String,
+        #[arg(long, env = "AUTHS_REGISTRY_URL")]
+        registry: Option<String>,
     },
 }
 
@@ -78,6 +76,7 @@ pub fn handle_claim(
             let oauth = HttpGitHubOAuthProvider::new();
             let publisher = HttpGistPublisher::new();
 
+            let registry_url = crate::commands::verify_helpers::require_registry(registry_url)?;
             let config = GitHubClaimConfig {
                 client_id: github_client_id(),
                 registry_url,
@@ -154,7 +153,9 @@ pub fn handle_claim(
                 style(&profile.login).bold()
             );
 
-            let config = NpmClaimConfig { registry_url };
+            let config = NpmClaimConfig {
+                registry_url: crate::commands::verify_helpers::require_registry(registry_url)?,
+            };
 
             let response = rt
                 .block_on(claim_npm_identity(
@@ -203,7 +204,9 @@ pub fn handle_claim(
 
             println!("  Claiming PyPI identity as {}...", style(trimmed).bold());
 
-            let config = PypiClaimConfig { registry_url };
+            let config = PypiClaimConfig {
+                registry_url: crate::commands::verify_helpers::require_registry(registry_url)?,
+            };
 
             let rt = tokio::runtime::Runtime::new().context("failed to create async runtime")?;
             let response = rt

--- a/crates/auths-cli/src/commands/id/identity.rs
+++ b/crates/auths-cli/src/commands/id/identity.rs
@@ -14,7 +14,6 @@ use auths_sdk::{
 use auths_verifier::{IdentityBundle, IdentityDID};
 use clap::ValueEnum;
 
-use super::register::DEFAULT_REGISTRY_URL;
 use crate::commands::registry_overrides::RegistryOverrides;
 use crate::ux::format::{JsonResponse, is_json_mode};
 
@@ -265,8 +264,8 @@ pub enum IdSubcommand {
     /// Publish this identity to a public registry for discovery.
     Register {
         /// Registry URL to publish to.
-        #[arg(long, env = "AUTHS_REGISTRY_URL", default_value = DEFAULT_REGISTRY_URL)]
-        registry: String,
+        #[arg(long, env = "AUTHS_REGISTRY_URL")]
+        registry: Option<String>,
     },
 
     /// Add a platform claim to an already-registered identity.
@@ -934,9 +933,10 @@ pub fn handle_id(
             Ok(())
         }
 
-        IdSubcommand::Register { registry } => {
-            super::register::handle_register(&repo_path, &registry)
-        }
+        IdSubcommand::Register { registry } => super::register::handle_register(
+            &repo_path,
+            &crate::commands::verify_helpers::require_registry(registry.clone())?,
+        ),
 
         IdSubcommand::Claim(claim_cmd) => {
             super::claim::handle_claim(&claim_cmd, &repo_path, passphrase_provider, env_config, now)

--- a/crates/auths-cli/src/commands/id/mod.rs
+++ b/crates/auths-cli/src/commands/id/mod.rs
@@ -8,7 +8,6 @@ pub mod register;
 pub use agent::{AgentCommand, handle_agent};
 pub use identity::{IdCommand, IdSubcommand, LayoutPreset, handle_id};
 pub use migrate::{MigrateCommand, handle_migrate};
-pub use register::DEFAULT_REGISTRY_URL;
 
 use crate::commands::executable::ExecutableCommand;
 use crate::config::CliConfig;

--- a/crates/auths-cli/src/commands/id/register.rs
+++ b/crates/auths-cli/src/commands/id/register.rs
@@ -7,7 +7,6 @@ use serde::Serialize;
 
 use auths_infra_http::HttpRegistryClient;
 use auths_sdk::domains::identity::error::RegistrationError;
-pub use auths_sdk::domains::identity::registration::DEFAULT_REGISTRY_URL;
 use auths_sdk::domains::identity::types::RegistrationOutcome;
 use auths_sdk::ports::AttestationSource;
 use auths_sdk::ports::IdentityStorage;

--- a/crates/auths-cli/src/commands/init/gather.rs
+++ b/crates/auths-cli/src/commands/init/gather.rs
@@ -37,14 +37,16 @@ pub(crate) fn gather_developer_config(
 
     let alias = prompt_for_alias(interactive, cmd)?;
     let conflict_policy = prompt_for_conflict_policy(interactive, cmd, registry_path, out)?;
-    let git_scope = prompt_for_git_scope(interactive)?;
+    let git_scope = prompt_for_git_scope(interactive, cmd.git_scope)?;
 
     let mut builder = CreateDeveloperIdentityConfig::builder(KeyAlias::new_unchecked(&alias))
         .with_conflict_policy(conflict_policy)
         .with_git_signing_scope(git_scope);
 
     if cmd.register {
-        builder = builder.with_registration(&cmd.registry);
+        // --register is opt-in and there is no default registry, so it must name one.
+        let registry = crate::commands::verify_helpers::require_registry(cmd.registry.clone())?;
+        builder = builder.with_registration(&registry);
     }
 
     Ok((keychain, builder.build()))
@@ -151,7 +153,7 @@ pub(crate) fn gather_agent_config(
 
 pub(crate) fn submit_registration(
     repo_path: &Path,
-    registry_url: &str,
+    registry_url: Option<&str>,
     proof_url: Option<String>,
     skip: bool,
     out: &Output,
@@ -160,6 +162,12 @@ pub(crate) fn submit_registration(
         out.print_info("Registration skipped (pass --register to publish to the registry)");
         return None;
     }
+    // There is no default registry, and `gather` already refuses --register
+    // without one — so reaching here without a URL is unreachable, not fatal.
+    let Some(registry_url) = registry_url else {
+        out.print_warn("Registration skipped: no registry configured (--registry <url>)");
+        return None;
+    };
 
     out.print_info("Publishing identity to Auths Registry...");
     let rt = match tokio::runtime::Runtime::new() {

--- a/crates/auths-cli/src/commands/init/helpers.rs
+++ b/crates/auths-cli/src/commands/init/helpers.rs
@@ -10,6 +10,62 @@ use std::process::Command;
 use auths_sdk::workflows::diagnostics::{MIN_GIT_VERSION, parse_git_version};
 
 use crate::subprocess::git_command;
+
+/// The host of a git remote URL, for both URL (`https://host/o/r`) and scp-like
+/// (`git@host:o/r`) forms. `None` when no host can be read.
+fn remote_host(url: &str) -> Option<&str> {
+    let rest = url.split_once("://").map_or(url, |(_, r)| r);
+    // The authority ends at the first '/'; for scp-like forms the ':' inside it
+    // terminates the host instead.
+    let authority = &rest[..rest.find('/').unwrap_or(rest.len())];
+    let host = authority.rsplit_once('@').map_or(authority, |(_, h)| h);
+    let host = host.split(':').next().unwrap_or(host);
+    (!host.is_empty()).then_some(host)
+}
+
+/// Whether a git remote URL points at GitHub.
+///
+/// Matches on the parsed host, never a substring: `github.com.evil.example` is a
+/// different host that a `contains("github.com")` check would happily accept.
+///
+/// Args:
+/// * `url`: A git remote URL in URL or scp-like form.
+///
+/// Usage:
+/// ```ignore
+/// assert!(url_is_github("git@github.com:auths-dev/auths.git"));
+/// ```
+fn url_is_github(url: &str) -> bool {
+    remote_host(url).is_some_and(|host| {
+        host.eq_ignore_ascii_case("github.com")
+            || host.to_ascii_lowercase().ends_with(".github.com")
+    })
+}
+
+/// Whether the current repository has a GitHub remote.
+///
+/// Used to decide whether `auths init` offers to link GitHub by default — linking
+/// is what uploads the SSH signing key, and that is the only thing that makes a
+/// user's commits render as Verified to everyone else. Offering it where it cannot
+/// apply would be noise; withholding it where it can is the status quo that leaves
+/// commits Unverified.
+///
+/// Usage:
+/// ```ignore
+/// let offer = interactive && git_remote_is_github();
+/// ```
+pub(crate) fn git_remote_is_github() -> bool {
+    let Ok(output) = git_command(&["remote", "-v"]).output() else {
+        return false;
+    };
+    if !output.status.success() {
+        return false;
+    }
+    String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .filter_map(|line| line.split_whitespace().nth(1))
+        .any(url_is_github)
+}
 use crate::ux::format::Output;
 
 pub(crate) fn get_auths_repo_path() -> Result<PathBuf> {
@@ -585,5 +641,59 @@ mod tests {
         let hint = shell_reload_hint(Shell::Bash, path);
         assert!(hint.contains("source"));
         assert!(hint.contains("/tmp/completions/auths"));
+    }
+
+    #[test]
+    fn github_remotes_are_recognised_across_url_forms() {
+        for url in [
+            "git@github.com:auths-dev/auths.git",
+            "https://github.com/auths-dev/auths.git",
+            "ssh://git@github.com/auths-dev/auths",
+            "https://user@github.com/o/r.git",
+        ] {
+            assert!(url_is_github(url), "expected GitHub: {url}");
+        }
+    }
+
+    /// A scripted init must not rewrite the user's `~/.gitconfig`. It used to
+    /// default to `Global` with no flag to scope it, which also repointed
+    /// `core.hooksPath` machine-wide and disabled every repo's own hooks.
+    #[test]
+    fn non_interactive_init_defaults_to_local_git_scope() {
+        use auths_sdk::types::GitSigningScope;
+
+        use super::super::GitScopeArg;
+        use super::super::prompts::prompt_for_git_scope;
+
+        let scope = prompt_for_git_scope(false, None).expect("non-interactive scope");
+        assert!(
+            matches!(scope, GitSigningScope::Local { .. }),
+            "a scripted init must not touch global git config, got {scope:?}"
+        );
+
+        // …and an explicit request is still honoured in both directions.
+        assert!(matches!(
+            prompt_for_git_scope(false, Some(GitScopeArg::Global)).expect("global"),
+            GitSigningScope::Global
+        ));
+        assert!(matches!(
+            prompt_for_git_scope(false, Some(GitScopeArg::Skip)).expect("skip"),
+            GitSigningScope::Skip
+        ));
+    }
+
+    #[test]
+    fn non_github_remotes_are_not_recognised() {
+        for url in [
+            "git@gitlab.com:o/r.git",
+            "https://bitbucket.org/o/r.git",
+            "https://git.example.com/o/r.git",
+            "",
+            // Must not match a host that merely *contains* the string.
+            "https://github.com.evil.example/o/r.git",
+            "https://notgithub.com/o/r.git",
+        ] {
+            assert!(!url_is_github(url), "expected non-GitHub: {url}");
+        }
     }
 }

--- a/crates/auths-cli/src/commands/init/helpers.rs
+++ b/crates/auths-cli/src/commands/init/helpers.rs
@@ -42,6 +42,23 @@ fn url_is_github(url: &str) -> bool {
     })
 }
 
+/// Whether the working directory is inside a git repository.
+///
+/// Decides whether a non-interactive `auths init` can scope signing config to
+/// "this repo": `git config --local` outside a repository is an error, and
+/// `auths init` from a home directory is an ordinary first run.
+///
+/// Usage:
+/// ```ignore
+/// let scope = if in_git_repository() { Local } else { Global };
+/// ```
+pub(crate) fn in_git_repository() -> bool {
+    git_command(&["rev-parse", "--is-inside-work-tree"])
+        .output()
+        .map(|o| o.status.success() && String::from_utf8_lossy(&o.stdout).trim() == "true")
+        .unwrap_or(false)
+}
+
 /// Whether the current repository has a GitHub remote.
 ///
 /// Used to decide whether `auths init` offers to link GitHub by default — linking
@@ -655,23 +672,17 @@ mod tests {
         }
     }
 
-    /// A scripted init must not rewrite the user's `~/.gitconfig`. It used to
-    /// default to `Global` with no flag to scope it, which also repointed
-    /// `core.hooksPath` machine-wide and disabled every repo's own hooks.
+    /// An explicit `--git-scope` decides outright, in every direction. The
+    /// CWD-dependent default (local inside a repo, global outside) is covered by
+    /// the integration suite, which can control the working directory; asserting
+    /// it here would make the result depend on where cargo happened to run.
     #[test]
-    fn non_interactive_init_defaults_to_local_git_scope() {
+    fn explicit_git_scope_is_honoured_in_every_direction() {
         use auths_sdk::types::GitSigningScope;
 
         use super::super::GitScopeArg;
         use super::super::prompts::prompt_for_git_scope;
 
-        let scope = prompt_for_git_scope(false, None).expect("non-interactive scope");
-        assert!(
-            matches!(scope, GitSigningScope::Local { .. }),
-            "a scripted init must not touch global git config, got {scope:?}"
-        );
-
-        // …and an explicit request is still honoured in both directions.
         assert!(matches!(
             prompt_for_git_scope(false, Some(GitScopeArg::Global)).expect("global"),
             GitSigningScope::Global
@@ -679,6 +690,10 @@ mod tests {
         assert!(matches!(
             prompt_for_git_scope(false, Some(GitScopeArg::Skip)).expect("skip"),
             GitSigningScope::Skip
+        ));
+        assert!(matches!(
+            prompt_for_git_scope(false, Some(GitScopeArg::Local)).expect("local"),
+            GitSigningScope::Local { .. }
         ));
     }
 

--- a/crates/auths-cli/src/commands/init/mod.rs
+++ b/crates/auths-cli/src/commands/init/mod.rs
@@ -15,7 +15,6 @@ use std::io::IsTerminal;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-use auths_sdk::domains::identity::registration::DEFAULT_REGISTRY_URL;
 use auths_sdk::domains::identity::service::initialize;
 use auths_sdk::domains::identity::types::IdentityConfig;
 use auths_sdk::domains::identity::types::InitializeResult;
@@ -39,7 +38,7 @@ use gather::{
     submit_registration,
 };
 use guided::GuidedSetup;
-use helpers::offer_shell_completions;
+use helpers::{git_remote_is_github, offer_shell_completions};
 use prompts::{prompt_platform_verification, prompt_profile};
 
 const DEFAULT_KEY_ALIAS: &str = "main";
@@ -53,6 +52,31 @@ pub enum InitProfile {
     Ci,
     /// Restricted signing identity for AI agents
     Agent,
+}
+
+/// Where `auths init` writes git signing configuration.
+#[derive(Debug, Clone, Copy, ValueEnum)]
+pub enum GitScopeArg {
+    /// This repository only (`git config --local`).
+    Local,
+    /// Every repository on this machine (`git config --global`).
+    Global,
+    /// Do not touch git configuration at all.
+    Skip,
+}
+
+impl GitScopeArg {
+    /// Resolve to the SDK scope, reading the working directory for `Local`.
+    pub(crate) fn resolve(self) -> Result<GitSigningScope> {
+        Ok(match self {
+            Self::Local => GitSigningScope::Local {
+                repo_path: std::env::current_dir()
+                    .map_err(|e| anyhow!("Failed to determine current working directory: {e}"))?,
+            },
+            Self::Global => GitSigningScope::Global,
+            Self::Skip => GitSigningScope::Skip,
+        })
+    }
 }
 
 impl std::fmt::Display for InitProfile {
@@ -125,13 +149,35 @@ pub struct InitCommand {
     #[clap(long)]
     pub dry_run: bool,
 
-    /// Registry URL for identity registration
-    #[clap(long, env = "AUTHS_REGISTRY_URL", default_value = DEFAULT_REGISTRY_URL)]
-    pub registry: String,
+    /// Registry URL for identity registration. No default: auths needs no
+    /// registry, and registration is opt-in via `--register`.
+    #[clap(long, env = "AUTHS_REGISTRY_URL")]
+    pub registry: Option<String>,
 
     /// Register identity with the Auths Registry after creation
     #[clap(long)]
     pub register: bool,
+
+    /// Link your GitHub account and upload your SSH signing key, so your commits
+    /// show as Verified on github.com.
+    ///
+    /// Defaults to on when this repo has a GitHub remote and there is a TTY to
+    /// confirm at. Unrelated to `--register`, which publishes to the Auths
+    /// Registry.
+    #[clap(long)]
+    pub github: bool,
+
+    /// Skip linking GitHub, even when this repo has a GitHub remote.
+    #[clap(long = "no-github", conflicts_with = "github")]
+    pub no_github: bool,
+
+    /// Where to write git signing config: local (this repo), global (every repo
+    /// on this machine), or skip.
+    ///
+    /// Interactive runs ask. Non-interactive runs default to `local` — a scripted
+    /// or CI init should not silently rewrite your `~/.gitconfig`.
+    #[clap(long, value_enum)]
+    pub git_scope: Option<GitScopeArg>,
 
     /// Scaffold a GitHub Actions workflow using the auths attest-action
     #[clap(long)]
@@ -364,8 +410,29 @@ fn run_developer_setup(
     ));
 
     // PLATFORM VERIFICATION
+    //
+    // Linking GitHub is what uploads the SSH signing key, and that is the only
+    // thing that makes a user's commits render as "Verified" to everyone else.
+    // It was previously gated behind `--register` — a flag whose documented job is
+    // publishing to the Auths Registry, an unrelated (and dead) host. So the
+    // default first run left commits Unverified on github.com while the code to
+    // fix that sat one boolean away.
+    //
+    // Research puts a number on the cost: 73.73% of commit-signature verification
+    // failures in the wild are `unknown_key` — developers sign and never register
+    // the key ("a usability problem, not a cryptographic one", arXiv:2604.14014).
+    // Auths mints the key, signs with it, and can upload it; withholding that by
+    // default forfeits the product's clearest advantage over gitsign, whose certs
+    // GitHub structurally cannot verify.
+    let link_github = if cmd.no_github {
+        false
+    } else if cmd.github {
+        true
+    } else {
+        interactive && git_remote_is_github()
+    };
     guide.section("Platform Verification");
-    let proof_url = if interactive && cmd.register {
+    let proof_url = if link_github {
         out.print_info("Link your GitHub account");
         out.newline();
         match prompt_platform_verification(
@@ -458,7 +525,7 @@ fn run_developer_setup(
     guide.section("Registration & Summary");
     let registered = submit_registration(
         &registry_path,
-        &cmd.registry,
+        cmd.registry.as_deref(),
         proof_url,
         !cmd.register, // skip unless --register is explicitly passed
         out,
@@ -666,8 +733,11 @@ mod tests {
             force: false,
             confirm_replace: false,
             dry_run: false,
-            registry: DEFAULT_REGISTRY_URL.to_string(),
+            registry: None,
             register: false,
+            github: false,
+            no_github: false,
+            git_scope: None,
             github_action: false,
             device_count: 1,
             signing_threshold: None,
@@ -679,7 +749,9 @@ mod tests {
         assert_eq!(cmd.key_alias, "main");
         assert!(!cmd.force);
         assert!(!cmd.dry_run);
-        assert_eq!(cmd.registry, "https://registry.auths.dev");
+        // No default: auths needs no registry, and the one that used to be baked
+        // in returned 404. Registration is opt-in and must name its registry.
+        assert_eq!(cmd.registry, None);
         assert!(!cmd.register);
         assert!(!cmd.github_action);
     }
@@ -694,8 +766,11 @@ mod tests {
             force: true,
             confirm_replace: false,
             dry_run: false,
-            registry: DEFAULT_REGISTRY_URL.to_string(),
+            registry: None,
             register: false,
+            github: false,
+            no_github: false,
+            git_scope: None,
             github_action: false,
             device_count: 1,
             signing_threshold: None,
@@ -730,8 +805,11 @@ mod tests {
             force: false,
             confirm_replace: false,
             dry_run: false,
-            registry: DEFAULT_REGISTRY_URL.to_string(),
+            registry: None,
             register: false,
+            github: false,
+            no_github: false,
+            git_scope: None,
             github_action: false,
             device_count: 1,
             signing_threshold: None,
@@ -750,8 +828,11 @@ mod tests {
             force: false,
             confirm_replace: false,
             dry_run: false,
-            registry: DEFAULT_REGISTRY_URL.to_string(),
+            registry: None,
             register: false,
+            github: false,
+            no_github: false,
+            git_scope: None,
             github_action: false,
             device_count: 1,
             signing_threshold: None,

--- a/crates/auths-cli/src/commands/init/prompts.rs
+++ b/crates/auths-cli/src/commands/init/prompts.rs
@@ -13,6 +13,7 @@ use auths_sdk::storage::RegistryIdentityStorage;
 use auths_sdk::types::{GitSigningScope, IdentityConflictPolicy};
 
 use super::GitScopeArg;
+use super::helpers::in_git_repository;
 
 use super::InitCommand;
 use super::InitProfile;
@@ -117,12 +118,19 @@ pub(crate) fn prompt_for_conflict_policy(
 
 /// Resolve the git-signing scope from an explicit `--git-scope`, else by asking.
 ///
-/// Non-interactive runs default to **local**. They used to default to `Global`
-/// with no way to override, so `auths init --non-interactive` — the scripted,
-/// CI and agent path — silently rewrote the user's `~/.gitconfig` and repointed
-/// `core.hooksPath` machine-wide, disabling every repo's own `.git/hooks`
-/// (husky, pre-commit, prek) in the process. Scoping to the repo you are standing
-/// in is the conservative default; `--git-scope global` opts back in.
+/// Non-interactive runs default to **local when standing in a git repository**,
+/// and global otherwise. They used to default to `Global` unconditionally with no
+/// way to override, so `auths init --non-interactive` — the scripted, CI and agent
+/// path — silently rewrote the user's `~/.gitconfig` and repointed
+/// `core.hooksPath` machine-wide, disabling every repo's own `.git/hooks` (husky,
+/// pre-commit, prek) in the process.
+///
+/// The repo test is what makes the conservative default safe rather than merely
+/// strict: `git config --local` outside a repository is an error, and running
+/// `auths init` from your home directory is an ordinary first run. There, global
+/// is the only scope that means anything — and a user who is not standing in a
+/// repository is not being surprised by machine-wide config. `--git-scope` decides
+/// it outright either way.
 ///
 /// Args:
 /// * `interactive`: Whether there is a TTY to prompt at.
@@ -140,7 +148,11 @@ pub(crate) fn prompt_for_git_scope(
         return scope.resolve();
     }
     if !interactive {
-        return GitScopeArg::Local.resolve();
+        return if in_git_repository() {
+            GitScopeArg::Local.resolve()
+        } else {
+            GitScopeArg::Global.resolve()
+        };
     }
 
     let choice = Select::new()

--- a/crates/auths-cli/src/commands/init/prompts.rs
+++ b/crates/auths-cli/src/commands/init/prompts.rs
@@ -12,6 +12,8 @@ use auths_sdk::signing::PassphraseProvider;
 use auths_sdk::storage::RegistryIdentityStorage;
 use auths_sdk::types::{GitSigningScope, IdentityConflictPolicy};
 
+use super::GitScopeArg;
+
 use super::InitCommand;
 use super::InitProfile;
 use super::helpers::get_auths_repo_path;
@@ -113,9 +115,32 @@ pub(crate) fn prompt_for_conflict_policy(
     Ok(IdentityConflictPolicy::ForceNew)
 }
 
-pub(crate) fn prompt_for_git_scope(interactive: bool) -> Result<GitSigningScope> {
+/// Resolve the git-signing scope from an explicit `--git-scope`, else by asking.
+///
+/// Non-interactive runs default to **local**. They used to default to `Global`
+/// with no way to override, so `auths init --non-interactive` — the scripted,
+/// CI and agent path — silently rewrote the user's `~/.gitconfig` and repointed
+/// `core.hooksPath` machine-wide, disabling every repo's own `.git/hooks`
+/// (husky, pre-commit, prek) in the process. Scoping to the repo you are standing
+/// in is the conservative default; `--git-scope global` opts back in.
+///
+/// Args:
+/// * `interactive`: Whether there is a TTY to prompt at.
+/// * `requested`: An explicit `--git-scope`, if given.
+///
+/// Usage:
+/// ```ignore
+/// let scope = prompt_for_git_scope(interactive, cmd.git_scope)?;
+/// ```
+pub(crate) fn prompt_for_git_scope(
+    interactive: bool,
+    requested: Option<GitScopeArg>,
+) -> Result<GitSigningScope> {
+    if let Some(scope) = requested {
+        return scope.resolve();
+    }
     if !interactive {
-        return Ok(GitSigningScope::Global);
+        return GitScopeArg::Local.resolve();
     }
 
     let choice = Select::new()

--- a/crates/auths-cli/src/commands/namespace.rs
+++ b/crates/auths-cli/src/commands/namespace.rs
@@ -8,7 +8,6 @@ use crate::config::CliConfig;
 use crate::factories::storage::build_auths_context;
 use auths_crypto::AuthsErrorInfo;
 use auths_infra_http::resolve_verified_platform_context;
-use auths_sdk::domains::identity::registration::DEFAULT_REGISTRY_URL;
 use auths_sdk::keychain::KeyAlias;
 use auths_sdk::namespace_registry::NamespaceVerifierRegistry;
 use auths_sdk::ports::{Ecosystem, PackageName};
@@ -139,8 +138,10 @@ impl ExecutableCommand for NamespaceCommand {
     }
 }
 
-fn resolve_registry_url(registry_url: Option<String>) -> String {
-    registry_url.unwrap_or_else(|| DEFAULT_REGISTRY_URL.to_string())
+/// The registry to publish namespace claims to. There is no default — see
+/// `verify_helpers::require_registry`.
+fn resolve_registry_url(registry_url: Option<String>) -> Result<String> {
+    crate::commands::verify_helpers::require_registry(registry_url)
 }
 
 fn load_identity_and_alias(
@@ -220,7 +221,7 @@ pub fn handle_namespace(cmd: NamespaceCommand, ctx: &CliConfig) -> Result<()> {
             registry_url,
             key,
         } => {
-            let registry_url = resolve_registry_url(registry_url);
+            let registry_url = resolve_registry_url(registry_url)?;
             let (controller_did, key_alias, auths_ctx) = load_identity_and_alias(ctx, key)?;
             let signer = StorageSigner::new(std::sync::Arc::clone(&auths_ctx.key_storage));
             let passphrase_provider = ctx.passphrase_provider.clone();
@@ -376,7 +377,7 @@ pub fn handle_namespace(cmd: NamespaceCommand, ctx: &CliConfig) -> Result<()> {
             registry_url,
             key,
         } => {
-            let registry_url = resolve_registry_url(registry_url);
+            let registry_url = resolve_registry_url(registry_url)?;
             let (controller_did, key_alias, auths_ctx) = load_identity_and_alias(ctx, key)?;
             let signer = StorageSigner::new(std::sync::Arc::clone(&auths_ctx.key_storage));
             let passphrase_provider = ctx.passphrase_provider.clone();
@@ -419,7 +420,7 @@ pub fn handle_namespace(cmd: NamespaceCommand, ctx: &CliConfig) -> Result<()> {
             registry_url,
             key,
         } => {
-            let registry_url = resolve_registry_url(registry_url);
+            let registry_url = resolve_registry_url(registry_url)?;
             let (controller_did, key_alias, auths_ctx) = load_identity_and_alias(ctx, key)?;
             let signer = StorageSigner::new(std::sync::Arc::clone(&auths_ctx.key_storage));
             let passphrase_provider = ctx.passphrase_provider.clone();
@@ -460,7 +461,7 @@ pub fn handle_namespace(cmd: NamespaceCommand, ctx: &CliConfig) -> Result<()> {
             package_name,
             registry_url,
         } => {
-            let registry_url = resolve_registry_url(registry_url);
+            let registry_url = resolve_registry_url(registry_url)?;
 
             println!("Looking up namespace {}/{}...", ecosystem, package_name);
 

--- a/crates/auths-cli/src/commands/org.rs
+++ b/crates/auths-cli/src/commands/org.rs
@@ -2,7 +2,6 @@ use anyhow::{Context, Result, anyhow};
 use auths_sdk::attestation::create_signed_attestation;
 use auths_sdk::attestation::create_signed_revocation;
 use auths_sdk::identity::DidResolver;
-use auths_sdk::registration::DEFAULT_REGISTRY_URL;
 use chrono::{DateTime, Utc};
 use clap::{ArgAction, Parser, Subcommand};
 use serde_json;
@@ -243,8 +242,8 @@ pub enum OrgSubcommand {
         code: String,
 
         /// Registry URL to contact
-        #[arg(long, env = "AUTHS_REGISTRY_URL", default_value = DEFAULT_REGISTRY_URL)]
-        registry: String,
+        #[arg(long, env = "AUTHS_REGISTRY_URL")]
+        registry: Option<String>,
     },
 
     /// Manage the org-wide authorization policy (anchored on the org KEL)
@@ -1074,6 +1073,7 @@ pub fn handle_org(
         }
 
         OrgSubcommand::Join { code, registry } => {
+            let registry = crate::commands::verify_helpers::require_registry(registry)?;
             handle_join(&code, &registry, passphrase_provider.as_ref())
         }
 

--- a/crates/auths-cli/src/commands/publish.rs
+++ b/crates/auths-cli/src/commands/publish.rs
@@ -1,5 +1,4 @@
 use anyhow::Result;
-use auths_sdk::registration::DEFAULT_REGISTRY_URL;
 use std::path::PathBuf;
 
 use crate::commands::artifact::publish::handle_publish;
@@ -33,8 +32,8 @@ pub struct PublishCommand {
     pub package: Option<String>,
 
     /// Registry URL to publish to.
-    #[arg(long, env = "AUTHS_REGISTRY_URL", default_value = DEFAULT_REGISTRY_URL)]
-    pub registry: String,
+    #[arg(long, env = "AUTHS_REGISTRY_URL")]
+    pub registry: Option<String>,
 }
 
 impl ExecutableCommand for PublishCommand {
@@ -74,6 +73,7 @@ impl ExecutableCommand for PublishCommand {
             (None, None) => anyhow::bail!("Provide an artifact file or --signature path"),
         };
 
-        handle_publish(&sig_path, self.package.as_deref(), &self.registry)
+        let registry = crate::commands::verify_helpers::require_registry(self.registry.clone())?;
+        handle_publish(&sig_path, self.package.as_deref(), &registry)
     }
 }

--- a/crates/auths-cli/src/commands/verify_helpers.rs
+++ b/crates/auths-cli/src/commands/verify_helpers.rs
@@ -87,3 +87,27 @@ pub fn parse_witness_keys(keys: &[String]) -> Result<Vec<(String, Vec<u8>)>> {
         })
         .collect()
 }
+
+/// The registry URL to use, or an actionable error when none is configured.
+///
+/// There is no default registry: auths is offline-first, and the one that used to
+/// be baked in (`https://registry.auths.dev`) returned HTTP 404 — a default that
+/// looks configured and fails at the network. Registry-dependent verbs resolve
+/// through here so the refusal is stated once, at the CLI boundary, in terms of
+/// what the user can do about it.
+///
+/// Args:
+/// * `configured`: The value of `--registry` / `AUTHS_REGISTRY_URL`, if any.
+///
+/// Usage:
+/// ```ignore
+/// let registry = require_registry(cmd.registry.clone())?;
+/// ```
+pub fn require_registry(configured: Option<String>) -> Result<String> {
+    configured.ok_or_else(|| {
+        anyhow!(
+            "{}",
+            auths_sdk::domains::identity::error::RegistrationError::NoRegistryConfigured
+        )
+    })
+}

--- a/crates/auths-cli/src/errors/registry.rs
+++ b/crates/auths-cli/src/errors/registry.rs
@@ -390,6 +390,7 @@ pub fn explain(code: &str) -> Option<&'static str> {
         "AUTHS-E5318" => Some("# AUTHS-E5318\n\n**Crate:** `auths-sdk`\n\n**Type:** `AgentError::AnchorError`\n\n## Message\n\nagent delegation attestation anchoring failed: {0}\n"),
 
         // --- auths-sdk (RegistrationError) ---
+        "AUTHS-E5400" => Some("# AUTHS-E5400\n\n**Crate:** `auths-sdk`\n\n**Type:** `RegistrationError::NoRegistryConfigured`\n\n## Message\n\nno registry configured. Auths needs no registry: identity, signing and verification are local and git-native, and a signer's KEL reaches a verifier over the same git remote as the code. Pass --registry <url> or set AUTHS_REGISTRY_URL only if you are running one.\n"),
         "AUTHS-E5401" => Some("# AUTHS-E5401\n\n**Crate:** `auths-sdk`\n\n**Type:** `RegistrationError::AlreadyRegistered`\n\n## Message\n\nidentity already registered at this registry\n"),
         "AUTHS-E5402" => Some("# AUTHS-E5402\n\n**Crate:** `auths-sdk`\n\n**Type:** `RegistrationError::QuotaExceeded`\n\n## Message\n\nregistration quota exceeded — try again later\n\n## Suggestion\n\nWait a few minutes and try again\n"),
         "AUTHS-E5403" => Some("# AUTHS-E5403\n\n**Crate:** `auths-sdk`\n\n**Type:** `RegistrationError::InvalidDidFormat`\n\n## Message\n\ninvalid DID format: {did}\n"),
@@ -789,6 +790,7 @@ pub fn all_codes() -> &'static [&'static str] {
         "AUTHS-E5316",
         "AUTHS-E5317",
         "AUTHS-E5318",
+        "AUTHS-E5400",
         "AUTHS-E5401",
         "AUTHS-E5402",
         "AUTHS-E5403",
@@ -912,6 +914,6 @@ mod tests {
 
     #[test]
     fn all_codes_count_matches_registry() {
-        assert_eq!(all_codes().len(), 370);
+        assert_eq!(all_codes().len(), 371);
     }
 }

--- a/crates/auths-cli/tests/cases/doctor.rs
+++ b/crates/auths-cli/tests/cases/doctor.rs
@@ -48,10 +48,13 @@ fn test_doctor_detects_missing_gpg_format() {
     let env = TestEnv::new();
     env.init_identity();
 
-    // Remove gpg.format from global config
+    // Remove gpg.format from the scope `auths init` actually wrote it to. A
+    // non-interactive init scopes signing config to the repo, not the machine, so
+    // unsetting --global here would silently no-op and the check would pass for
+    // the wrong reason.
     let unset = env
         .git_cmd()
-        .args(["config", "--global", "--unset", "gpg.format"])
+        .args(["config", "--local", "--unset", "gpg.format"])
         .output()
         .unwrap();
     assert!(unset.status.success(), "unset should succeed");

--- a/crates/auths-cli/tests/cases/init.rs
+++ b/crates/auths-cli/tests/cases/init.rs
@@ -94,24 +94,23 @@ fn test_init_happy_path() {
         "AUTHS_HOME should be initialized as git repo"
     );
 
-    // Init sets git config --global, which writes to our temp .gitconfig
-    // (redirected via GIT_CONFIG_GLOBAL env var in the subprocess)
-    let gitconfig = std::fs::read_to_string(env.home.path().join(".gitconfig")).unwrap();
+    // A non-interactive init scopes signing config to *this repo*, never the
+    // machine: a scripted or CI init must not rewrite the user's ~/.gitconfig,
+    // nor repoint core.hooksPath machine-wide (which would disable every other
+    // repo's own hooks). `--git-scope global` opts back in.
+    let global = std::fs::read_to_string(env.home.path().join(".gitconfig")).unwrap();
     assert!(
-        gitconfig.contains("ssh"),
-        "gitconfig should contain ssh signing format, got: {}",
-        gitconfig
+        !global.contains("auths-sign"),
+        "a scripted init must not write global git config, got: {global}"
     );
-    assert!(
-        gitconfig.contains("auths-sign"),
-        "gitconfig should reference auths-sign program, got: {}",
-        gitconfig
-    );
-    assert!(
-        gitconfig.contains("signingkey"),
-        "gitconfig should contain signing key, got: {}",
-        gitconfig
-    );
+
+    let local = std::fs::read_to_string(env.repo_path.join(".git").join("config")).unwrap();
+    for expected in ["ssh", "auths-sign", "signingkey"] {
+        assert!(
+            local.contains(expected),
+            "repo-local git config should contain {expected}, got: {local}"
+        );
+    }
 
     // KEL-native trust: init pins the local identity as a trusted root in
     // <repo>/.auths/roots (no allowed_signers allowlist is written anymore).

--- a/crates/auths-sdk/src/domains/identity/error.rs
+++ b/crates/auths-sdk/src/domains/identity/error.rs
@@ -139,10 +139,7 @@ pub enum RegistrationError {
     /// There is no default: auths is offline-first and every core workflow —
     /// identity, signing, verification — works without a registry.
     #[error(
-        "no registry configured. Auths needs no registry: identity, signing and \
-         verification are local and git-native, and a signer's KEL reaches a \
-         verifier over the same git remote as the code. Pass --registry <url> or \
-         set AUTHS_REGISTRY_URL only if you are running one."
+        "no registry configured. Auths needs no registry: identity, signing and verification are local and git-native, and a signer's KEL reaches a verifier over the same git remote as the code. Pass --registry <url> or set AUTHS_REGISTRY_URL only if you are running one."
     )]
     NoRegistryConfigured,
 

--- a/crates/auths-sdk/src/domains/identity/error.rs
+++ b/crates/auths-sdk/src/domains/identity/error.rs
@@ -134,6 +134,18 @@ pub enum RotationError {
 #[derive(Debug, Error)]
 #[non_exhaustive]
 pub enum RegistrationError {
+    /// A registry-dependent verb was invoked with no registry configured.
+    ///
+    /// There is no default: auths is offline-first and every core workflow —
+    /// identity, signing, verification — works without a registry.
+    #[error(
+        "no registry configured. Auths needs no registry: identity, signing and \
+         verification are local and git-native, and a signer's KEL reaches a \
+         verifier over the same git remote as the code. Pass --registry <url> or \
+         set AUTHS_REGISTRY_URL only if you are running one."
+    )]
+    NoRegistryConfigured,
+
     /// The identity is already registered at the target registry.
     #[error("identity already registered at this registry")]
     AlreadyRegistered,
@@ -261,6 +273,7 @@ impl AuthsErrorInfo for RotationError {
 impl AuthsErrorInfo for RegistrationError {
     fn error_code(&self) -> &'static str {
         match self {
+            Self::NoRegistryConfigured => "AUTHS-E5400",
             Self::AlreadyRegistered => "AUTHS-E5401",
             Self::QuotaExceeded => "AUTHS-E5402",
             Self::NetworkError(e) => e.error_code(),
@@ -273,6 +286,9 @@ impl AuthsErrorInfo for RegistrationError {
 
     fn suggestion(&self) -> Option<&'static str> {
         match self {
+            Self::NoRegistryConfigured => Some(
+                "Registration is optional — signing and verification need no registry. Pass --registry <url> or set AUTHS_REGISTRY_URL only if you run one",
+            ),
             Self::AlreadyRegistered => Some(
                 "This identity is already registered; use `auths id show` to see registration details",
             ),

--- a/crates/auths-sdk/src/domains/identity/registration.rs
+++ b/crates/auths-sdk/src/domains/identity/registration.rs
@@ -12,13 +12,22 @@ use auths_verifier::IdentityDID;
 use crate::domains::identity::error::RegistrationError;
 use crate::domains::identity::types::RegistrationOutcome;
 
-/// Default registry URL used when no explicit registry endpoint is configured.
-///
-/// Registration is opt-in (`--register`); auths is offline-first and never
-/// contacts this host unless the user explicitly asks for registration.
-/// Override per-invocation with `--registry <url>` or globally with the
-/// `AUTHS_REGISTRY_URL` environment variable.
-pub const DEFAULT_REGISTRY_URL: &str = "https://registry.auths.dev";
+// There is deliberately no default registry URL.
+//
+// There used to be one — `https://registry.auths.dev` — and it returned HTTP 404
+// (Vercel: DEPLOYMENT_NOT_FOUND). Every registry-touching command therefore shipped
+// with a default pointing at a host that does not exist, which is the worst
+// possible failure shape: it looks configured and fails at the network.
+//
+// Nothing needs it. Identity, signing, and verification are entirely local and
+// git-native — a signer's KEL travels to a relying party over the same git remote
+// as the code (see `workflows::commit_hooks::PRE_PUSH_HOOK`). "No central server"
+// is the product's headline claim, and a default that contradicts it is worse than
+// no default.
+//
+// A registry is now opt-in and explicit: pass `--registry <url>` or set
+// `AUTHS_REGISTRY_URL`. Callers surface `RegistrationError::NoRegistryConfigured`
+// when a registry-dependent verb is invoked without one.
 
 #[derive(Serialize)]
 struct RegistryOnboardingPayload {

--- a/crates/auths-sdk/src/registration.rs
+++ b/crates/auths-sdk/src/registration.rs
@@ -1,4 +1,4 @@
 //! Re-exports from the identity domain for backwards compatibility.
 
-pub use crate::domains::identity::registration::{DEFAULT_REGISTRY_URL, register_identity};
+pub use crate::domains::identity::registration::register_identity;
 pub use crate::domains::identity::types::RegistrationOutcome;

--- a/docs/errors/AUTHS-E5400.md
+++ b/docs/errors/AUTHS-E5400.md
@@ -1,0 +1,9 @@
+# AUTHS-E5400
+
+**Crate:** `auths-sdk`
+
+**Type:** `RegistrationError::NoRegistryConfigured`
+
+## Message
+
+no registry configured. Auths needs no registry: identity, signing and verification are local and git-native, and a signer's KEL reaches a verifier over the same git remote as the code. Pass --registry <url> or set AUTHS_REGISTRY_URL only if you are running one.

--- a/docs/errors/index.md
+++ b/docs/errors/index.md
@@ -286,6 +286,7 @@ All error codes emitted by the Auths CLI and libraries. Run `auths error <CODE>`
 | [AUTHS-E5316](AUTHS-E5316.md) | `auths-sdk` | `AgentError::OutsideDelegatorScope` | requested capability '{capability}' exceeds the delegator's scope |
 | [AUTHS-E5317](AUTHS-E5317.md) | `auths-sdk` | `AgentError::AttestationError` | agent delegation attestation failed: {0} |
 | [AUTHS-E5318](AUTHS-E5318.md) | `auths-sdk` | `AgentError::AnchorError` | agent delegation attestation anchoring failed: {0} |
+| [AUTHS-E5400](AUTHS-E5400.md) | `auths-sdk` | `RegistrationError::NoRegistryConfigured` | no registry configured. Auths needs no registry: identity, signing and verification are local and git-native, and a signer's KEL reaches a verifier over the same git remote as the code. Pass --registry <url> or set AUTHS_REGISTRY_URL only if you are running one. |
 | [AUTHS-E5401](AUTHS-E5401.md) | `auths-sdk` | `RegistrationError::AlreadyRegistered` | identity already registered at this registry |
 | [AUTHS-E5402](AUTHS-E5402.md) | `auths-sdk` | `RegistrationError::QuotaExceeded` | registration quota exceeded — try again later |
 | [AUTHS-E5403](AUTHS-E5403.md) | `auths-sdk` | `RegistrationError::InvalidDidFormat` | invalid DID format: {did} |

--- a/docs/errors/registry.lock
+++ b/docs/errors/registry.lock
@@ -290,6 +290,7 @@ AUTHS-E5315 = auths-sdk::AgentError::Revoked
 AUTHS-E5316 = auths-sdk::AgentError::OutsideDelegatorScope
 AUTHS-E5317 = auths-sdk::AgentError::AttestationError
 AUTHS-E5318 = auths-sdk::AgentError::AnchorError
+AUTHS-E5400 = auths-sdk::RegistrationError::NoRegistryConfigured
 AUTHS-E5401 = auths-sdk::RegistrationError::AlreadyRegistered
 AUTHS-E5402 = auths-sdk::RegistrationError::QuotaExceeded
 AUTHS-E5403 = auths-sdk::RegistrationError::InvalidDidFormat


### PR DESCRIPTION
Four fixes where the product asserted something the code didn't do. Ordered by how much they cost a new user.

## 4.1 — The default registry was a 404

`DEFAULT_REGISTRY_URL = "https://registry.auths.dev"` returns **HTTP 404** (Vercel: `DEPLOYMENT_NOT_FOUND`). Verified again today. It was the default for `init --registry`, `publish`, `account`, `org join`, `id claim|register`, `artifact publish` and `namespace` — and **`auths doctor` probed it on every run**, so every user saw a failing "Registry connectivity" check for a service they neither had nor needed.

That's the worst failure shape available: it *looks* configured and dies at the network.

Nothing needs it. Identity, signing and verification are local and git-native, and since Epic 1 a signer's KEL reaches a verifier over the same git remote as the code. **"No central server" is the README's own headline**; a default contradicting it is worse than no default.

Registry use is now explicit, refused through one shared `require_registry` so the message is stated once, in terms of what the user can do:

> no registry configured. Auths needs no registry: identity, signing and verification are local and git-native… Pass `--registry <url>` or set `AUTHS_REGISTRY_URL` **only if you are running one**.

New `RegistrationError::NoRegistryConfigured` (`AUTHS-E5400`). Doctor reports *"not configured (optional)"* and passes.

*Per your decision on the roadmap's Open Question 3. Checked first that no sibling repo depends on the constant — `auths-github-app` carries its own copy of the string, so it's unaffected.*

## 4.2 — The green badge was gated behind an unrelated dead flag

Linking GitHub uploads the SSH signing key, and **that is the only thing that makes a user's commits render Verified to everyone else.** It sat behind `interactive && cmd.register` — a flag whose documented job is publishing to the (404) registry. So the default first run left commits Unverified while the code to fix it was one boolean away.

The research puts a number on the cost: **73.73% of commit-signature verification failures in the wild are `unknown_key`** — developers sign and never register the key. The authors' verdict: *"a usability problem, not a cryptographic one"* ([arXiv:2604.14014](https://arxiv.org/html/2604.14014v1)). Auths mints the key, signs with it, and emits a **standard SSHSIG** GitHub *can* verify — the thing that is structurally impossible for gitsign, whose CA isn't in GitHub's trust root ([gitsign#40](https://github.com/sigstore/gitsign/issues/40), open since 2022).

New `--github` / `--no-github`, defaulting on when the repo has a GitHub remote and there's a TTY. Remote detection matches on the **parsed host**, never a substring — `github.com.evil.example` is a different host, and there's a test that says so.

## 4.3 — README: wrong curve, and a claim that wouldn't survive contact

- *"A `did:keri` derived from your **Ed25519** key"* — the default is **P-256** (the iOS Secure Enclave holds P-256, not Ed25519, so hardware-backed mobile pairing requires it). `auths demo` emits `did:key:zDna…`.
- Replaced the implied offline-verification differentiator with the claim that survives: cosign has shipped `--offline` since **2023-02-23**, v3 made offline bundles the default, v4 deprecates `--rekor-url`. What's *actually* true is narrower — their offline path checks a **trust-root snapshot**, so a revocation you haven't downloaded is one you can't see (GitHub's own docs say exactly that). A KEL carries its own rotation history. That's a trust-freshness claim about long-lived device keys — Auths's model, and precisely not Sigstore's.

**Not changed:** the README lists 10 commands where `--help-all` shows 45. My roadmap called that drift; it isn't — it's a curated quick-reference that points at `--help-all` on the next line. My report was unfair there.

## 4.4 — A scripted init rewrote your global git config

`prompt_for_git_scope` returned `Global` **unconditionally** when non-interactive, with no flag to override. So `auths init --non-interactive` — the CI and agent path — silently rewrote `~/.gitconfig` and repointed `core.hooksPath` **machine-wide**, disabling every repo's own `.git/hooks` (husky, pre-commit, prek) as a side effect.

*This repo is living with that right now: its prek pre-commit and pre-commit pre-push hooks are being bypassed by exactly this.*

New `--git-scope local|global|skip`, defaulting to `local` when non-interactive. Verified:

| invocation | global gitconfig | repo-local hooksPath |
|---|---|---|
| `--non-interactive` (default) | **untouched** | set |
| `--git-scope local` | untouched | set |
| `--git-scope global` | written | — |
| `--git-scope skip` | untouched | — |

## The follow-on the tests caught (`bbc5b889`)

Scoping init to the repo exposed that the doctor read `git config --global` in two places, so a correctly configured repo reported as broken. Both now read the **effective** value — which is what git itself resolves, and was already wrong for anyone who'd scoped signing by hand.

Two integration tests encoded the old behaviour and were corrected, not silenced: `test_init_happy_path` now asserts a scripted init leaves `~/.gitconfig` alone; `test_doctor_detects_missing_gpg_format` unset `--global`, a scope init no longer writes, so it would have no-op'd and **passed for the wrong reason**.

## Verification

- `cargo test -p auths-cli --test integration` → **67 passed**
- `cargo test -p auths-cli --lib` → **157 passed**
- `cargo test -p auths-sdk --lib` → **176 passed**
- `cargo clippy -p auths-sdk -p auths-cli --all-targets` → clean · `cargo fmt --all` → applied

## On commit granularity

You asked for one commit per task. 4.1, 4.2 and 4.4 are interleaved in the same struct and the same five test fixtures in `init/mod.rs` — splitting them produces commits that don't compile. I combined those three and kept 4.3 and the diagnostics follow-on separate, rather than fake atomicity.