### PR TITLE
sdk(node): export conformance/*.json so consumers can import the shipped manifest

### DIFF
--- a/.github/workflows/publish-node.yml
+++ b/.github/workflows/publish-node.yml
@@ -211,6 +211,18 @@ jobs:
         working-directory: packages/auths-node
         run: npx napi prepublish -t npm --no-gh-release
 
+      # `npm publish --ignore-scripts` skips prepublishOnly, so the conformance
+      # sync must run here explicitly — 0.1.14 shipped without verdicts.json
+      # because it did not. Fail closed if the packed tarball misses it.
+      - name: Sync conformance surface into the tarball (fail-closed)
+        if: steps.published.outputs.exists != 'true'
+        working-directory: packages/auths-node
+        run: |
+          set -euo pipefail
+          node scripts/sync-conformance.mjs
+          npm pack --dry-run 2>&1 | grep -q "conformance/verdicts.json" \
+            || { echo "::error::packed tarball is missing conformance/verdicts.json"; exit 1; }
+
       - name: Publish main package
         if: steps.published.outputs.exists != 'true'
         working-directory: packages/auths-node

--- a/packages/auths-node/package.json
+++ b/packages/auths-node/package.json
@@ -15,7 +15,8 @@
       "types": "./index.d.ts",
       "default": "./index.js"
     },
-    "./package.json": "./package.json"
+    "./package.json": "./package.json",
+    "./conformance/*.json": "./conformance/*.json"
   },
   "engines": {
     "node": ">=20.0.0"


### PR DESCRIPTION
Two fixes that together make the conformance manifest actually consumable:

**1. `exports`: expose `./conformance/*.json`.** The conformance surface ships in the tarball but the `exports` map only exposed `.` and `./package.json` — every exports-aware resolver refuses the subpath with `ERR_PACKAGE_PATH_NOT_EXPORTED` (reproduced against the installed package). Consumers were forced into `require.resolve('@auths-dev/sdk/package.json')` path arithmetic, and bundled (client) code — where tsc `moduleResolution: bundler` and Turbopack both enforce `exports` — had no sanctioned path at all.

**2. Publish pipeline: run the conformance sync, fail-closed.** `npm publish --ignore-scripts` skips `prepublishOnly`, and `conformance/verdicts.json` is generated, not committed — so **0.1.14 published without the verdict manifest the release existed to ship** (verified: `npm pack @auths-dev/sdk@0.1.14` contains the four older conformance files, no `verdicts.json`). The publish job now runs `scripts/sync-conformance.mjs` explicitly and refuses to publish a tarball missing `conformance/verdicts.json`.

Downstream (auths-docs / auths-mcp / auths-site) manifest wiring is implemented against the conformance contract and verified with the schema file; it goes green against a real registry artifact on the first release that carries both fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)