### PR TITLE
Epic B: make the referee (P2) provable — lock the rotate→bundle attachment

### DIFF
--- a/crates/auths-sdk/src/domains/identity/rotation.rs
+++ b/crates/auths-sdk/src/domains/identity/rotation.rs
@@ -1041,6 +1041,78 @@ mod tests {
         );
     }
 
+    /// Regression: after `rotate_identity`, every KEL event — the inception AND
+    /// the rotation — must have a stored signature attachment.
+    ///
+    /// This is the exact precondition `auths id export-bundle` enforces: it reads
+    /// `registry.get_attachment(prefix, seq)` for each event and aborts with "KEL
+    /// event at seq N has no stored signature attachment" if any is missing. The
+    /// shipped 0.1.3 wheel's rotate dropped the rot attachment, so `export-bundle`
+    /// bricked after a rotation and stateless CI verification (a core claim) died
+    /// with it. The fix threads the CESR-signed attachment through `apply_rotation`;
+    /// this test exists so it can never regress silently again.
+    #[test]
+    fn rotate_persists_a_signature_attachment_for_every_kel_event() {
+        let (_keychain_guard, ctx) = fake_ctx("Test-passphrase1!");
+
+        let signer = StorageSigner::new(MemoryKeychainHandle);
+        let provider = PrefilledPassphraseProvider::new("Test-passphrase1!");
+        let config = CreateDeveloperIdentityConfig::builder(KeyAlias::new_unchecked("bundle-key"))
+            .with_git_signing_scope(GitSigningScope::Skip)
+            .build();
+        let key_alias = match initialize(
+            IdentityConfig::Developer(config),
+            &ctx,
+            Arc::new(MemoryKeychainHandle),
+            &signer,
+            &provider,
+            None,
+        )
+        .unwrap()
+        {
+            InitializeResult::Developer(r) => r.key_alias,
+            _ => unreachable!(),
+        };
+
+        let rotation_config = IdentityRotationConfig {
+            repo_path: std::path::PathBuf::from("/unused"),
+            identity_key_alias: Some(key_alias),
+            next_key_alias: Some(KeyAlias::new_unchecked("rotated-key")),
+        };
+        rotate_identity(rotation_config, &ctx, &SystemClock).unwrap();
+
+        let prefix = auths_id::keri::parse_did_keri(
+            ctx.identity_storage
+                .load_identity()
+                .unwrap()
+                .controller_did
+                .as_str(),
+        )
+        .unwrap();
+
+        // The rotation advances the KEL to at least seq 1 (icp@0, rot@1). Walk
+        // every event and assert its attachment is present and non-empty — exactly
+        // what export-bundle does before it will emit a verifiable bundle.
+        let tip = ctx.registry.get_key_state(&prefix).unwrap().sequence;
+        assert!(tip >= 1, "a rotation must advance the KEL past inception");
+        for seq in 0..=tip {
+            let att = ctx
+                .registry
+                .get_attachment(&prefix, seq)
+                .unwrap()
+                .unwrap_or_else(|| {
+                    panic!(
+                        "KEL event at seq {seq} has no stored signature attachment — \
+                         export-bundle would abort here (the shipped-0.1.3 rotate bug)"
+                    )
+                });
+            assert!(
+                !att.is_empty(),
+                "attachment for seq {seq} is present but empty — not a real signature"
+            );
+        }
+    }
+
     fn p(s: &str) -> Prefix {
         Prefix::new_unchecked(s.to_string())
     }


### PR DESCRIPTION
P2 is the neutral referee: *"proof your agent's code passed, that anyone can re-verify offline."* Its offline-bundle path is how a counterparty verifies without an account. That path had a live defect.

## B.3 — The rotate→export-bundle attachment (the verifiable core of this PR)

The shipped **PyPI 0.1.3 wheel's `rotate()` dropped the rot event's signature attachment**, so `auths id export-bundle` bricked after *any* rotation — and stateless CI verification (a core P2 claim, and the thing that crashes the marquee agent demo at its finale) died with it.

The source fix landed in `9a349d9d`, threading the CESR-signed attachment through `apply_rotation`. **But nothing tested it**, so the exact regression could silently return on the next wheel.

This adds `rotate_persists_a_signature_attachment_for_every_kel_event`: rotate a fresh identity, then walk every KEL event and assert `get_attachment(prefix, seq)` is `Some` and non-empty — the precise precondition `export-bundle` enforces before it emits a verifiable bundle.

**Mutation-checked.** Restoring the empty-attachment behaviour makes the test fail with the very error `export-bundle` raises:
```
KEL event at seq N has no stored signature attachment —
export-bundle would abort here (the shipped-0.1.3 rotate bug)
```
So it's a test that *would have caught the shipped bug*, not one that passes beside the fix. The fix reaches PyPI on the next wheel; this keeps it from regressing there.

**Why SDK-level, not CLI-level:** the shipped bug lived in the FFI/SDK `rotate_identity` path (which the Python wheel calls). The CLI's `emergency rotate-now` uses a *different, half-wired* legacy backend (see `key_rotation_cli.rs`'s own note) — a CLI e2e would fight that pre-existing seam, not exercise the path that broke. The SDK test hits the real path directly.

## The rest of Epic B — sibling-repo / owner / large-feature

Documented, not done here, because none is an `auths`-repo code change:

- **B.1 — green the referee's own red gates.** `auths-curve`'s merge-gate and `interop` (`GATE FAILED — 26 stale, 1 green`) are in sibling repos and need Docker oracles (keripy/keriox) + byte-vector regeneration. A trust product whose own gates are red has no argument — this is real work, just not this PR's.
- **B.2 — fold the referee into `auths` proper.** `auths-curve`'s compliance export + merge-gate belong in the shipped CLI. A feature, not a fix.
- **B.4 — give `auths-demos` a git remote.** Seven working demos, currently unclonable. Creating the public repo is an owner action.

Note: **A.6 (already merged in #371)** gated `verify-spend`, the counterparty-audit surface — the other half of "make P2 provable." Together with B.3 this materially advances P2's provability from the `auths` repo.

## Verification

- `cargo test -p auths-sdk --lib domains::identity::rotation` → **15 passed**
- mutation: empty attachment → test fails with the export-bundle error; restored clean