### PR TITLE
Epic A: make the bounded agent (P1) publishable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: Check package versions match the workspace version
         run: python3 scripts/releases/0_versions.py --check
+      - name: Every publishable crate is in the release (or explicitly excluded)
+        run: python3 scripts/releases/2_crates.py --validate
 
   clippy:
     name: Clippy

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,21 +38,28 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # node_platform is `${process.platform}-${process.arch}` — the exact key
+          # `@auths/mcp`'s launcher looks up under vendor/<platform>/, so the
+          # standalone gateway asset drops straight into that tree with no mapping.
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
             asset_name: auths-linux-x86_64
+            node_platform: linux-x64
             ext: .tar.gz
           - os: ubuntu-24.04-arm
             target: aarch64-unknown-linux-gnu
             asset_name: auths-linux-aarch64
+            node_platform: linux-arm64
             ext: .tar.gz
           - os: macos-latest
             target: aarch64-apple-darwin
             asset_name: auths-macos-aarch64
+            node_platform: darwin-arm64
             ext: .tar.gz
           - os: windows-latest
             target: x86_64-pc-windows-msvc
             asset_name: auths-windows-x86_64
+            node_platform: win32-x64
             ext: .zip
     runs-on: ${{ matrix.os }}
     steps:
@@ -103,6 +110,26 @@ jobs:
           # No SilentlyContinue: a silently absent gateway is how it shipped to nobody.
           Copy-Item target/${{ matrix.target }}/release/auths-mcp-gateway.exe staging/
           Compress-Archive -Path staging/* -DestinationPath ${{ matrix.asset_name }}${{ matrix.ext }}
+
+      # A standalone gateway asset, named by node platform, so `@auths/mcp` can drop
+      # it straight into vendor/<platform>/ — either bundled at publish or fetched at
+      # postinstall. The combined archive above is for `brew`/direct-download users;
+      # this is for the npm launcher, which wants only the gateway.
+      - name: Package MCP gateway standalone (Unix)
+        if: matrix.ext == '.tar.gz'
+        run: |
+          ASSET="auths-mcp-gateway-${{ matrix.node_platform }}.tar.gz"
+          tar -czf "$ASSET" -C target/${{ matrix.target }}/release auths-mcp-gateway
+          shasum -a 256 "$ASSET" > "$ASSET.sha256"
+
+      - name: Package MCP gateway standalone (Windows)
+        if: matrix.ext == '.zip'
+        shell: pwsh
+        run: |
+          $asset = "auths-mcp-gateway-${{ matrix.node_platform }}.zip"
+          Compress-Archive -Path target/${{ matrix.target }}/release/auths-mcp-gateway.exe -DestinationPath $asset
+          $hash = (Get-FileHash $asset -Algorithm SHA256).Hash.ToLower()
+          "$hash  $asset" | Out-File -Encoding ascii "$asset.sha256"
 
       - name: Generate SHA256 checksum (Unix)
         if: matrix.ext == '.tar.gz'
@@ -166,6 +193,8 @@ jobs:
             ${{ matrix.asset_name }}${{ matrix.ext }}
             ${{ matrix.asset_name }}${{ matrix.ext }}.sha256
             ${{ matrix.asset_name }}${{ matrix.ext }}.auths.json
+            auths-mcp-gateway-${{ matrix.node_platform }}${{ matrix.ext }}
+            auths-mcp-gateway-${{ matrix.node_platform }}${{ matrix.ext }}.sha256
 
   release:
     needs: build

--- a/.recurve/claims/auths-mcp/gaps.yaml
+++ b/.recurve/claims/auths-mcp/gaps.yaml
@@ -610,3 +610,37 @@
   unlocks: An operator can default to REAL money safely — real is the default, the cap is a
     mandatory seatbelt that cannot be skipped, and the mode is never silent (PRD §11). Test mode
     is a single, deliberate opt-in.
+
+- id: AGENT-AUDIT-1
+  title: A party who did not operate the agent can re-derive its spend offline and
+    catch a tampered proof — verify-spend, the north-star surface
+  class: missing-surface
+  status: closed
+  severity: headline
+  reads: gateway
+  covers:
+  - offline-audit
+  evidence:
+  - 'BUILT: auths-mcp-gateway verify-spend re-verifies every signed per-call proof through
+    the same verifier the live gate uses, re-derives the spend, and exits non-zero on any
+    non-consistent verdict — needing only the issuer''s registry (to resolve the agent +
+    delegator KELs) and the persisted spend log.'
+  - 'GAP it closed: eleven probes gated the gateway''s live path (agent-mcp-1..8, agent-pay-1..3);
+    NONE exercised verify-spend — the one surface that proves the "receipts anyone can verify,
+    without trusting you" half of the pitch.'
+  observed: 'GREEN 2026-07-17: driving one replay persists the signed spend log into the sandbox
+    registry and emits the standalone audit command; running verify-spend over it re-derived
+    "consistent — 1 call(s), $0.00 re-derived from signed costs" (exit 0) with no trust in the
+    operator. Trap RED: flipping one byte of the signed call_commit in the log — a proof tampered
+    AFTER signing — is caught "tampered-proof … failed verification" (exit 1); a verifier that
+    accepted it would be trusting the operator, which is the property this forbids. RED-capable
+    confirmed: against a binary lacking the surface the probe reports the missing spend log and
+    exits 1 (RED), never coerces to BROKEN.'
+  smallest_fix: 'Add a probe (probes/agent-audit-1.sh) that drives one replay, reads the emitted
+    audit-cmd, runs verify-spend over the persisted log (acceptance: honest log → consistent, exit 0),
+    and re-runs it over a copy with one signed call_commit byte flipped (adversary: → tampered-proof,
+    exit non-zero). GREEN requires BOTH halves — an audit that accepts the tampered log is trusting
+    the operator, not re-verifying the signatures.'
+  probe: probes/agent-audit-1.sh
+  unlocks: The counterparty-verification claim is behaviorally gated — a receipt nobody can
+    independently check is a log, and this is the surface that makes it not one.

--- a/.recurve/claims/auths-mcp/probes/agent-audit-1.sh
+++ b/.recurve/claims/auths-mcp/probes/agent-audit-1.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# AGENT-AUDIT-1 — the north-star surface: a party who did NOT operate the agent can
+# re-derive its spend OFFLINE and detect a tampered proof, with no trust in the
+# operator that produced the log.
+#
+# `auths-mcp-gateway verify-spend` re-verifies every signed per-call proof through the
+# SAME verifier the live gate uses, re-derives the spend, and exits non-zero on any
+# non-`consistent` verdict — needing only the issuer's registry (to resolve the agent
+# + delegator KELs) and the persisted spend log. This is the "receipts anyone can
+# verify, without trusting you" half of the pitch. Eleven probes gate the gateway's
+# live path; NONE gated this — the one surface that proves the category exists.
+#
+# GREEN requires BOTH halves:
+#   1. Acceptance: an honest spend log verifies `consistent` (exit 0).
+#   2. Adversary:  a proof tampered AFTER signing (one byte of the signed
+#      `call_commit`) is caught `tampered-proof` (exit non-zero). A verifier that
+#      accepts the tampered log is not auditing signatures — it is trusting the
+#      operator, which is the whole thing this claim forbids.
+#
+# RED  = verify-spend is absent, OR the honest log is not consistent, OR the tampered
+#        log is accepted (the audit does not actually re-verify the signatures).
+# BROKEN = no staged binary / missing transcript.
+#
+# Contract: 0 GREEN · 1 RED · 2 BROKEN. Hermetic: throwaway sandbox, no network,
+# never touches ~/.auths or the user's git config.
+set -uo pipefail
+cd "$(dirname "$0")/.."
+. ./harness/env.sh
+. ./probes/_contract.sh
+set +e
+
+# ── Trap mode ─────────────────────────────────────────────────────────────────
+# A known-bad fixture: a verify-spend run over a tampered log that was ACCEPTED
+# (reported consistent) instead of caught tampered-proof — the regression this
+# probe forbids. The captured verdict must show the tamper was caught.
+if [ -n "${TRAP_FIXTURE:-}" ]; then
+    [ -f "${TRAP_FIXTURE}/verify.out" ] \
+        || broken "trap fixture missing verify.out: ${TRAP_FIXTURE}"
+    out="$(cat "${TRAP_FIXTURE}/verify.out")"
+    if ! printf '%s' "$out" | grep -qiE 'tampered-proof|failed verification|inconsistent'; then
+        red "ours=accepted expected=tampered-proof — verify-spend reported \"$(printf '%s' "$out" | head -1)\" over a post-signing-tampered log; the audit did not re-verify the signed proof, so it is trusting the operator"
+    fi
+    green "the tampered log was caught (tampered-proof) — the offline audit re-verifies signatures, not the operator's word"
+fi
+
+bin_ready || broken "no staged bin/auths-mcp-gateway — run the suite rebuild first"
+
+TRANSCRIPT="$(transcript_path agent-mcp-1)"
+[ -f "$TRANSCRIPT" ] || broken "missing replay transcript: $TRANSCRIPT"
+
+LAB="$(mktemp -d "${TMPDIR:-/tmp}/audit1.XXXXXX")"
+trap 'rm -rf "$LAB"' EXIT
+sandbox_env "$LAB"
+
+# ONE drive (the chain build is not idempotent). The replay persists the signed
+# spend log into the sandbox registry and prints the exact standalone audit command
+# — `verify-spend`'s --log/--registry/--agent/--root — which we then run ourselves,
+# as an independent auditor would, over the persisted artifacts.
+RAW="$(gateway_replay "$TRANSCRIPT" 2>/dev/null)"
+AUDIT_ARGS="$(printf '%s\n' "$RAW" | sed -n 's/^▸* *audit-cmd: //p' | head -1)"
+[ -n "$AUDIT_ARGS" ] \
+    || red "ours=no-audit-cmd expected=verify-spend — replay emitted no 'audit-cmd:' line; the gateway does not expose an offline spend-audit command over the persisted log (\"$(printf '%s' "$RAW" | tail -1)\")"
+
+LOG="$(printf '%s' "$AUDIT_ARGS" | sed -n 's/.*--log \([^ ]*\).*/\1/p')"
+[ -f "$LOG" ] \
+    || red "ours=no-spend-log expected=$LOG — replay did not persist a signed spend log for the audit to re-verify"
+
+# ── Half 1: the honest log must re-derive consistent, offline ─────────────────
+HONEST="$("$GATEWAY_BIN" verify-spend $AUDIT_ARGS 2>&1)"
+honest_rc=$?
+accept_ok=0
+[ $honest_rc -eq 0 ] && printf '%s' "$HONEST" | grep -qi 'consistent' && accept_ok=1
+
+# ── Half 2: a proof tampered after signing must be caught tampered-proof ───────
+# Flip one byte of the signed `call_commit` in a COPY of the log (verify-spend takes
+# --log by path, so the registry stays untouched and we never re-drive the gateway).
+TAMPERED="$LAB/tampered-spend.jsonl"
+python3 - "$LOG" "$TAMPERED" <<'PY'
+import json, sys, pathlib
+src, dst = sys.argv[1], sys.argv[2]
+lines = [l for l in pathlib.Path(src).read_text().splitlines() if l.strip()]
+entry = json.loads(lines[0])
+cc = entry.get("call_commit")
+if isinstance(cc, list) and cc:          # signed message bytes → flip one
+    cc[0] ^= 0x01
+    lines[0] = json.dumps(entry)
+pathlib.Path(dst).write_text("\n".join(lines) + "\n")
+PY
+TAMPER_ARGS="$(printf '%s' "$AUDIT_ARGS" | sed "s#--log [^ ]*#--log $TAMPERED#")"
+TAMPER_OUT="$("$GATEWAY_BIN" verify-spend $TAMPER_ARGS 2>&1)"
+tamper_rc=$?
+adversary_ok=0
+[ $tamper_rc -ne 0 ] \
+    && printf '%s' "$TAMPER_OUT" | grep -qiE 'tampered-proof|failed verification|inconsistent' \
+    && adversary_ok=1
+
+if [ $accept_ok -eq 1 ] && [ $adversary_ok -eq 1 ]; then
+    green "offline audit holds: an honest spend log re-derived consistent, and a proof tampered after signing was caught tampered-proof — a third party can verify the receipts without trusting the operator"
+fi
+
+if [ $accept_ok -ne 1 ]; then
+    red "ours=$(printf '%s' "$HONEST" | head -1) expected=consistent(exit 0) — the honest, untampered spend log did not re-derive consistent offline (rc=$honest_rc); the counterparty audit surface does not work"
+fi
+
+red "ours=accepted(rc=$tamper_rc) expected=tampered-proof — verify-spend accepted a log whose signed call_commit was altered after signing (\"$(printf '%s' "$TAMPER_OUT" | head -1)\"); it is not re-verifying the proofs, so it trusts the operator — the north-star property is absent"

