### PR TITLE
ci: fix verify-HEAD routing test on signed checkouts; skip npm republish of existing versions

### DIFF
--- a/.github/workflows/publish-node.yml
+++ b/.github/workflows/publish-node.yml
@@ -162,11 +162,27 @@ jobs:
       - name: Upgrade npm for trusted publishing
         run: npm install -g npm@latest
 
+      # A re-pushed tag re-fires this workflow; npm refuses republishing an
+      # existing version, so an already-published version is a SKIP, not a failure.
+      - name: Skip if this version is already on npm
+        id: published
+        working-directory: packages/auths-node
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          if npm view "@auths-dev/sdk@$VERSION" version >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "@auths-dev/sdk@$VERSION already on npm — skipping republish"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Publish platform packages
+        if: steps.published.outputs.exists != 'true'
         working-directory: packages/auths-node
         run: npx napi prepublish -t npm --no-gh-release
 
       - name: Publish main package
+        if: steps.published.outputs.exists != 'true'
         working-directory: packages/auths-node
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ github.event.inputs.target }}" = "dry-run" ]; then

--- a/crates/auths-cli/tests/cases/verify_commit.rs
+++ b/crates/auths-cli/tests/cases/verify_commit.rs
@@ -44,10 +44,18 @@ fn test_verify_commit_json_output_error() {
 // Tests for the unified `auths verify` command routing to commit verification
 #[test]
 fn test_unified_verify_routes_head_to_commit_verify() {
-    // `auths verify HEAD` routes to commit verification. Without a trusted, trailer-bearing
-    // commit it fails (non-zero exit), but that is a routing success — not a clap parse error.
+    // `auths verify HEAD` routes to commit verification. The VERDICT depends on the
+    // checkout this test runs in: an unsigned or untrusted HEAD fails, while a fully
+    // signed, root-pinned checkout (CI on main, now that every commit is signed)
+    // legitimately succeeds. Routing is what this test pins: either verdict exits
+    // 0 or 1 — never clap's usage-error exit 2.
     let mut cmd = Command::cargo_bin("auths").unwrap();
     cmd.arg("verify").arg("HEAD");
 
-    cmd.assert().failure();
+    let output = cmd.output().unwrap();
+    let code = output.status.code().unwrap_or(-1);
+    assert!(
+        code == 0 || code == 1,
+        "verify HEAD must route to commit verification (exit {code}; 2 = clap parse error)"
+    );
 }


### PR DESCRIPTION
Two CI fixes:

1. **`test_unified_verify_routes_head_to_commit_verify`** asserted `auths verify HEAD` always fails — true only on unsigned checkouts. Now that main is fully signed and root-pinned, verification legitimately succeeds in CI and the assertion broke. The test now pins what it always meant to: routing. Either verdict must exit 0 or 1 — never clap's usage-error exit 2.

2. **`publish-node.yml`** re-fires on a re-pushed tag and npm refuses republishing an existing version ("You cannot publish over the previously published versions: 0.1.6"). An already-published version is now a stated SKIP, not a red job — re-tagging a release stays green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)