### PR TITLE
identity: signer resolution must not stamp a delegated device it can't sign as

### DIFF
--- a/crates/auths-sdk/src/domains/identity/local.rs
+++ b/crates/auths-sdk/src/domains/identity/local.rs
@@ -64,7 +64,7 @@ pub fn resolve_local_signer(ctx: &AuthsContext) -> Result<LocalSigner, SetupErro
                 ctx.registry.as_ref(),
                 &root_prefix,
             )
-            && let Some(dev) = devices.iter().find(|d| !d.revoked)
+            && let Some(dev) = devices.iter().find(|d| is_local_signing_device(ctx, d))
         {
             return Ok(LocalSigner {
                 signer_did: format!("did:keri:{}", dev.device_prefix),
@@ -72,6 +72,11 @@ pub fn resolve_local_signer(ctx: &AuthsContext) -> Result<LocalSigner, SetupErro
                 anchor_seq,
             });
         }
+        // No delegated device whose key this machine actually holds: sign as the
+        // root directly (whose key IS local). This is the pre-delegation default,
+        // and it is what keeps the stamped `Auths-Device` equal to the key that
+        // will make the signature — a device we cannot sign as must never be
+        // stamped, or every commit fails `SignerKeyMismatch` at verify time.
         return Ok(LocalSigner {
             signer_did: root_did.clone(),
             root_did,
@@ -113,6 +118,44 @@ pub fn resolve_local_signer(ctx: &AuthsContext) -> Result<LocalSigner, SetupErro
         )
         .into(),
     ))
+}
+
+/// Whether a delegated device may stand in as THIS machine's interactive signer.
+///
+/// Two conditions, both required — because the stamped `Auths-Device` must be the
+/// identity whose key actually makes the signature:
+/// * not revoked, and not an `agent:` role delegation (a headless agent delegated
+///   for its own signing is never the human operator's interactive identity), and
+/// * its signing key is present in THIS machine's keychain — a device whose key
+///   lives elsewhere (or was never stored, e.g. a failed delegation's orphan `dip`)
+///   cannot be signed as here, so stamping it would guarantee a verify-time
+///   `SignerKeyMismatch`.
+///
+/// Args:
+/// * `ctx`: the auths context (key storage + registry).
+/// * `dev`: one delegated device from `list_delegated_devices`.
+///
+/// Usage:
+/// ```ignore
+/// let signer = devices.iter().find(|d| is_local_signing_device(ctx, d));
+/// ```
+fn is_local_signing_device(
+    ctx: &AuthsContext,
+    dev: &auths_id::keri::delegation::DelegatedDeviceInfo,
+) -> bool {
+    use auths_id::keri::delegation::DelegatedRole;
+    if dev.revoked || matches!(dev.role, DelegatedRole::Agent) {
+        return false;
+    }
+    let device_did = format!("did:keri:{}", dev.device_prefix);
+    match auths_core::storage::keychain::IdentityDID::parse(&device_did) {
+        Ok(did) => ctx
+            .key_storage
+            .list_aliases_for_identity(&did)
+            .map(|aliases| !aliases.is_empty())
+            .unwrap_or(false),
+        Err(_) => false,
+    }
 }
 
 /// The delegator (root) KEL tip sequence for `root_did`, or `None` if unreadable.


### PR DESCRIPTION
## The bug

`resolve_local_signer` (`auths-sdk/src/domains/identity/local.rs`) preferred "delegated device #0" as the signer identity whenever *any* delegated device existed under the root — **without checking that device's key is what git actually signs with**. Since git signs with the configured `user.signingkey` (typically `auths:main` = the root's key), the stamped `Auths-Device` trailer and the actual signature can disagree the instant a delegation exists.

Concretely: a maintainer whose commits had always verified (signed as root) delegated an agent, which left a delegated `dip` under the root. The next commit stamped `Auths-Device: <that device>` (Ed25519 in its KEL) but was still signed by the root's key (P-256). Verify resolved the device's KEL, checked the signature against its key, and failed `SignerKeyMismatch` — "Signing key is not the device's current key". Every subsequent commit failed the same way; a delegated agent had silently hijacked the human's signing identity.

## The fix

A delegated device may stand in as this machine's interactive signer only if:
- it isn't revoked and isn't an `agent:`-role delegation (a headless agent delegated for its own signing is never the operator's interactive identity), **and**
- its signing key is actually present in this machine's keychain (`list_aliases_for_identity` non-empty).

Otherwise the resolver signs as the **root** directly — the pre-delegation default — guaranteeing the stamped `Auths-Device` is always the identity whose key makes the signature. This also correctly ignores an orphaned `dip` from a failed delegation (key never stored), which is a plain `Device` role and would otherwise be picked.

## Why it matters
- Delegating *any* agent (the flagship headless-signing use case) currently breaks the delegator's own commit verification. This makes the two coexist.
- The invariant "the trailer's signer == the key that signed" is now enforced at selection time, not left to chance.

Verified: this commit is itself agent-signed (`did:keri:EO1cBsYo…`, claude-release) and `auths verify` accepts it. Follow-up (separate): a test covering "root with a delegated agent still signs+verifies as root."

🤖 Generated with [Claude Code](https://claude.com/claude-code)