--- a/scripts/releases/2_crates.py
+++ b/scripts/releases/2_crates.py
@@ -36,8 +36,12 @@ CRATES_IO_API = "https://crates.io/api/v1/crates"
 # Topological order computed from `cargo metadata` (a crate may only appear
 # after every internal dependency it has). Regenerate when crate deps change:
 # each batch contains crates whose internal deps are all in earlier batches.
-# Deliberately excluded: auths-radicle (deprecated), auths-api (server bin),
-# auths-test-utils (test helper, only a dev-dependency of published crates).
+#
+# Every publishable workspace member must be either in a batch here or in
+# EXCLUDED_FROM_PUBLISH below — `validate_batches()` enforces that, so a crate
+# can no longer silently fall out of the release (which is exactly what happened
+# to auths-mcp-core/-gateway: built, wired, and never published because nothing
+# checked they were listed).
 PUBLISH_BATCHES: list[list[str]] = [
     ["auths", "auths-crypto", "auths-telemetry", "auths-utils"],
     ["auths-keri", "auths-oidc-port"],
@@ -48,11 +52,90 @@ PUBLISH_BATCHES: list[list[str]] = [
     ["auths-id"],
     ["auths-storage"],
     ["auths-sdk"],
-    ["auths-infra-git", "auths-mcp-server", "auths-scim-server"],
-    ["auths-cli"],
+    ["auths-infra-git", "auths-mcp-core", "auths-mcp-server", "auths-scim-server"],
+    ["auths-cli", "auths-mcp-gateway"],
 ]
 
+# Publishable workspace members deliberately NOT published to crates.io, each
+# with the reason. Keeping this explicit is what makes the coverage check
+# meaningful: an omission is a decision recorded here, never an accident.
+EXCLUDED_FROM_PUBLISH: dict[str, str] = {
+    "auths-api": "org control-plane server binary; not a library anyone depends on from crates.io",
+    "murmur-core": "belongs to the Murmur messenger — a separate product with its own release",
+    "murmur-relay": "belongs to the Murmur messenger — a separate product with its own release",
+}
+
 SLEEP_BETWEEN_BATCHES = 60
+
+
+def workspace_members() -> list[str]:
+    """Crate names of the `[workspace] members` under `crates/`.
+
+    Read from the root Cargo.toml so the coverage check sees exactly what
+    `cargo` would build, not whatever happens to sit in the crates/ directory.
+    """
+    text = CARGO_TOML.read_text()
+    members_block = re.search(r"members\s*=\s*\[(.*?)\]", text, re.DOTALL)
+    if not members_block:
+        return []
+    paths = re.findall(r'"(crates/[^"]+)"', members_block.group(1))
+    names = []
+    for p in paths:
+        crate_toml = CARGO_TOML.parent / p / "Cargo.toml"
+        if not crate_toml.exists():
+            continue
+        name = re.search(r'^\s*name\s*=\s*"([^"]+)"', crate_toml.read_text(), re.MULTILINE)
+        if name:
+            names.append(name.group(1))
+    return names
+
+
+def is_publishable(crate_name: str) -> bool:
+    """Whether a workspace member is publishable (no `publish = false`)."""
+    for p in re.findall(r'"(crates/[^"]+)"', CARGO_TOML.read_text()):
+        crate_toml = CARGO_TOML.parent / p / "Cargo.toml"
+        if not crate_toml.exists():
+            continue
+        text = crate_toml.read_text()
+        name = re.search(r'^\s*name\s*=\s*"([^"]+)"', text, re.MULTILINE)
+        if name and name.group(1) == crate_name:
+            return not re.search(r"^\s*publish\s*=\s*false", text, re.MULTILINE)
+    return False
+
+
+def validate_batches() -> list[str]:
+    """Return coverage errors: publishable members neither batched nor excluded,
+    plus batch/exclusion entries that no longer name a publishable member."""
+    batched = [c for batch in PUBLISH_BATCHES for c in batch]
+    errors: list[str] = []
+
+    dupes = sorted({c for c in batched if batched.count(c) > 1})
+    for c in dupes:
+        errors.append(f"{c} appears in PUBLISH_BATCHES more than once")
+
+    batched_set = set(batched)
+    overlap = batched_set & set(EXCLUDED_FROM_PUBLISH)
+    for c in sorted(overlap):
+        errors.append(f"{c} is both batched and excluded — pick one")
+
+    for crate in sorted(workspace_members()):
+        if not is_publishable(crate):
+            if crate in batched_set:
+                errors.append(f"{crate} has publish=false but is in a batch")
+            continue
+        if crate not in batched_set and crate not in EXCLUDED_FROM_PUBLISH:
+            errors.append(
+                f"{crate} is publishable but is neither in a batch nor in "
+                f"EXCLUDED_FROM_PUBLISH — add it to the release or record why not"
+            )
+
+    members = set(workspace_members())
+    for crate in sorted(batched_set - members):
+        errors.append(f"{crate} is batched but is not a workspace member")
+    for crate in sorted(set(EXCLUDED_FROM_PUBLISH) - members):
+        errors.append(f"{crate} is excluded but is not a workspace member")
+
+    return errors
 
 
 def get_workspace_version() -> str:
@@ -137,6 +220,28 @@ def publish_crate(crate_name: str) -> bool:
 
 
 def main() -> None:
+    # Coverage is checked on every run — a batch that has drifted out of sync
+    # with the workspace is a release bug whether or not we are publishing today.
+    errors = validate_batches()
+    if "--validate" in sys.argv:
+        if errors:
+            print("PUBLISH_BATCHES coverage FAILED:", file=sys.stderr)
+            for e in errors:
+                print(f"  - {e}", file=sys.stderr)
+            sys.exit(1)
+        members = [c for c in workspace_members() if is_publishable(c)]
+        print(
+            f"PUBLISH_BATCHES coverage OK: {len(members)} publishable members "
+            f"({sum(len(b) for b in PUBLISH_BATCHES)} batched, "
+            f"{len(EXCLUDED_FROM_PUBLISH)} excluded)"
+        )
+        return
+    if errors:
+        print("ERROR: PUBLISH_BATCHES coverage is out of date:", file=sys.stderr)
+        for e in errors:
+            print(f"  - {e}", file=sys.stderr)
+        sys.exit(1)
+
     publish = "--publish" in sys.argv
 
     version = get_workspace_version()


### PR DESCRIPTION
The MCP gateway is the one product in this portfolio with a plausible market — and it ships to nobody. `registry.npmjs.org/@auths/mcp` returns **404**; the gateway crates aren't on crates.io. This is the release-side half of unblocking it.

**Scope note:** the npm launcher lives in the sibling `auths-mcp` repo, and the actual `npm publish` / `cargo publish` are the owner's to trigger — they need the registry tokens and are irreversible public acts. This PR makes those a single command instead of a research project.

## A.1 — Put the gateway crates in the release, and stop them falling out again

`auths-mcp-core` and `auths-mcp-gateway` were **absent from `PUBLISH_BATCHES` entirely** — the actual reason they never published, no matter how finished. Added them (core after `auths-sdk`; gateway after core).

The deeper fix is *why nobody noticed*: nothing checked that a publishable crate was in the release. Added `validate_batches()` + `--validate`, wired into the **Package version sync** CI job. It fails if any publishable workspace member is neither batched nor in an explicit `EXCLUDED_FROM_PUBLISH` list (`auths-api`, `murmur-core`, `murmur-relay`, each with a recorded reason).

**Mutation-checked:** dropping the gateway from a batch turns the check red —
```
auths-mcp-gateway is publishable but is neither in a batch nor in
EXCLUDED_FROM_PUBLISH — add it to the release or record why not
```
This is the "built but not shipped" disease caught at the crate boundary.

## A.2 — Emit a standalone gateway asset per platform

`release.yml` already bundles the gateway inside the combined archive (for brew / direct download). The npm launcher wants **only** the gateway, under `vendor/<node-platform>/`. So the build now also emits `auths-mcp-gateway-<node_platform>.{tar.gz,zip}` (+ `.sha256`), named by the exact `${process.platform}-${process.arch}` key the launcher looks up — it drops straight into the vendor tree with no mapping.

## A.6 — Gate `verify-spend`, the surface that proves the whole pitch

Eleven probes gated the gateway's live path; **zero** exercised `verify-spend` — the offline, no-trust-in-the-operator spend audit that *is* the "receipts anyone can verify without trusting you" claim.

`probes/agent-audit-1.sh` drives one replay, runs `verify-spend` over the persisted signed log (**acceptance:** honest log → `consistent`, exit 0), then re-runs it over a copy with one signed `call_commit` byte flipped (**adversary:** → `tampered-proof`, exit non-zero). GREEN requires **both** — an audit that accepts the tampered log is trusting the operator, not the signatures.

Verified bidirectional: GREEN against the real binary, **RED (exit 1, not BROKEN)** against a binary lacking the surface. Registered as `AGENT-AUDIT-1`.

## What's left for the owner (can't be a code PR)

- **A.3** `npm publish @auths/mcp` — drop `private: true`, un-404 the repo. Needs `NPM_TOKEN`; irreversible.
- **A.4/A.5** README + quickstart in the sibling `auths-mcp` repo (I'll prep these locally).
- The first `v*` tag after merge fans the gateway crates out to crates.io via the existing `publish-crates.yml`.

## Verification

- `python3 scripts/releases/2_crates.py --validate` → coverage OK (30 members: 27 batched, 3 excluded), and red on a dropped crate
- `probes/agent-audit-1.sh` → GREEN on the real binary, RED (exit 1) when the surface is absent
- `release.yml` + `ci.yml` → valid YAML